### PR TITLE
fix(autonomy): record the runs that were being lost, and always count subagents (#1905)

### DIFF
--- a/core/adapters/outbound/filesystem/autonomy_kind_test.go
+++ b/core/adapters/outbound/filesystem/autonomy_kind_test.go
@@ -12,12 +12,14 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
-// Autonomy run KIND (#1905 subagents) — the storage half.
+// Autonomy run KIND (#1905 subagents) — the storage half, retargeted at the
+// FIELD after the filter was removed (#1905 recording).
 //
-// A subagent's span is a NESTED INTERVAL inside its parent's: the daemon holds
-// a parent `working` while its children run. So the store has to know which
-// kind a row is, exclude subagent rows by default, and — this is the part with
-// teeth — never let a row that never said read as one of the two answers.
+// The store still has to know which kind a row is, still has to count the
+// window by kind, and — the part with teeth — must never let a row that never
+// said read as one of the two answers. What it no longer does is DROP anything
+// for its kind: a subagent's run is a run Irrlicht recorded, so every window
+// read returns it.
 
 func kindedSpan(start, end int64, sessionID, kind, parent string) outbound.AutonomySpan {
 	s := span(start, end, "proj", session.StateReady)
@@ -46,11 +48,9 @@ func writeRawSpanRow(t *testing.T, dir, project, line string) {
 	}
 }
 
-func allSpans(t *testing.T, tr *AutonomySpanTracker, includeSubagents bool) *outbound.AutonomySpanResult {
+func allSpans(t *testing.T, tr *AutonomySpanTracker) *outbound.AutonomySpanResult {
 	t.Helper()
-	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{
-		Start: 0, End: math.MaxInt64, IncludeSubagents: includeSubagents,
-	})
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: math.MaxInt64})
 	if err != nil {
 		t.Fatalf("SpansInWindow: %v", err)
 	}
@@ -112,8 +112,8 @@ func TestAutonomySpanTracker_WritesAnExplicitKindOnEveryRow(t *testing.T) {
 }
 
 // THE LEGACY ROW. A row with no `kind` key at all — the shape every row on the
-// maintainer's disk had before this change — must read back as UNKNOWN, be
-// COUNTED as unknown, and be RETURNED under the default query.
+// maintainer's disk had before the classification existed — must read back as
+// UNKNOWN, be COUNTED as unknown, and be RETURNED.
 //
 // Each third of that is a separate way to get it wrong: resolving it to
 // top-level is the silent claim; counting it as top-level hides it from the
@@ -124,9 +124,9 @@ func TestAutonomySpanTracker_LegacyRowIsNeverSilentlyClassified(t *testing.T) {
 	writeRawSpanRow(t, dir, "proj",
 		`{"start":1000,"end":1100,"project":"proj","session":"legacy","reason":"ready"}`)
 
-	res := allSpans(t, tr, false)
+	res := allSpans(t, tr)
 	if len(res.Spans) != 1 {
-		t.Fatalf("returned %d spans, want 1 — a legacy row must not be dropped by the default view", len(res.Spans))
+		t.Fatalf("returned %d spans, want 1 — a legacy row must not be dropped", len(res.Spans))
 	}
 	if got := res.Spans[0].Kind; got != session.AutonomyKindUnknown {
 		t.Fatalf("legacy row Kind = %q, want %q — absence must never resolve to a claim",
@@ -140,10 +140,15 @@ func TestAutonomySpanTracker_LegacyRowIsNeverSilentlyClassified(t *testing.T) {
 	}
 }
 
-// THE DEFAULT VIEW. Subagent rows are left out, and the count of what was left
-// out survives the filter — because "N subagent runs excluded" is exactly the
-// number a client cannot compute from a list those runs are missing from.
-func TestAutonomySpanTracker_DefaultExcludesSubagentsButStillCountsThem(t *testing.T) {
+// EVERY RUN IS RETURNED, subagent runs included (#1905 recording). The
+// classification survives — each row still says which kind it is, and the
+// census still counts the window by kind — but nothing is dropped for it.
+//
+// This is the retargeted form of the test that used to pin the default view's
+// exclusion. The mutation it now catches is a subagent filter coming back in
+// any shape: reinstating one drops `sub-a` and `sub-b` and the count falls to
+// two.
+func TestAutonomySpanTracker_ReturnsEveryRunIncludingSubagents(t *testing.T) {
 	dir := t.TempDir()
 	tr := NewAutonomySpanTrackerWithDir(dir)
 	for _, s := range []outbound.AutonomySpan{
@@ -157,39 +162,28 @@ func TestAutonomySpanTracker_DefaultExcludesSubagentsButStillCountsThem(t *testi
 		}
 	}
 
-	def := allSpans(t, tr, false)
-	if len(def.Spans) != 2 {
-		t.Fatalf("default view returned %d spans, want 2 (the top-level one and the unknown one): %+v",
-			len(def.Spans), def.Spans)
+	res := allSpans(t, tr)
+	if len(res.Spans) != 4 {
+		t.Fatalf("returned %d spans, want 4 — a subagent's run is a run Irrlicht recorded, "+
+			"and nothing is dropped for its kind: %+v", len(res.Spans), res.Spans)
 	}
-	for _, s := range def.Spans {
-		if s.Kind == session.AutonomyKindSubagent {
-			t.Fatalf("the default view returned a subagent run: %+v", s)
-		}
+	if res.Kinds != (outbound.AutonomySpanKinds{TopLevel: 1, Subagent: 2, Unknown: 1}) {
+		t.Fatalf("Kinds = %+v, want {TopLevel:1 Subagent:2 Unknown:1}", res.Kinds)
 	}
-	if def.Kinds != (outbound.AutonomySpanKinds{TopLevel: 1, Subagent: 2, Unknown: 1}) {
-		t.Fatalf("default Kinds = %+v, want {TopLevel:1 Subagent:2 Unknown:1} — the census counts the "+
-			"WINDOW, not the rows that survived the filter", def.Kinds)
-	}
-
-	all := allSpans(t, tr, true)
-	if len(all.Spans) != 4 {
-		t.Fatalf("include-subagents view returned %d spans, want 4", len(all.Spans))
-	}
-	if all.Kinds != def.Kinds {
-		t.Fatalf("the census changed with the mode: %+v vs %+v — the same window holds the same runs "+
-			"whichever ones were asked for", all.Kinds, def.Kinds)
+	if res.Kinds.Total() != len(res.Spans) {
+		t.Fatalf("census total %d != rows returned %d — with no filter left, the two must agree",
+			res.Kinds.Total(), len(res.Spans))
 	}
 	// The parent link survives the round trip: it is what lets a nested run be
-	// attributed to the run that contains it, not merely excluded from it.
+	// attributed to the run that contains it.
 	var sub *outbound.AutonomySpan
-	for i := range all.Spans {
-		if all.Spans[i].Session == "sub-a" {
-			sub = &all.Spans[i]
+	for i := range res.Spans {
+		if res.Spans[i].Session == "sub-a" {
+			sub = &res.Spans[i]
 		}
 	}
 	if sub == nil {
-		t.Fatal("the subagent run is missing from the include-subagents view")
+		t.Fatal("the subagent run is missing")
 	}
 	if sub.Parent != "top-a" {
 		t.Fatalf("subagent run Parent = %q, want %q", sub.Parent, "top-a")
@@ -225,7 +219,7 @@ func TestAutonomySpanTracker_DropReconstructedKeepsMeasuredRows(t *testing.T) {
 	if dropped != 3 {
 		t.Fatalf("dropped %d rows, want 3", dropped)
 	}
-	res := allSpans(t, tr, true)
+	res := allSpans(t, tr)
 	if len(res.Spans) != 1 {
 		t.Fatalf("kept %d spans, want 1: %+v", len(res.Spans), res.Spans)
 	}

--- a/core/adapters/outbound/filesystem/autonomy_open.go
+++ b/core/adapters/outbound/filesystem/autonomy_open.go
@@ -1,0 +1,263 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// The OPEN-RUN JOURNAL (#1905 recording).
+//
+// The span log records runs that ENDED. That was the whole of the feature, and
+// it is why the feature lost most of what it was built to report: a run only
+// reaches the log when it closes, so a run still in progress contributed
+// nothing, and a run whose daemon died mid-flight contributed nothing EVER.
+// The bias is what makes it a defect rather than a lag — the longer a run, the
+// likelier it crosses a restart, so the runs that vanished were precisely the
+// long autonomous ones.
+//
+// The journal is the missing half: the runs that have STARTED. Two consumers,
+// one file:
+//
+//   - a restarting daemon reads it and adopts the start of a run that is still
+//     going, so a 3-hour run that spans four restarts is one 3-hour run and
+//     not four lost ones;
+//   - a window read serves it, so a run in progress is visible WHILE it
+//     happens instead of only in retrospect.
+//
+// ONE FILE, REWRITTEN WHOLE, not the append-only JSONL the closed log uses —
+// because this is a keyed set with deletes, not a history. Its size is bounded
+// by how many sessions are working at once (tens), which is why rewriting it is
+// affordable and appending would not be.
+
+const (
+	// autonomyOpenFileName is the journal's name under the autonomy dir,
+	// sibling to the per-project closed logs. `.json`, not `.jsonl`, and that
+	// matters: SpansInWindow and Prune both walk the directory for
+	// autonomyFileExt, so a journal named `.jsonl` would be read back as a
+	// project's closed log and every open run would be filed twice.
+	autonomyOpenFileName = "open.json"
+
+	// autonomyOpenSchemaVersion documents the on-disk shape. v1 is the
+	// original (#1905 recording). Documentary, like autonomySchemaVersion —
+	// the file is a JSON object of omitempty-tolerant rows, so a row written
+	// by another build decodes with unknown fields dropped and absent fields
+	// zero.
+	autonomyOpenSchemaVersion = 1
+)
+
+// openRow is one run that has started and not finished.
+//
+// LastSeen is the load-bearing field and the one a reader must not confuse
+// with an end: it is the last instant the daemon OBSERVED this run still
+// going. For a live daemon it is a few seconds ago. For a journal left behind
+// by a daemon that died, it is the last thing anyone knows — which is exactly
+// where such a run gets closed, rather than at "now", which would credit the
+// run with the whole time the daemon was down.
+type openRow struct {
+	Start    int64  `json:"start"`
+	LastSeen int64  `json:"last_seen"`
+	Project  string `json:"project,omitempty"`
+	Session  string `json:"session,omitempty"`
+	Adapter  string `json:"adapter,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Kind     string `json:"kind,omitempty"`
+	Parent   string `json:"parent,omitempty"`
+
+	// StartLowerBound marks a run Irrlicht met already in progress, so Start
+	// is when it started WATCHING and not when the run began.
+	StartLowerBound bool `json:"start_lower_bound,omitempty"`
+}
+
+// openPath is the journal's path.
+func (t *AutonomySpanTracker) openPath() string {
+	return filepath.Join(t.dir, autonomyOpenFileName)
+}
+
+// RecordOpenSpan records or refreshes one run that is under way.
+//
+// A read-modify-write under the journal's own lock. No-ops on a span with no
+// session id: the journal is keyed by session, and an entry nothing can be
+// matched back to could never be adopted after a restart nor cleared when the
+// run ends — it would just be a run that is permanently "still going".
+func (t *AutonomySpanTracker) RecordOpenSpan(span outbound.AutonomySpan) error {
+	if span.Session == "" {
+		return nil
+	}
+	t.openMu.Lock()
+	defer t.openMu.Unlock()
+	rows, err := t.readOpenRows()
+	if err != nil {
+		return err
+	}
+	rows[span.Session] = openRowFrom(span)
+	return t.writeOpenRows(rows)
+}
+
+// SyncOpenSpans replaces the journal with exactly these runs.
+//
+// The reconciling write, and the reason the journal cannot leak: a session that
+// disappeared without ever closing its run is simply absent from the next sync,
+// so its entry goes with it. RecordOpenSpan alone could never do that — it only
+// ever adds.
+func (t *AutonomySpanTracker) SyncOpenSpans(spans []outbound.AutonomySpan) error {
+	rows := make(map[string]openRow, len(spans))
+	for _, s := range spans {
+		if s.Session == "" {
+			continue
+		}
+		rows[s.Session] = openRowFrom(s)
+	}
+	t.openMu.Lock()
+	defer t.openMu.Unlock()
+	return t.writeOpenRows(rows)
+}
+
+// OpenSpans returns every run in the journal, ordered by start ascending so two
+// reads of an unchanged journal agree (a map's iteration order does not).
+//
+// Each carries Running: an open run's End is where it was last SEEN, not where
+// it ended, and a caller that lost that distinction would file "the daemon
+// checked on it four seconds ago" as "the run finished four seconds ago".
+func (t *AutonomySpanTracker) OpenSpans() ([]outbound.AutonomySpan, error) {
+	t.openMu.Lock()
+	rows, err := t.readOpenRows()
+	t.openMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]outbound.AutonomySpan, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.span())
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Start != out[j].Start {
+			return out[i].Start < out[j].Start
+		}
+		return out[i].Session < out[j].Session
+	})
+	return out, nil
+}
+
+// clearOpenSpan drops one session's entry. Called by RecordSpan: a run that has
+// been filed as closed is no longer open, and leaving the entry behind would
+// make the same stretch of time appear twice — once as a finished run and once
+// as one still going.
+func (t *AutonomySpanTracker) clearOpenSpan(sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
+	t.openMu.Lock()
+	defer t.openMu.Unlock()
+	rows, err := t.readOpenRows()
+	if err != nil {
+		return err
+	}
+	if _, ok := rows[sessionID]; !ok {
+		return nil
+	}
+	delete(rows, sessionID)
+	return t.writeOpenRows(rows)
+}
+
+// readOpenRows loads the journal. A missing file is an empty journal, not an
+// error — that is every machine before the first run of the day.
+//
+// A journal that exists but cannot be PARSED is a different case and is treated
+// as empty too, deliberately: the alternative is refusing to record anything
+// until someone deletes a file, and the recovery a corrupt journal costs is at
+// most the open runs, which the next sync rebuilds from the live sessions.
+// Caller holds openMu.
+func (t *AutonomySpanTracker) readOpenRows() (map[string]openRow, error) {
+	data, err := os.ReadFile(t.openPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]openRow{}, nil
+		}
+		return nil, err
+	}
+	rows := map[string]openRow{}
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return map[string]openRow{}, nil
+	}
+	return rows, nil
+}
+
+// writeOpenRows persists the journal atomically. Caller holds openMu.
+//
+// An EMPTY journal is written as an empty object rather than removed, so
+// "nothing is running" and "no daemon has ever written here" stay
+// distinguishable on disk — the same reason the span log's provenance block
+// separates an empty window from an empty log.
+func (t *AutonomySpanTracker) writeOpenRows(rows map[string]openRow) error {
+	if err := os.MkdirAll(t.dir, 0700); err != nil {
+		return fmt.Errorf("create autonomy dir: %w", err)
+	}
+	data, err := json.Marshal(rows)
+	if err != nil {
+		return fmt.Errorf("marshal open autonomy runs: %w", err)
+	}
+	return writeFileAtomic(t.openPath(), data, 0600)
+}
+
+// openRowFrom converts a span the detector is holding open into its row. Kind
+// is normalized on the way in, exactly as RecordSpan normalizes it, so a run
+// adopted after a restart carries the same classification it had before.
+func openRowFrom(s outbound.AutonomySpan) openRow {
+	return openRow{
+		Start:           s.Start,
+		LastSeen:        s.End,
+		Project:         s.Project,
+		Session:         s.Session,
+		Adapter:         s.Adapter,
+		Model:           s.Model,
+		Kind:            session.AutonomyKindOrUnknown(s.Kind),
+		Parent:          s.Parent,
+		StartLowerBound: s.StartLowerBound,
+	}
+}
+
+// span converts a row back, always marked Running.
+func (r openRow) span() outbound.AutonomySpan {
+	return outbound.AutonomySpan{
+		Start:           r.Start,
+		End:             r.LastSeen,
+		Project:         r.Project,
+		Session:         r.Session,
+		Adapter:         r.Adapter,
+		Model:           r.Model,
+		Kind:            session.AutonomyKindOrUnknown(r.Kind),
+		Parent:          r.Parent,
+		Running:         true,
+		StartLowerBound: r.StartLowerBound,
+		// Reason is deliberately left empty: a run that has not ended has no
+		// end reason, and session.AutonomyReasonUnknown would claim it ended
+		// in a way nothing could name.
+	}
+}
+
+// foldOpenRun folds one in-progress run into a window result.
+//
+// OVERLAP, not "ended inside the window", because a run that has not ended
+// cannot be asked where it ended. It is in view when it had begun before the
+// window closed and was still alive after the window opened. Its end-so-far is
+// clamped to the window, so a trailing window ending "now" reports the run as
+// running up to now rather than up to the last heartbeat.
+func foldOpenRun(s outbound.AutonomySpan, q outbound.AutonomySpanQuery, res *outbound.AutonomySpanResult) {
+	if s.Start >= q.End || s.End < q.Start {
+		return
+	}
+	if s.End > q.End {
+		s.End = q.End
+	}
+	if s.End < s.Start {
+		s.End = s.Start
+	}
+	countSpanKind(s.Kind, res)
+	res.Spans = append(res.Spans, s)
+}

--- a/core/adapters/outbound/filesystem/autonomy_open_fixtures_test.go
+++ b/core/adapters/outbound/filesystem/autonomy_open_fixtures_test.go
@@ -1,0 +1,290 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Mutation fixtures for the open-run journal (#1905 recording). Each names the
+// wrong behaviour it catches; none had a "before the fix" state to run red in.
+
+// A run in progress is MARKED, so nothing downstream can mistake it for a
+// finished one.
+//
+// MUTATION CAUGHT: serving the journal without Running would put "the daemon
+// checked on it four seconds ago" into the percentiles as "the run finished
+// four seconds ago" — a floor read as a measurement, and always in the
+// direction that shortens the longest runs.
+func TestOpenRun_IsMarkedRunningAndCarriesNoEndReason(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenJournal(t, dir, `{"s":{"start":1000,"last_seen":1400,"project":"p","session":"s","kind":"top"}}`)
+
+	res, err := NewAutonomySpanTrackerWithDir(dir).SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 1500})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(res.Spans))
+	}
+	got := res.Spans[0]
+	if !got.Running {
+		t.Fatal("an in-progress run is not marked Running — every consumer would treat its " +
+			"seconds-so-far as a finished duration")
+	}
+	if got.Reason != "" {
+		t.Errorf("Reason = %q, want empty — a run that has not ended has no end reason, and any "+
+			"value here is a claim about how it finished", got.Reason)
+	}
+	if res.Measurement.Running != 1 {
+		t.Errorf("Measurement.Running = %d, want 1 — an uncounted running run cannot be stated on screen",
+			res.Measurement.Running)
+	}
+}
+
+// The journal is served by OVERLAP, and its end is clamped to the window. A run
+// that has not ended cannot be asked where it ended, so the closed log's
+// "ended inside the window" rule cannot decide it.
+//
+// MUTATION CAUGHT: reusing the closed rule (`End >= Start && End < q.End`)
+// silently drops every open run from a trailing window that ends at "now",
+// because a live journal's last-seen instant is at or beyond it.
+func TestOpenRun_IsSelectedByOverlapNotByItsEnd(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenJournal(t, dir, `{`+
+		`"live":{"start":900,"last_seen":2000,"project":"p","session":"live","kind":"top"},`+
+		`"old":{"start":10,"last_seen":50,"project":"p","session":"old","kind":"top"},`+
+		`"future":{"start":9000,"last_seen":9000,"project":"p","session":"future","kind":"top"}`+
+		`}`)
+
+	// A trailing window whose end is BEFORE the live run's last-seen instant —
+	// exactly what a request served a moment after a heartbeat looks like.
+	res, err := NewAutonomySpanTrackerWithDir(dir).SpansInWindow(outbound.AutonomySpanQuery{Start: 1000, End: 1900})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("got %d spans, want only the overlapping one: %+v", len(res.Spans), res.Spans)
+	}
+	got := res.Spans[0]
+	if got.Session != "live" {
+		t.Fatalf("returned %q, want %q — `old` ended before the window and `future` had not begun",
+			got.Session, "live")
+	}
+	if got.End != 1900 {
+		t.Errorf("End = %d, want the window's end 1900 — an open run's end-so-far is clamped to the "+
+			"window, never reported beyond it", got.End)
+	}
+	if got.Start != 900 {
+		t.Errorf("Start = %d, want 900 — the run began before the window and keeps its real start", got.Start)
+	}
+}
+
+// Closing a run REPLACES its journal entry rather than adding to it. Otherwise
+// the same stretch of time is on record twice: once as a finished run and once
+// as one still going — and the next daemon adopts the stale entry as a run.
+//
+// MUTATION CAUGHT: dropping the clear from RecordSpan leaves a permanent
+// phantom whose duration grows without bound.
+func TestRecordSpan_ClearsTheSessionsOpenRun(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+
+	open := outbound.AutonomySpan{Start: 1000, End: 1400, Project: "p", Session: "s",
+		Kind: session.AutonomyKindTopLevel, Running: true}
+	if err := tr.RecordOpenSpan(open); err != nil {
+		t.Fatalf("RecordOpenSpan: %v", err)
+	}
+	closed := open
+	closed.End = 1500
+	closed.Running = false
+	closed.Reason = session.StateReady
+	if err := tr.RecordSpan(closed); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+
+	openNow, err := tr.OpenSpans()
+	if err != nil {
+		t.Fatalf("OpenSpans: %v", err)
+	}
+	if len(openNow) != 0 {
+		t.Fatalf("journal still holds %d runs after the run was filed as closed: %+v", len(openNow), openNow)
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 2000})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("window holds %d rows for one run, want 1 — the same stretch is on record twice",
+			len(res.Spans))
+	}
+	if res.Spans[0].Running {
+		t.Error("the surviving row is the open one, not the closed one")
+	}
+}
+
+// RecordSpan clears the open entry even when the closed span is not worth
+// FILING (no project, or no positive duration). The run is over either way, and
+// an entry left behind would be adopted as a live run by the next daemon.
+//
+// MUTATION CAUGHT: putting the clear behind RecordSpan's "nothing useful to
+// store" early return — the natural place to put it — leaks exactly the runs
+// whose session had no project name resolved, which is the population a session
+// discovered and torn down quickly falls into.
+func TestRecordSpan_ClearsTheOpenRunEvenWhenItFilesNothing(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	if err := tr.RecordOpenSpan(outbound.AutonomySpan{Start: 1000, End: 1400, Session: "s"}); err != nil {
+		t.Fatalf("RecordOpenSpan: %v", err)
+	}
+	// No project: RecordSpan files nothing.
+	if err := tr.RecordSpan(outbound.AutonomySpan{Start: 1000, End: 1500, Session: "s"}); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	open, err := tr.OpenSpans()
+	if err != nil {
+		t.Fatalf("OpenSpans: %v", err)
+	}
+	if len(open) != 0 {
+		t.Fatalf("journal still holds %d runs: %+v", len(open), open)
+	}
+}
+
+// SyncOpenSpans is a REPLACE, and that is what keeps the journal from leaking.
+//
+// MUTATION CAUGHT: implementing it as a merge means a session that disappeared
+// between ticks keeps an entry nothing will ever close.
+func TestSyncOpenSpans_ReplacesRatherThanMerges(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	for _, id := range []string{"a", "b"} {
+		if err := tr.RecordOpenSpan(outbound.AutonomySpan{Start: 100, End: 200, Session: id, Project: "p"}); err != nil {
+			t.Fatalf("RecordOpenSpan: %v", err)
+		}
+	}
+	if err := tr.SyncOpenSpans([]outbound.AutonomySpan{{Start: 100, End: 300, Session: "a", Project: "p"}}); err != nil {
+		t.Fatalf("SyncOpenSpans: %v", err)
+	}
+	open, err := tr.OpenSpans()
+	if err != nil {
+		t.Fatalf("OpenSpans: %v", err)
+	}
+	if len(open) != 1 || open[0].Session != "a" {
+		t.Fatalf("journal = %+v, want only `a` — `b`'s session is gone and its entry has to go with it", open)
+	}
+	if open[0].End != 300 {
+		t.Errorf("last seen = %d, want 300 — the surviving run's heartbeat did not move forward", open[0].End)
+	}
+}
+
+// The journal must not be mistaken for a project's closed log. Both live in the
+// same directory, and both the window read and Prune walk it by extension.
+//
+// MUTATION CAUGHT: naming the journal `open.jsonl` makes every open run parse
+// as a closed span too, so each is counted twice — once with its real end and
+// once with none.
+func TestOpenJournal_IsNotReadAsAProjectLog(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	if err := tr.RecordOpenSpan(outbound.AutonomySpan{Start: 1000, End: 1400, Session: "s", Project: "p"}); err != nil {
+		t.Fatalf("RecordOpenSpan: %v", err)
+	}
+	if filepath.Ext(autonomyOpenFileName) == autonomyFileExt {
+		t.Fatalf("the journal is named %q, which the directory walk reads as a project's closed log",
+			autonomyOpenFileName)
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 2000})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("got %d rows for one open run, want 1: %+v", len(res.Spans), res.Spans)
+	}
+	if res.TotalRecorded != 0 {
+		t.Errorf("TotalRecorded = %d, want 0 — an open run is not a row in the closed log, and "+
+			"counting it there would make `N runs recorded` include runs that have not finished",
+			res.TotalRecorded)
+	}
+}
+
+// A corrupt journal reads as EMPTY rather than failing the whole request. The
+// closed log is the answer; the journal is the extra half, and refusing to
+// serve a window because of it would replace one missing row with a broken
+// section.
+//
+// MUTATION CAUGHT: propagating the parse error turns a truncated write — the
+// exact thing a crash mid-write produces, and a crash is when this file matters
+// most — into an unusable Autonomy tab.
+func TestOpenJournal_CorruptFileDoesNotBreakTheWindowRead(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	if err := tr.RecordSpan(span(1000, 1100, "p", session.StateReady)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	writeOpenJournal(t, dir, `{"s":{"start":1000,`)
+
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 2000})
+	if err != nil {
+		t.Fatalf("SpansInWindow returned an error for a corrupt journal: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("got %d spans, want the one closed row: %+v", len(res.Spans), res.Spans)
+	}
+}
+
+// The lower-bound mark survives the round trip to disk, and an OLD row without
+// the key reads back as measured — the only thing it can mean, since a build
+// that could not open a span for such a run never wrote one.
+func TestSpanRow_CarriesTheLowerBoundMarkToDiskAndBack(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	bounded := span(1000, 1100, "p", session.StateReady)
+	bounded.Session = "bounded"
+	bounded.StartLowerBound = true
+	if err := tr.RecordSpan(bounded); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	writeRawSpanRow(t, dir, "p",
+		`{"start":2000,"end":2100,"project":"p","session":"legacy","reason":"ready"}`)
+
+	raw, err := os.ReadFile(filepath.Join(dir, "p"+autonomyFileExt))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var first map[string]any
+	if err := json.Unmarshal([]byte(splitFirstLine(string(raw))), &first); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if first["start_lower_bound"] != true {
+		t.Fatalf("the marked row lost its mark on disk: %v", first)
+	}
+
+	res := allSpans(t, tr)
+	if len(res.Spans) != 2 {
+		t.Fatalf("got %d spans, want 2", len(res.Spans))
+	}
+	if !res.Spans[0].StartLowerBound {
+		t.Error("the marked row read back as measured")
+	}
+	if res.Spans[1].StartLowerBound {
+		t.Error("a row written before the mark existed read back as a lower bound — a build that " +
+			"could not open a span for such a run never wrote one, so absence means measured")
+	}
+	if res.Measurement.LowerBoundStart != 1 {
+		t.Errorf("Measurement.LowerBoundStart = %d, want 1", res.Measurement.LowerBoundStart)
+	}
+}
+
+// splitFirstLine returns everything before the first newline.
+func splitFirstLine(s string) string {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}

--- a/core/adapters/outbound/filesystem/autonomy_open_test.go
+++ b/core/adapters/outbound/filesystem/autonomy_open_test.go
@@ -1,0 +1,52 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/ports/outbound"
+)
+
+// writeOpenJournal drops a hand-written open-run journal into dir. Written as
+// raw bytes on purpose: this is the shape a PREVIOUS daemon left behind, so the
+// test must not depend on the writer it is checking the reader against — and it
+// is what let this test run red against a build that had no journal writer at
+// all.
+func writeOpenJournal(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, autonomyOpenFileName), []byte(body), 0600); err != nil {
+		t.Fatalf("write open journal: %v", err)
+	}
+}
+
+// TestSpansInWindow_ReturnsTheRunStillInProgress is red-first defect 3 (#1905
+// recording), at the layer that serves the clients: a span reached the log only
+// when it CLOSED, so a window read returned nothing for a run that was still
+// going — the longest run on the machine was the one guaranteed to be missing.
+//
+// Seen red before the fix: `spans in window = 0`.
+func TestSpansInWindow_ReturnsTheRunStillInProgress(t *testing.T) {
+	dir := t.TempDir()
+	writeOpenJournal(t, dir, `{"sess-1":{"start":1000,"last_seen":1400,"project":"irrlicht",`+
+		`"session":"sess-1","adapter":"claude-code","kind":"top"}}`)
+
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 1500})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("spans in window = %d, want 1 — a run that has not ended yet is invisible, "+
+			"and it is the long ones that are still going", len(res.Spans))
+	}
+	if got := res.Spans[0].Start; got != 1000 {
+		t.Errorf("span.Start = %d, want 1000", got)
+	}
+	if got := res.Spans[0].Session; got != "sess-1" {
+		t.Errorf("span.Session = %q, want %q", got, "sess-1")
+	}
+}

--- a/core/adapters/outbound/filesystem/autonomy_tracker.go
+++ b/core/adapters/outbound/filesystem/autonomy_tracker.go
@@ -82,6 +82,13 @@ type spanRow struct {
 	// Parent is the parent session id of a subagent run. Empty on a top-level
 	// run, and on a subagent run whose source never named the parent.
 	Parent string `json:"parent,omitempty"`
+
+	// StartLowerBound marks a run whose start Irrlicht did not measure — it
+	// met the session already working (#1905 recording). Absent on every row
+	// written before that case was recorded at all, which reads back as
+	// false: those rows are the MEASURED case, because a build that could not
+	// open a span for such a run never wrote one.
+	StartLowerBound bool `json:"start_lower_bound,omitempty"`
 }
 
 // AutonomySpanTracker persists closed autonomy spans in append-only JSONL
@@ -99,6 +106,12 @@ type AutonomySpanTracker struct {
 	// mu guards fileMus.
 	mu      sync.Mutex
 	fileMus map[string]*sync.Mutex // sanitized project name → per-file write mutex
+
+	// openMu guards the single open-run journal (autonomy_open.go). Its own
+	// lock rather than a fileMus entry: the journal is not a project's log, it
+	// is read-modify-written whole, and a project's append must never wait on
+	// it.
+	openMu sync.Mutex
 }
 
 // NewAutonomySpanTracker returns a tracker rooted at the user's Application
@@ -142,7 +155,15 @@ func (t *AutonomySpanTracker) fileMu(project string) *sync.Mutex {
 // duration: a span with nothing to file it under cannot be drawn on a
 // per-project strip, and a zero-length span is a transition artefact, not a
 // run. Matches RecordSnapshot's "nothing useful to store" rule.
+//
+// The session's OPEN-RUN entry is cleared first and unconditionally, ahead of
+// that no-op rule (#1905 recording). The run is over whether or not it was
+// worth filing, and an entry left behind would keep reporting a finished run as
+// still going — and would be adopted, as a run, by the next daemon to start.
 func (t *AutonomySpanTracker) RecordSpan(span outbound.AutonomySpan) error {
+	if err := t.clearOpenSpan(span.Session); err != nil {
+		return err
+	}
 	project := projectKey(span.Project)
 	if project == "" || span.Duration() <= 0 {
 		return nil
@@ -161,8 +182,9 @@ func (t *AutonomySpanTracker) RecordSpan(span outbound.AutonomySpan) error {
 		// reader has to guess about. That is what "written explicitly on every
 		// new row" means in practice — the only blank `kind` on disk belongs to
 		// a build that predates the field.
-		Kind:   session.AutonomyKindOrUnknown(span.Kind),
-		Parent: span.Parent,
+		Kind:            session.AutonomyKindOrUnknown(span.Kind),
+		Parent:          span.Parent,
+		StartLowerBound: span.StartLowerBound,
 	}
 	data, err := json.Marshal(row)
 	if err != nil {
@@ -222,6 +244,20 @@ func (t *AutonomySpanTracker) SpansInWindow(q outbound.AutonomySpanQuery) (*outb
 			return nil, err
 		}
 	}
+	// The runs still in progress join the same list (#1905 recording). Folded
+	// AFTER the closed log and before the sort, so an open run sorts into place
+	// by its start like any other — a client that draws the strip in order does
+	// not need to know which rows came from which store.
+	//
+	// A journal read failure is NOT fatal here, unlike a closed-log one: the
+	// closed log is the answer, while the journal is the extra half, and
+	// failing the whole request would replace "the run in progress is missing"
+	// with "the section is broken".
+	if open, err := t.OpenSpans(); err == nil {
+		for _, s := range open {
+			foldOpenRun(s, q, res)
+		}
+	}
 	sort.Slice(res.Spans, func(i, j int) bool {
 		if res.Spans[i].Start != res.Spans[j].Start {
 			return res.Spans[i].Start < res.Spans[j].Start
@@ -242,13 +278,21 @@ func (t *AutonomySpanTracker) SpansInWindow(q outbound.AutonomySpanQuery) (*outb
 }
 
 // countSpanProvenance fills the window-scoped half of the provenance block
-// from the spans the query is actually returning. LiveSince is NOT computed
-// here: it is log-wide by definition and is accumulated over every row during
-// the fold, including rows outside the window.
+// from the spans the query is actually returning, plus the measurement block
+// beside it. LiveSince is NOT computed here: it is log-wide by definition and
+// is accumulated over every row during the fold, including rows outside the
+// window.
 func countSpanProvenance(res *outbound.AutonomySpanResult) {
 	res.Provenance.Reconstructed = 0
 	res.Provenance.CostDerived = 0
+	res.Measurement = outbound.AutonomySpanMeasurement{}
 	for _, s := range res.Spans {
+		if s.Running {
+			res.Measurement.Running++
+		}
+		if s.StartLowerBound {
+			res.Measurement.LowerBoundStart++
+		}
 		if !session.IsAutonomyReconstructed(s.Source) {
 			continue
 		}
@@ -256,6 +300,20 @@ func countSpanProvenance(res *outbound.AutonomySpanResult) {
 		if s.Source == session.AutonomySourceCost {
 			res.Provenance.CostDerived++
 		}
+	}
+}
+
+// countSpanKind folds one span's resolved kind into the window census. Shared
+// by the closed log's fold and the open-run journal's, so a run counts the same
+// whether it has finished or not.
+func countSpanKind(kind string, res *outbound.AutonomySpanResult) {
+	switch kind {
+	case session.AutonomyKindSubagent:
+		res.Kinds.Subagent++
+	case session.AutonomyKindTopLevel:
+		res.Kinds.TopLevel++
+	default:
+		res.Kinds.Unknown++
 	}
 }
 
@@ -283,40 +341,29 @@ func foldSpanRow(r spanRow, fallback string, q outbound.AutonomySpanQuery, res *
 	if r.End < q.Start || r.End >= q.End {
 		return
 	}
-	// The kind census counts EVERY span in the window, ahead of the filter
-	// below. A client's sentence is "N subagent runs excluded", and N cannot be
-	// counted off a list those runs have already been dropped from.
+	// The census counts every span in the window, and every span in the window
+	// is returned: NOTHING IS DROPPED FOR ITS KIND (#1905 recording). Subagent
+	// runs are runs Irrlicht recorded, so they are counted like the rest; the
+	// `kind` and `parent` fields on the row are what still tell them apart, for
+	// a client that wants to say so.
 	kind := session.AutonomyKindOrUnknown(r.Kind)
-	switch kind {
-	case session.AutonomyKindSubagent:
-		res.Kinds.Subagent++
-	case session.AutonomyKindTopLevel:
-		res.Kinds.TopLevel++
-	default:
-		res.Kinds.Unknown++
-	}
-	// A subagent's span is a nested interval inside its parent's, so the
-	// default view leaves it out. A run of UNKNOWN kind is kept: nothing
-	// established it was a subagent's, and dropping it would delete history to
-	// make a figure look tidy.
-	if kind == session.AutonomyKindSubagent && !q.IncludeSubagents {
-		return
-	}
+	countSpanKind(kind, res)
 	project := r.Project
 	if project == "" {
 		project = fallback
 	}
 	res.Spans = append(res.Spans, outbound.AutonomySpan{
-		Start:   r.Start,
-		End:     r.End,
-		Project: project,
-		Session: r.Session,
-		Adapter: r.Adapter,
-		Model:   r.Model,
-		Reason:  r.Reason,
-		Source:  r.Source,
-		Kind:    kind,
-		Parent:  r.Parent,
+		Start:           r.Start,
+		End:             r.End,
+		Project:         project,
+		Session:         r.Session,
+		Adapter:         r.Adapter,
+		Model:           r.Model,
+		Reason:          r.Reason,
+		Source:          r.Source,
+		Kind:            kind,
+		Parent:          r.Parent,
+		StartLowerBound: r.StartLowerBound,
 	})
 }
 

--- a/core/application/services/autonomy_span.go
+++ b/core/application/services/autonomy_span.go
@@ -85,6 +85,57 @@ func (d *SessionDetector) openOrResumeAutonomySpan(state *session.SessionState, 
 	start := now
 	state.AutonomySpanStart = &start
 	state.AutonomySpanPendingEnd = nil
+	// This edge was OBSERVED — the session was seen entering `working` — so the
+	// start is measured and the run is not a lower bound. Set explicitly rather
+	// than left alone: the same session may have carried a lower-bound span
+	// earlier in its life, and a stale true here would mark a fully measured
+	// run as an estimate.
+	state.AutonomySpanStartLowerBound = false
+	d.journalOpenAutonomySpan(state, now)
+}
+
+// openAutonomySpanAtBirth opens the span for a session that was ALREADY
+// `working` when Irrlicht first saw it (#1905 recording).
+//
+// This is the fix for the largest of the three losses. shouldClassifyAtBirth
+// births such a session `working` by assigning state.State directly, which
+// bypasses applyStateTransition — and applyStateTransition's single call to
+// applyAutonomySpanTransition was the only place a span could open. Every run
+// already under way at discovery therefore recorded nothing, and after a daemon
+// restart EVERY live session is a session already under way.
+//
+// THE START IS AN EVIDENCE LADDER, and which rung fired is carried on the span:
+//
+//  1. The open-run journal a previous daemon left behind. That start was
+//     MEASURED, by the daemon that died holding it, so the run keeps it and is
+//     not marked as a bound. This is what makes a run that outlives its daemon
+//     one run rather than none.
+//  2. Discovery time, MARKED AS A LOWER BOUND. Nothing in the daemon's own
+//     state says when a run it did not see start began, and the transcript
+//     signals it does hold cannot answer it either: SessionMetrics carries no
+//     turn-start instant, and the two session-scope times that exist
+//     (ElapsedSeconds' session start, CompletedTurns) would date the run to the
+//     start of the whole SESSION — hours early on a session that has taken
+//     twenty turns. Overstating is the one direction that turns a missing
+//     number into a wrong one, so the run is dated from the moment Irrlicht
+//     began watching and says that its duration is a floor.
+//
+// Dropping such runs instead is what produced the 5-recorded-of-35 under-count
+// this fix exists to end, so rung 2 records rather than declines.
+func (d *SessionDetector) openAutonomySpanAtBirth(state *session.SessionState, now int64) {
+	if state == nil || state.State != session.StateWorking {
+		return
+	}
+	start := now
+	lowerBound := true
+	if recovered, ok := d.adoptRecoveredAutonomySpan(state.SessionID); ok {
+		start = recovered.Start
+		lowerBound = recovered.StartLowerBound
+	}
+	state.AutonomySpanStart = &start
+	state.AutonomySpanPendingEnd = nil
+	state.AutonomySpanStartLowerBound = lowerBound
+	d.journalOpenAutonomySpan(state, now)
 }
 
 // settleAutonomySpanOnLeave closes the span for a transition into a state that
@@ -122,16 +173,27 @@ func (d *SessionDetector) flushExpiredAutonomySpan(state *session.SessionState, 
 	return true
 }
 
-// settleAutonomySpanOnTeardown finalizes a still-pending span for a session
-// that is going away. A deleted session can never return to `working`, so the
-// grace has nothing left to decide and the pending close is written
-// immediately rather than waiting for a ticker that will never see this
-// session again.
+// settleAutonomySpanOnTeardown finalizes a still-open span for a session that
+// is going away. A deleted session can never return to `working`, so the grace
+// has nothing left to decide and the close is written immediately rather than
+// waiting for a ticker that will never see this session again.
+//
+// TWO CASES, and the second one was a leak (#1905 recording). A session with a
+// PENDING end closes there — it finished its turn and then vanished, and the
+// turn is where the run ended. A session torn down while still WORKING — the
+// agent's process exited mid-run, which is how most sessions actually end —
+// used to close nowhere at all: its run was simply lost. It now closes at the
+// last instant the daemon saw it, with an end reason of unknown, because
+// nothing observed why it stopped and `ready` would claim it finished its turn.
 func (d *SessionDetector) settleAutonomySpanOnTeardown(state *session.SessionState) {
-	if state == nil || state.AutonomySpanPendingEnd == nil {
+	if state == nil || state.AutonomySpanStart == nil {
 		return
 	}
-	d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+	if state.AutonomySpanPendingEnd != nil {
+		d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+		return
+	}
+	d.closeAutonomySpan(state, d.nowFn().Unix(), session.AutonomyReasonUnknown)
 }
 
 // closeAutonomySpan clears the open span off the session and appends the
@@ -150,8 +212,10 @@ func (d *SessionDetector) settleAutonomySpanOnTeardown(state *session.SessionSta
 // `error`); nothing could make the second case legible after the fact.
 func (d *SessionDetector) closeAutonomySpan(state *session.SessionState, end int64, reason string) {
 	start := state.AutonomySpanStart
+	lowerBound := state.AutonomySpanStartLowerBound
 	state.AutonomySpanStart = nil
 	state.AutonomySpanPendingEnd = nil
+	state.AutonomySpanStartLowerBound = false
 	if start == nil || d.autonomySpans == nil {
 		return
 	}
@@ -163,6 +227,10 @@ func (d *SessionDetector) closeAutonomySpan(state *session.SessionState, end int
 		Adapter: state.Adapter,
 		Model:   autonomySpanModel(state),
 		Reason:  reason,
+		// Carried onto the closed row, not recomputed: by the time a run ends,
+		// the only thing that still remembers whether its start was measured is
+		// the run itself.
+		StartLowerBound: lowerBound,
 		// The live path always knows which it is: it is holding the session
 		// state, where an empty ParentSessionID means "no parent", not "nobody
 		// looked". So it writes `top` or `sub` and never `unknown` — the

--- a/core/application/services/autonomy_span_open.go
+++ b/core/application/services/autonomy_span_open.go
@@ -1,0 +1,236 @@
+package services
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Open-run bookkeeping (#1905 recording).
+//
+// A span used to exist only in the daemon's memory until it closed, which made
+// the daemon's own lifetime an invisible ceiling on what the feature could
+// report. Two consequences, and they compound:
+//
+//   - a run in progress was worth nothing until it finished, so the longest run
+//     on the machine was always the one the section could not show;
+//   - a run whose daemon died was worth nothing EVER, and the longer a run, the
+//     likelier it crossed a restart.
+//
+// The store's open-run journal is the fix, and this file is the daemon's half
+// of it: journal a run the moment it opens, refresh it while it lasts, adopt it
+// after a restart, and settle it if nobody ever comes back for it.
+
+const (
+	// autonomyRecoveryWindow is how long a run left in the journal by a
+	// previous daemon waits to be adopted by the session it belongs to.
+	//
+	// Two minutes, which is a discovery budget rather than a guess: the
+	// watchers' initial scan emits every live transcript in the first seconds,
+	// but a session is only rediscovered once its adapter's watcher is
+	// running, and monitoring is consent-gated (#570) — a permission exercised
+	// during startup can put a watcher up appreciably after the event loop.
+	//
+	// Nothing is lost by the wait: an unadopted run is closed where the
+	// previous daemon last SAW it, not at the deadline, so waiting longer
+	// costs only how soon the row appears, never what it says.
+	autonomyRecoveryWindow = 2 * time.Minute
+
+	// autonomyOpenSyncInterval is how often the journal's last-seen instants
+	// are pushed forward when nothing about the open set has changed.
+	//
+	// It bounds what a crash costs: an unadopted run is closed at its last-seen
+	// instant, so a daemon killed mid-run under-reports that run by at most
+	// this much. Thirty seconds against a feature whose subject is multi-hour
+	// runs — and one small write per half minute instead of one every tick.
+	autonomyOpenSyncInterval = 30 * time.Second
+)
+
+// loadRecoverableAutonomySpans reads the open-run journal a previous daemon
+// left behind and arms the adoption window.
+//
+// Nothing is closed here. A run in the journal is a run that WAS going when the
+// last daemon stopped looking, and whether it is still going is a question only
+// rediscovery can answer — so every entry waits, and settleUnadoptedAutonomySpans
+// deals with the ones nobody claims.
+func (d *SessionDetector) loadRecoverableAutonomySpans() {
+	if d.autonomySpans == nil {
+		return
+	}
+	open, err := d.autonomySpans.OpenSpans()
+	if err != nil {
+		d.log.LogError(logComponentAutonomySpans, "", err.Error())
+		return
+	}
+	deadline := d.nowFn().Add(autonomyRecoveryWindow).Unix()
+	d.mu.Lock()
+	for _, s := range open {
+		if s.Session == "" {
+			continue
+		}
+		d.autonomyRecovered[s.Session] = s
+	}
+	d.autonomyRecoveryDeadline = deadline
+	n := len(d.autonomyRecovered)
+	d.mu.Unlock()
+	if n > 0 {
+		d.log.LogInfo(logComponentAutonomySpans, "",
+			strconv.Itoa(n)+" autonomous run(s) were still open when the last daemon stopped; "+
+				"each is held for adoption by its session and otherwise closed where it was last seen")
+	}
+}
+
+// adoptRecoveredAutonomySpan hands back the recovered run for a session being
+// rediscovered, removing it from the pending set so it can never be settled
+// afterwards as well.
+//
+// Past the deadline it adopts NOTHING, and that is the whole guard against
+// resurrection: a session id that reappears an hour after the daemon started is
+// not the run that was open when the daemon before it died — settleUnadopted
+// has already closed that one where it was last seen, and adopting it now would
+// splice the downtime, plus everything since, into a single fabricated run.
+func (d *SessionDetector) adoptRecoveredAutonomySpan(sessionID string) (outbound.AutonomySpan, bool) {
+	if sessionID == "" {
+		return outbound.AutonomySpan{}, false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.autonomyRecoveryDeadline == 0 || d.nowFn().Unix() > d.autonomyRecoveryDeadline {
+		return outbound.AutonomySpan{}, false
+	}
+	span, ok := d.autonomyRecovered[sessionID]
+	if !ok {
+		return outbound.AutonomySpan{}, false
+	}
+	delete(d.autonomyRecovered, sessionID)
+	return span, true
+}
+
+// settleUnadoptedAutonomySpans closes every recovered run nobody claimed, once
+// the adoption window has passed. Idempotent: the pending set is emptied and
+// the deadline disarmed, so it does its work exactly once per daemon.
+//
+// Each is closed AT ITS LAST-SEEN INSTANT, with an end reason of unknown. Both
+// halves are the honest choice and both matter:
+//
+//   - at last-seen, not now, because the daemon was not watching in between and
+//     crediting a run with the downtime is how a five-minute run becomes an
+//     overnight one;
+//   - unknown, because nothing observed why it stopped. `ready` would claim it
+//     finished its turn, which is the one thing a run interrupted by a dying
+//     daemon has no evidence of.
+func (d *SessionDetector) settleUnadoptedAutonomySpans(now int64) {
+	d.mu.Lock()
+	if d.autonomyRecoveryDeadline == 0 || now <= d.autonomyRecoveryDeadline {
+		d.mu.Unlock()
+		return
+	}
+	pending := make([]outbound.AutonomySpan, 0, len(d.autonomyRecovered))
+	for _, s := range d.autonomyRecovered {
+		pending = append(pending, s)
+	}
+	d.autonomyRecovered = make(map[string]outbound.AutonomySpan)
+	d.autonomyRecoveryDeadline = 0
+	d.mu.Unlock()
+
+	sort.Slice(pending, func(i, j int) bool { return pending[i].Session < pending[j].Session })
+	for _, s := range pending {
+		s.Running = false
+		s.Reason = session.AutonomyReasonUnknown
+		if d.autonomySpans == nil {
+			continue
+		}
+		if err := d.autonomySpans.RecordSpan(s); err != nil {
+			d.log.LogError(logComponentAutonomySpans, s.Session, err.Error())
+		}
+	}
+}
+
+// journalOpenAutonomySpan records the session's open run the instant it opens,
+// so a daemon that dies seconds later still leaves it recoverable. The
+// reconciling SyncOpenSpans on the refresh ticker is what later moves its
+// last-seen instant forward and removes it if the session disappears.
+func (d *SessionDetector) journalOpenAutonomySpan(state *session.SessionState, now int64) {
+	if d.autonomySpans == nil || state.AutonomySpanStart == nil {
+		return
+	}
+	if err := d.autonomySpans.RecordOpenSpan(openAutonomySpanOf(state, now)); err != nil {
+		d.log.LogError(logComponentAutonomySpans, state.SessionID, err.Error())
+	}
+}
+
+// syncOpenAutonomySpans reconciles the journal against the sessions that
+// actually hold an open run right now, and reports whether it wrote.
+//
+// Throttled on two conditions, not one: the set CHANGING is what has to be
+// written immediately (a run that just ended must stop being reported as
+// running), while an unchanged set only needs its last-seen instants pushed
+// forward, which is worth one write per autonomyOpenSyncInterval and no more.
+//
+// A session whose run is held by the flicker grace still counts as open — the
+// grace has not decided yet, and a daemon that dies mid-grace should recover a
+// run rather than lose one.
+func (d *SessionDetector) syncOpenAutonomySpans(states []*session.SessionState, now int64) bool {
+	if d.autonomySpans == nil {
+		return false
+	}
+	open := make([]outbound.AutonomySpan, 0, 4)
+	for _, state := range states {
+		if state == nil || state.AutonomySpanStart == nil {
+			continue
+		}
+		open = append(open, openAutonomySpanOf(state, now))
+	}
+	key := autonomyOpenSetKey(open)
+
+	d.mu.Lock()
+	unchanged := key == d.autonomyOpenSyncKey
+	fresh := now-d.autonomyOpenSyncAt < int64(autonomyOpenSyncInterval/time.Second)
+	if unchanged && fresh {
+		d.mu.Unlock()
+		return false
+	}
+	d.autonomyOpenSyncKey = key
+	d.autonomyOpenSyncAt = now
+	d.mu.Unlock()
+
+	if err := d.autonomySpans.SyncOpenSpans(open); err != nil {
+		d.log.LogError(logComponentAutonomySpans, "", err.Error())
+		return false
+	}
+	return true
+}
+
+// openAutonomySpanOf renders a session's open run as a span whose End is the
+// instant it was last seen alive — never an end, which is why Running is set
+// and no reason is stamped.
+func openAutonomySpanOf(state *session.SessionState, now int64) outbound.AutonomySpan {
+	return outbound.AutonomySpan{
+		Start:           *state.AutonomySpanStart,
+		End:             now,
+		Project:         state.ProjectName,
+		Session:         state.SessionID,
+		Adapter:         state.Adapter,
+		Model:           autonomySpanModel(state),
+		Kind:            session.AutonomyKindForParent(state.ParentSessionID),
+		Parent:          state.ParentSessionID,
+		Running:         true,
+		StartLowerBound: state.AutonomySpanStartLowerBound,
+	}
+}
+
+// autonomyOpenSetKey is a signature of WHICH runs are open and when each began
+// — deliberately not of their last-seen instants, which change every tick and
+// would defeat the throttle they are being compared for.
+func autonomyOpenSetKey(open []outbound.AutonomySpan) string {
+	ids := make([]string, 0, len(open))
+	for _, s := range open {
+		ids = append(ids, s.Session+"@"+strconv.FormatInt(s.Start, 10))
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}

--- a/core/application/services/autonomy_span_recording_test.go
+++ b/core/application/services/autonomy_span_recording_test.go
@@ -1,0 +1,194 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// journalSpanStore is a span store that also keeps the OPEN-run journal, so a
+// test can hand the same store to two detectors and ask what survived between
+// them — which is what a daemon restart is.
+//
+// It carries the journal methods even in the shape this file was first run
+// against, where the shipped AutonomySpanStore had none of them: a Go value may
+// hold methods beyond the interface it satisfies, so the two red-first tests
+// below compiled and FAILED ON BEHAVIOUR against the unfixed daemon rather than
+// failing to build. That is the difference between evidence and a claim
+// (AGENTS.md, "House style for what counts as evidence").
+type journalSpanStore struct {
+	spans []outbound.AutonomySpan
+	open  map[string]outbound.AutonomySpan
+}
+
+func newJournalSpanStore() *journalSpanStore {
+	return &journalSpanStore{open: map[string]outbound.AutonomySpan{}}
+}
+
+func (j *journalSpanStore) RecordSpan(s outbound.AutonomySpan) error {
+	delete(j.open, s.Session)
+	if s.Project == "" || s.Duration() <= 0 {
+		return nil
+	}
+	j.spans = append(j.spans, s)
+	return nil
+}
+
+func (j *journalSpanStore) RecordOpenSpan(s outbound.AutonomySpan) error {
+	j.open[s.Session] = s
+	return nil
+}
+
+func (j *journalSpanStore) SyncOpenSpans(spans []outbound.AutonomySpan) error {
+	j.open = make(map[string]outbound.AutonomySpan, len(spans))
+	for _, s := range spans {
+		j.open[s.Session] = s
+	}
+	return nil
+}
+
+func (j *journalSpanStore) OpenSpans() ([]outbound.AutonomySpan, error) {
+	out := make([]outbound.AutonomySpan, 0, len(j.open))
+	for _, s := range j.open {
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (j *journalSpanStore) SpansInWindow(outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, error) {
+	return &outbound.AutonomySpanResult{}, nil
+}
+
+func (j *journalSpanStore) Prune(int) error { return nil }
+
+// bornWorkingDetector builds a detector wired to store, with a metrics
+// collector whose transcript already shows an open turn — the population
+// shouldClassifyAtBirth births `working`.
+func bornWorkingDetector(store outbound.AutonomySpanStore) *SessionDetector {
+	d := NewSessionDetector(nil, SessionDetectorDeps{
+		Log:     bornLog{},
+		Git:     bornGit{},
+		Metrics: openTurnMetrics{},
+	})
+	d.SetAutonomySpanStore(store)
+	return d
+}
+
+// birthEvent is the discovery event both restart halves see: same session id,
+// same transcript, because a restart rediscovers the SAME session.
+func birthEvent() agent.Event {
+	return agent.Event{SessionID: "sess-1", TranscriptPath: "/tmp/x/events.jsonl", CWD: "/tmp/x"}
+}
+
+// TestAutonomySpan_SessionBornWorkingOpensASpan is red-first defect 1 (#1905
+// recording).
+//
+// shouldClassifyAtBirth births a session `working` when it is a child (#889) or
+// when the transcript already carries evidence (#1447) — and the birth path
+// assigns state.State DIRECTLY, bypassing applyStateTransition, whose single
+// call to applyAutonomySpanTransition was the only place a span could open. So
+// every session that was ALREADY running when Irrlicht first saw it recorded
+// nothing at all, and "already running when Irrlicht first saw it" is what
+// every session is after a daemon restart.
+//
+// Seen red before the fix: `AutonomySpanStart = <nil>`.
+func TestAutonomySpan_SessionBornWorkingOpensASpan(t *testing.T) {
+	const born = 1_700_000_000
+
+	d := bornWorkingDetector(newJournalSpanStore())
+	state := d.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), born)
+
+	if state.State != session.StateWorking {
+		t.Fatalf("State = %q, want %q — the fixture's whole point is a session born working",
+			state.State, session.StateWorking)
+	}
+	if state.AutonomySpanStart == nil {
+		t.Fatal("AutonomySpanStart = nil: a session born `working` is a run that is " +
+			"under way, and opening no span for it is how the feature lost most of its runs")
+	}
+	if got := *state.AutonomySpanStart; got != born {
+		t.Errorf("AutonomySpanStart = %d, want %d (discovery time — nothing else is known)", got, born)
+	}
+}
+
+// TestAutonomySpan_OpenRunSurvivesADaemonRestart is red-first defect 2 (#1905
+// recording), and it is the one that ate the LONG runs: the longer a run, the
+// likelier it crosses a restart, so the feature systematically lost precisely
+// the runs it exists to report.
+//
+// The two halves share one store, which is what makes this a restart rather
+// than two unrelated daemons: the first daemon's open run has to be readable by
+// the second.
+//
+// Seen red before the fix: `spans recorded = 0`.
+func TestAutonomySpan_OpenRunSurvivesADaemonRestart(t *testing.T) {
+	const (
+		startedAt   = 1_700_000_000
+		restartedAt = startedAt + 3600
+		finishedAt  = restartedAt + 1800
+	)
+
+	store := newJournalSpanStore()
+
+	// Daemon 1 discovers a session that is already working, and dies.
+	first := bornWorkingDetector(store)
+	first.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), startedAt)
+
+	// Daemon 2 comes up and rediscovers the same session, still working.
+	second := bornWorkingDetector(store)
+	revived := second.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), restartedAt)
+
+	// It finishes its turn; the grace expires and the span is filed.
+	second.applyAutonomySpanTransition(revived, session.StateReady, finishedAt)
+	second.flushExpiredAutonomySpan(revived, finishedAt+autonomySpanGraceSeconds)
+
+	if len(store.spans) != 1 {
+		t.Fatalf("spans recorded = %d, want 1 — a run that crossed a daemon restart was lost entirely",
+			len(store.spans))
+	}
+	got := store.spans[0]
+	if got.Start != startedAt {
+		t.Errorf("span.Start = %d, want %d — the restart must not restart the clock: a "+
+			"90-minute run would otherwise be filed as a 30-minute one", got.Start, startedAt)
+	}
+	if got.End != finishedAt {
+		t.Errorf("span.End = %d, want %d", got.End, finishedAt)
+	}
+}
+
+// TestAutonomySpan_RunInProgressIsVisible is red-first defect 3 (#1905
+// recording): a span was only ever written when it CLOSED, so a run still under
+// way contributed nothing at all — the 3-hour run the maintainer was watching
+// while the panel said its longest was 35 minutes.
+//
+// Asserted through the store's open-run journal, which is the daemon's record
+// of what is running right now; the filesystem tracker's own half of this —
+// serving that journal back through SpansInWindow — is
+// TestSpansInWindow_ReturnsTheRunStillInProgress.
+//
+// Seen red before the fix: `open runs = 0`.
+func TestAutonomySpan_RunInProgressIsVisible(t *testing.T) {
+	const born = 1_700_000_000
+
+	store := newJournalSpanStore()
+	d := bornWorkingDetector(store)
+	d.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), born)
+
+	open, err := store.OpenSpans()
+	if err != nil {
+		t.Fatalf("OpenSpans: %v", err)
+	}
+	if len(open) != 1 {
+		t.Fatalf("open runs = %d, want 1 — a run that has not ended yet is still a run, "+
+			"and a feature that only records finished ones cannot see the long one you are watching",
+			len(open))
+	}
+	if open[0].Start != born {
+		t.Errorf("open run Start = %d, want %d", open[0].Start, born)
+	}
+	if open[0].Session != "sess-1" {
+		t.Errorf("open run Session = %q, want %q", open[0].Session, "sess-1")
+	}
+}

--- a/core/application/services/autonomy_span_recovery_test.go
+++ b/core/application/services/autonomy_span_recovery_test.go
@@ -1,0 +1,210 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Mutation fixtures for what #1905's recording fix ADDS.
+//
+// None of these had a "before the fix" to run red against: they pin behaviour
+// that did not exist. Each therefore names the MUTATION it catches and, where
+// it can, computes the wrong answer into the failure message, per AGENTS.md's
+// rule for a guard with no red-first history.
+
+// The lower-bound mark separates a start Irrlicht MEASURED from one it merely
+// discovered, and it has to be right in both directions.
+//
+// MUTATIONS CAUGHT, one per case:
+//
+//   - marking nothing: a run of unknown start would be reported as measured,
+//     which is the wrong number the marking exists to stop;
+//   - marking everything: an observed `→ working` transition would report as
+//     an estimate, discrediting the numbers that ARE measured;
+//   - marking a recovered run: a start the previous daemon measured would be
+//     downgraded to a guess on every restart, so the longest runs on the
+//     machine would end up the least trusted ones.
+func TestAutonomySpanLowerBound_MarksExactlyTheUnmeasuredStarts(t *testing.T) {
+	const t0 = 1_700_000_000
+
+	t.Run("born working is a lower bound", func(t *testing.T) {
+		d := bornWorkingDetector(newJournalSpanStore())
+		st := d.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), t0)
+		if !st.AutonomySpanStartLowerBound {
+			t.Fatal("a session met already working reports its start as measured — nothing " +
+				"measured it, so its duration is a floor and the row has to say so")
+		}
+	})
+
+	t.Run("an observed transition is measured", func(t *testing.T) {
+		d, _, st := spanFixture()
+		// Poisoned first: the flag must be SET false by the transition, not
+		// merely left alone. A session that carried a lower-bound run earlier
+		// in its life would otherwise taint a fully measured one later.
+		st.AutonomySpanStartLowerBound = true
+		d.applyAutonomySpanTransition(st, session.StateWorking, t0)
+		if st.AutonomySpanStartLowerBound {
+			t.Fatal("a run whose opening transition was observed is marked as an estimate")
+		}
+	})
+
+	t.Run("a recovered run keeps its measured start", func(t *testing.T) {
+		store := newJournalSpanStore()
+		first := bornWorkingDetector(store)
+		firstState := first.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), t0)
+		// Give the first daemon an OBSERVED start, the way a session already
+		// alive when its run began would have.
+		first.applyAutonomySpanTransition(firstState, session.StateReady, t0+10)
+		first.applyAutonomySpanTransition(firstState, session.StateWorking, t0+600)
+
+		second := bornWorkingDetector(store)
+		revived := second.buildNewSessionState(agent.Identity{Name: "copilot"}, birthEvent(), t0+900)
+		if revived.AutonomySpanStartLowerBound {
+			t.Fatal("a run adopted from the journal is marked as an estimate — that start was " +
+				"measured by the daemon that died holding it, which is why the journal exists")
+		}
+		if revived.AutonomySpanStart == nil || *revived.AutonomySpanStart != t0+600 {
+			t.Fatalf("recovered start = %v, want %d", revived.AutonomySpanStart, int64(t0+600))
+		}
+	})
+}
+
+// A recovered run that NOBODY rediscovers is closed where it was last seen —
+// not at "now", and not never.
+//
+// MUTATIONS CAUGHT:
+//
+//   - closing at `now`: the run absorbs the daemon's whole downtime, so a
+//     30-minute run interrupted by an overnight reboot becomes an 8-hour one;
+//   - never closing: the run stays "in progress" forever, so a session that
+//     ended months ago is still reported as running;
+//   - adopting it late: a rediscovery after the window would splice the
+//     downtime, and everything since, into one fabricated run.
+func TestAutonomySpanRecovery_UnadoptedRunClosesWhereItWasLastSeen(t *testing.T) {
+	const (
+		startedAt = 1_700_000_000
+		lastSeen  = startedAt + 1800
+		bootedAt  = lastSeen + 8*3600 // an overnight reboot
+	)
+
+	store := newJournalSpanStore()
+	store.open["gone"] = outbound.AutonomySpan{
+		Start: startedAt, End: lastSeen, Project: "irrlicht", Session: "gone",
+		Kind: session.AutonomyKindTopLevel, Running: true,
+	}
+
+	d := bornWorkingDetector(store)
+	d.now = func() time.Time { return time.Unix(bootedAt, 0) }
+	d.loadRecoverableAutonomySpans()
+
+	// Inside the window nothing is settled: the session may still turn up.
+	d.settleUnadoptedAutonomySpans(bootedAt + 1)
+	if len(store.spans) != 0 {
+		t.Fatalf("settled %d runs inside the adoption window, want 0 — the session had not yet "+
+			"had its chance to be rediscovered", len(store.spans))
+	}
+
+	past := bootedAt + int64(autonomyRecoveryWindow/time.Second) + 1
+	d.settleUnadoptedAutonomySpans(past)
+	if len(store.spans) != 1 {
+		t.Fatalf("settled %d runs past the window, want 1 — an unadopted run must not stay open forever",
+			len(store.spans))
+	}
+	got := store.spans[0]
+	if got.End != lastSeen {
+		t.Fatalf("closed at %d (a %ds run), want %d (a %ds run) — closing at `now` credits the run "+
+			"with the whole time the daemon was down",
+			got.End, past-startedAt, int64(lastSeen), int64(lastSeen-startedAt))
+	}
+	if got.Reason != session.AutonomyReasonUnknown {
+		t.Errorf("end reason = %q, want %q — nothing observed why it stopped, and %q would claim "+
+			"it finished its turn", got.Reason, session.AutonomyReasonUnknown, session.StateReady)
+	}
+	if got.Running {
+		t.Error("a settled run is still marked running")
+	}
+
+	if _, ok := d.adoptRecoveredAutonomySpan("gone"); ok {
+		t.Error("a settled run was adopted after the fact — that is resurrection, not recovery")
+	}
+}
+
+// A session torn down while still WORKING files its run.
+//
+// MUTATION CAUGHT: the shipped teardown settled only a PENDING end, so a
+// session whose agent process exited mid-run — which is how most sessions
+// actually end — recorded nothing at all. Removing the still-open branch loses
+// the span entirely and the count goes to zero.
+func TestAutonomySpan_TeardownWhileWorkingStillFilesTheRun(t *testing.T) {
+	const t0 = 1_700_000_000
+	const goneAt = t0 + 4200
+
+	d, store, st := spanFixture()
+	d.now = func() time.Time { return time.Unix(goneAt, 0) }
+	d.applyAutonomySpanTransition(st, session.StateWorking, t0)
+	st.State = session.StateWorking
+
+	d.settleAutonomySpanOnTeardown(st)
+
+	if len(store.spans) != 1 {
+		t.Fatalf("got %d spans, want 1 — a %d-minute run whose agent exited mid-flight was lost",
+			len(store.spans), (goneAt-t0)/60)
+	}
+	got := store.spans[0]
+	if got.Start != t0 || got.End != goneAt {
+		t.Errorf("span = [%d,%d], want [%d,%d]", got.Start, got.End, int64(t0), int64(goneAt))
+	}
+	if got.Reason != session.AutonomyReasonUnknown {
+		t.Errorf("end reason = %q, want %q — the session vanished, so nothing observed why the "+
+			"run stopped", got.Reason, session.AutonomyReasonUnknown)
+	}
+}
+
+// The journal is RECONCILED, not merely appended to: the sync writes exactly
+// the runs that are open right now.
+//
+// MUTATIONS CAUGHT:
+//
+//   - upsert-only (no removal): a session that vanished between ticks keeps an
+//     entry nothing will ever close, so it is reported as running forever and
+//     adopted as a run by the next daemon to start;
+//   - throttling on time alone: a run that just ended would keep being served
+//     as still-running until the interval elapsed.
+func TestSyncOpenAutonomySpans_WritesExactlyTheRunsThatAreOpen(t *testing.T) {
+	const t0 = 1_700_000_000
+
+	store := newJournalSpanStore()
+	d := newSessionDetector()
+	d.log = &gateLogger{}
+	d.autonomySpans = store
+
+	working := &session.SessionState{SessionID: "a", ProjectName: "p", AutonomySpanStart: ptrInt64(t0)}
+	idle := &session.SessionState{SessionID: "b", ProjectName: "p"}
+
+	if !d.syncOpenAutonomySpans([]*session.SessionState{working, idle}, t0+5) {
+		t.Fatal("the first sync did not write")
+	}
+	if len(store.open) != 1 {
+		t.Fatalf("journal holds %d runs, want 1 — only the working session has one open", len(store.open))
+	}
+	if _, ok := store.open["a"]; !ok {
+		t.Fatalf("journal is missing the open run: %+v", store.open)
+	}
+
+	// The run ends. The set changed, so the write happens NOW rather than
+	// waiting out autonomyOpenSyncInterval.
+	working.AutonomySpanStart = nil
+	if !d.syncOpenAutonomySpans([]*session.SessionState{working, idle}, t0+6) {
+		t.Fatal("a changed open set did not write immediately — a finished run would go on " +
+			"being served as still running")
+	}
+	if len(store.open) != 0 {
+		t.Fatalf("journal still holds %d runs after every run ended: %+v", len(store.open), store.open)
+	}
+}
+
+func ptrInt64(v int64) *int64 { return &v }

--- a/core/application/services/autonomy_span_test.go
+++ b/core/application/services/autonomy_span_test.go
@@ -26,6 +26,14 @@ func (r *recordingSpanStore) SpansInWindow(outbound.AutonomySpanQuery) (*outboun
 }
 func (r *recordingSpanStore) Prune(int) error { return nil }
 
+// The open-run journal (#1905 recording). Deliberately inert here: these tests
+// are about the transition rules that CLOSE a span, and a store that remembered
+// open runs would let one test's leftovers reach the next. journalSpanStore, in
+// autonomy_span_recording_test.go, is the one that keeps them.
+func (r *recordingSpanStore) RecordOpenSpan(outbound.AutonomySpan) error  { return nil }
+func (r *recordingSpanStore) SyncOpenSpans([]outbound.AutonomySpan) error { return nil }
+func (r *recordingSpanStore) OpenSpans() ([]outbound.AutonomySpan, error) { return nil, nil }
+
 // spanFixture builds a detector wired to a recording store, plus a session to
 // drive transitions on. Struct-literal detector: the span code touches only
 // the store and the logger.

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -134,6 +134,29 @@ type SessionDetector struct {
 	mu              sync.Mutex
 	projectSessions map[string]string // sessionID → projectDir
 
+	// autonomyRecovered holds the open autonomy runs a PREVIOUS daemon left in
+	// the span store's journal, keyed by session id, waiting to be adopted by
+	// the session they belong to as it is rediscovered (#1905 recording).
+	//
+	// An entry is removed when it is adopted, and settled — closed where the
+	// previous daemon last saw it alive — when autonomyRecoveryDeadline passes
+	// without adoption. That deadline is what stops recovery from becoming
+	// resurrection: a session that finished or went away while the daemon was
+	// down is never rediscovered, so its run closes at the last instant anyone
+	// measured rather than being credited with the downtime.
+	//
+	// Guarded by mu, like projectSessions beside it: written on the event-loop
+	// goroutine and read by the refresh ticker's.
+	autonomyRecovered        map[string]outbound.AutonomySpan
+	autonomyRecoveryDeadline int64
+
+	// autonomyOpenSyncAt and autonomyOpenSyncKey throttle the open-run journal
+	// rewrite on the refresh ticker: it happens when the set of open runs
+	// CHANGED, or once every autonomyOpenSyncInterval to move their last-seen
+	// instant forward. Also under mu.
+	autonomyOpenSyncAt  int64
+	autonomyOpenSyncKey string
+
 	// deletedSessions tracks session IDs that were explicitly deleted (process
 	// exit, /clear cleanup) with their deletion timestamp. Prevents late-
 	// arriving transcript activity from re-creating a session that was
@@ -312,6 +335,7 @@ func newSessionDetector() *SessionDetector {
 		signals:                  session.NewSignalHolds(),
 		dwell:                    session.NewStateDwell(),
 		idleProjectRetryAttempts: make(map[string]int),
+		autonomyRecovered:        make(map[string]outbound.AutonomySpan),
 		bgLiveProbe:              anyLiveOutputWriter,
 		bgPIDProbe:               anyLivePID,
 		bgLive:                   make(map[string]bool),
@@ -474,8 +498,15 @@ func (d *SessionDetector) SetCostTracker(c outbound.CostTracker) {
 // autonomy spans are appended to it as sessions leave `working`. Pass nil to
 // disable — the open-span bookkeeping on the session still runs, so a daemon
 // without a store never accumulates a stale "open since".
+//
+// It also loads the store's OPEN-RUN JOURNAL, which is what makes a run survive
+// the daemon that was measuring it (#1905 recording). Done here rather than in
+// startup.go because this is the single wiring point every daemon and every
+// test goes through, and a recovery that only ran on one of those paths would
+// be a recovery nothing exercises.
 func (d *SessionDetector) SetAutonomySpanStore(s outbound.AutonomySpanStore) {
 	d.autonomySpans = s
+	d.loadRecoverableAutonomySpans()
 }
 
 // SetHistoryTracker wires an optional HistoryTracker that records per-session

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -363,6 +363,17 @@ func (d *SessionDetector) buildNewSessionState(id agent.Identity, ev agent.Event
 			state.State = newState
 		}
 	}
+
+	// A session born `working` is a RUN ALREADY UNDER WAY, and its autonomy
+	// span opens here (#1905 recording).
+	//
+	// It cannot open in applyStateTransition, which is where every other span
+	// opens: the block above assigns state.State directly and by design — the
+	// session does not yet exist for anything to transition. That is precisely
+	// why the run went unrecorded, and why the fix has to be at the birth site
+	// rather than folded into the transition path. See openAutonomySpanAtBirth
+	// for the start it picks and what it marks.
+	d.openAutonomySpanAtBirth(state, now)
 	return state
 }
 
@@ -1847,6 +1858,14 @@ func (d *SessionDetector) refreshStaleSessions() {
 		return
 	}
 	now := d.nowFn()
+
+	// Autonomy runs left open by a previous daemon that nobody rediscovered
+	// are closed here, once their adoption window has passed (#1905
+	// recording). Ahead of the per-session loop, because it is about sessions
+	// this loop will never see: they are the ones that ended while the daemon
+	// was down.
+	d.settleUnadoptedAutonomySpans(now.Unix())
+
 	for _, state := range sessions {
 		// An autonomy span held open by the flicker grace (#1905) settles
 		// here: this ticker is the only thing that revisits a session which
@@ -1883,6 +1902,14 @@ func (d *SessionDetector) refreshStaleSessions() {
 			}
 		}
 	}
+
+	// The open-run journal is reconciled LAST, against the sessions as this
+	// tick leaves them (#1905 recording) — so a run that just closed above is
+	// already gone from the set rather than being written out as running and
+	// removed a tick later. It also drops entries for sessions that are simply
+	// no longer in the repo, which is what keeps the journal from accumulating
+	// runs nothing will ever close.
+	d.syncOpenAutonomySpans(sessions, now.Unix())
 }
 
 // shouldRevisitIdleSession reports whether the ticker has a reason to run a

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -691,12 +691,6 @@ type historyQuery struct {
 	rangeKey    string
 	start, end  int64
 	seriesQuery outbound.SeriesQuery
-	// includeSubagents is Autonomy's own selector (#1905 subagents): whether
-	// runs of child sessions join the ones of top-level sessions. Every other
-	// chart ignores it — a subagent's cost is its own, but a subagent's RUN is
-	// a nested interval inside its parent's, which is what makes this one
-	// section need the distinction.
-	includeSubagents bool
 }
 
 // resolveHistoryWindow resolves a chart's [start, end) window and bucket width
@@ -792,33 +786,25 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	}
 
 	return historyQuery{
-		chart:            chart,
-		group:            group,
-		metric:           metric,
-		scopeEcho:        scopeEcho,
-		rangeKey:         rangeKey,
-		start:            start,
-		end:              end,
-		seriesQuery:      seriesQuery,
-		includeSubagents: autonomyIncludeSubagents(q),
+		chart:       chart,
+		group:       group,
+		metric:      metric,
+		scopeEcho:   scopeEcho,
+		rangeKey:    rangeKey,
+		start:       start,
+		end:         end,
+		seriesQuery: seriesQuery,
 	}, true
 }
 
-// autonomyIncludeSubagents reads ?include_subagents= (#1905 subagents).
-//
-// ABSENT MEANS FALSE — top-level runs only — and so does any value that is not
-// an affirmative one. That direction is deliberate: the failure mode of
-// guessing "true" is a headline p50 dragged down by short nested runs that were
-// already counted inside their parents', which is a wrong number nothing on
-// screen would explain. The failure mode of guessing "false" is a control that
-// looks like it did nothing, which the reader can see.
-func autonomyIncludeSubagents(q url.Values) bool {
-	switch q.Get("include_subagents") {
-	case "1", "true", "yes":
-		return true
-	}
-	return false
-}
+// There is no ?include_subagents= any more (#1905 recording). Autonomy counts
+// every run, subagent runs included: they are runs Irrlicht recorded, and which
+// ones a window holds stopped being a per-request choice. An old client still
+// sending the parameter is answered with every run, which is what its
+// affirmative setting asked for and a superset of what its default did — never
+// an error, because a query parameter that no longer exists is not a bad
+// request. The `kind` and `parent` fields on each row are what still tell a
+// subagent's run from a top-level one.
 
 // historyChartDeps bundles the readers the non-cost charts need, so the
 // dispatcher below takes one value instead of four positional collaborators
@@ -840,9 +826,9 @@ func serveNonCostHistoryChart(w http.ResponseWriter, r *http.Request, hq history
 	case chartAutonomyDuration:
 		// Autonomy (#1905) reads the always-on span log, never the opt-in
 		// recordings — see outbound.AutonomySpanStore for why that matters.
-		serveHistoryAutonomyDurationChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end, hq.includeSubagents)
+		serveHistoryAutonomyDurationChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
 	case chartAutonomySpans:
-		serveHistoryAutonomySpansChart(w, deps.autonomy, hq.rangeKey, hq.start, hq.end, hq.includeSubagents)
+		serveHistoryAutonomySpansChart(w, deps.autonomy, hq.rangeKey, hq.start, hq.end)
 	case "yield":
 		// A per-project aggregate over completed sessions, not a time series (#373).
 		writeHistoryJSON(w, buildYieldResponse(hq.rangeKey, hq.group, hq.start, hq.end, deps.sessions))

--- a/core/cmd/irrlichd/history_autonomy.go
+++ b/core/cmd/irrlichd/history_autonomy.go
@@ -177,9 +177,13 @@ type historyAutonomyDurationResponse struct {
 	// measured (#1905 back-fill). Always present, zero-valued when the whole
 	// window was measured live.
 	Provenance historyAutonomyProvenance `json:"provenance"`
-	// Kinds says what this payload counted and what it left out (#1905
-	// subagents). Always present.
+	// Kinds says what this payload is made of, by run kind (#1905 subagents).
+	// Always present.
 	Kinds historyAutonomyKinds `json:"kinds"`
+	// Measurement says how many of the runs in view have a duration that is a
+	// floor rather than a measurement (#1905 recording). Always present,
+	// zero-valued when every run in view is finished and fully measured.
+	Measurement historyAutonomyMeasurement `json:"measurement"`
 }
 
 // historyAutonomyProvenance is the wire shape of
@@ -298,55 +302,63 @@ func autonomyEraName(source string) string {
 	return source
 }
 
-// historyAutonomyKinds is the wire shape of outbound.AutonomySpanKinds plus the
-// MODE that produced the response (#1905 subagents).
+// historyAutonomyKinds is the wire shape of outbound.AutonomySpanKinds: what
+// the window is made of, by run kind (#1905 subagents).
 //
-// The mode ships with the counts rather than being left for the client to
-// remember it asked for, because the two together are what makes a figure
-// unambiguous: "42 runs" means different things under each mode, and a client
-// that redrew from a cached payload after the toggle moved would otherwise
-// label the old number with the new mode.
+// THERE IS NO MODE ANY MORE (#1905 recording). Subagent runs are always
+// counted — they are runs Irrlicht itself recorded — so "42 runs" means one
+// thing and a client has nothing to remember it asked for. The three counts
+// stay because they still say something a reader wants: how much of a window
+// was subagent work, and how much of it predates the classification.
 type historyAutonomyKinds struct {
-	// Mode is autonomyModeTopLevel or autonomyModeAll — what the spans and
-	// every figure derived from them actually counted.
-	Mode string `json:"mode"`
-	// TopLevel, Subagent and Unknown count the WINDOW, not the response: they
-	// are taken before the subagent filter runs, so `Subagent` is the number a
-	// client prints as "N subagent runs excluded" under the default mode.
+	// TopLevel, Subagent and Unknown count the window, and — nothing being
+	// dropped for its kind — the rows returned with them.
 	TopLevel int `json:"top_level"`
 	Subagent int `json:"subagent"`
 	Unknown  int `json:"unknown"`
 }
 
-// The two mode names on the wire. Spelled here and nowhere else so the two
-// clients cannot disagree about what a payload counted.
-const (
-	// autonomyModeTopLevel is the default: subagent runs are left out, because
-	// a subagent's span is a nested interval inside its parent's and counting
-	// both counts one stretch twice.
-	autonomyModeTopLevel = "top_level"
-
-	// autonomyModeAll counts every run, subagent runs included.
-	autonomyModeAll = "all"
-)
-
-// autonomyModeName names the mode a query ran under.
-func autonomyModeName(includeSubagents bool) string {
-	if includeSubagents {
-		return autonomyModeAll
-	}
-	return autonomyModeTopLevel
-}
-
-// autonomyKindsFrom converts the store's kind census to the wire shape,
-// stamping the mode it was read under. One converter for both payloads, so the
-// two elements of one section can never disagree about what they counted.
-func autonomyKindsFrom(k outbound.AutonomySpanKinds, includeSubagents bool) historyAutonomyKinds {
+// autonomyKindsFrom converts the store's kind census to the wire shape. One
+// converter for both payloads, so the two elements of one section can never
+// disagree about what they counted.
+func autonomyKindsFrom(k outbound.AutonomySpanKinds) historyAutonomyKinds {
 	return historyAutonomyKinds{
-		Mode:     autonomyModeName(includeSubagents),
 		TopLevel: k.TopLevel,
 		Subagent: k.Subagent,
 		Unknown:  k.Unknown,
+	}
+}
+
+// historyAutonomyMeasurement is the wire shape of
+// outbound.AutonomySpanMeasurement: how many of the runs in view have a
+// duration that is a LOWER BOUND rather than a measurement (#1905 recording).
+//
+// It ships beside Provenance and answers a different question. Provenance asks
+// where a number came from; this asks whether the number is finished. A run
+// still going, and a run Irrlicht met already in progress, are both real runs
+// with real durations — floors, not measurements. Both are counted, returned
+// and named on screen rather than quietly dropped, because dropping them is
+// what left 5 of a day's 35 runs on the record.
+type historyAutonomyMeasurement struct {
+	// Running is how many of the runs in view have not ended.
+	//
+	// They are NOT samples for the percentiles — see
+	// buildAutonomyDurationResponse, where that decision is made and stated —
+	// so this is also the gap between the runs the section shows and the runs
+	// its percentiles were computed from.
+	Running int `json:"running"`
+
+	// LowerBoundStart is how many began before Irrlicht was watching, so their
+	// recorded start is when it started watching and not when the run began.
+	LowerBoundStart int `json:"start_lower_bound"`
+}
+
+// autonomyMeasurementFrom converts the store's measurement census to the wire
+// shape. One converter for both payloads, same reason as the kinds census.
+func autonomyMeasurementFrom(m outbound.AutonomySpanMeasurement) historyAutonomyMeasurement {
+	return historyAutonomyMeasurement{
+		Running:         m.Running,
+		LowerBoundStart: m.LowerBoundStart,
 	}
 }
 
@@ -365,6 +377,13 @@ type historyAutonomySpanRow struct {
 	Kind string `json:"kind"`
 	// Parent is the parent session id of a subagent run, "" otherwise.
 	Parent string `json:"parent,omitempty"`
+	// Running marks a run that has not ended: End is where it had got to when
+	// the window was taken, so its length is a floor (#1905 recording). A row
+	// carrying it must never be drawn as a finished run.
+	Running bool `json:"running,omitempty"`
+	// StartLowerBound marks a run Irrlicht met already in progress, so Start
+	// is when it began WATCHING. Its length is a floor for the other reason.
+	StartLowerBound bool `json:"start_lower_bound,omitempty"`
 }
 
 // historyAutonomySpansResponse is the chart=autonomy_spans payload: the spans
@@ -384,30 +403,31 @@ type historyAutonomySpansResponse struct {
 	// Provenance marks how much of THIS window was reconstructed. Counted
 	// after the limit clips the spans, so it describes the rows above it.
 	Provenance historyAutonomyProvenance `json:"provenance"`
-	// Kinds says what this payload counted and what it left out (#1905
-	// subagents). Unlike Provenance these counts describe the WINDOW, not the
-	// returned rows — the excluded runs are the whole point of the number.
+	// Kinds says what this payload is made of, by run kind (#1905 subagents).
 	Kinds historyAutonomyKinds `json:"kinds"`
+	// Measurement says how many of the returned runs have a duration that is a
+	// floor rather than a measurement (#1905 recording).
+	Measurement historyAutonomyMeasurement `json:"measurement"`
 }
 
 // serveHistoryAutonomyDurationChart serves chart=autonomy_duration. A nil
 // store yields an empty-but-valid payload rather than an error, mirroring
 // serveHistoryAgentsChart.
-func serveHistoryAutonomyDurationChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64, includeSubagents bool) {
-	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end, IncludeSubagents: includeSubagents})
+func serveHistoryAutonomyDurationChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64) {
+	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end})
 	if !ok {
 		return
 	}
-	writeHistoryJSON(w, buildAutonomyDurationResponse(window, bucketSeconds, start, end, res, includeSubagents))
+	writeHistoryJSON(w, buildAutonomyDurationResponse(window, bucketSeconds, start, end, res))
 }
 
 // serveHistoryAutonomySpansChart serves chart=autonomy_spans.
-func serveHistoryAutonomySpansChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, start, end int64, includeSubagents bool) {
-	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end, Limit: autonomySpanLimit, IncludeSubagents: includeSubagents})
+func serveHistoryAutonomySpansChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, start, end int64) {
+	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end, Limit: autonomySpanLimit})
 	if !ok {
 		return
 	}
-	writeHistoryJSON(w, buildAutonomySpansResponse(window, start, end, res, includeSubagents))
+	writeHistoryJSON(w, buildAutonomySpansResponse(window, start, end, res))
 }
 
 // readAutonomySpans performs the store read shared by both elements,
@@ -435,7 +455,29 @@ func readAutonomySpans(w http.ResponseWriter, store outbound.AutonomySpanStore, 
 // named in stats.Percentile — not because the clients could not divide, but
 // because "the p95" is ambiguous enough that two independent implementations
 // draw two different lines from the same data (#1905 design decision 5).
-func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult, includeSubagents bool) historyAutonomyDurationResponse {
+// A RUN STILL IN PROGRESS IS NOT A SAMPLE. This is where that is decided
+// (#1905 recording), and it is a decision rather than an omission.
+//
+// A run that is three hours in and continuing has a duration of "at least three
+// hours". Folding that into a percentile treats a floor as a measurement, and
+// the error is not random: it always shortens, and it shortens the longest runs
+// hardest, which is the exact bias this whole fix exists to remove. A p95 that
+// counted it would say the top 5% of runs were shorter than they were.
+//
+// So a running run is COUNTED, RETURNED, DRAWN and NAMED — response.Measurement
+// carries how many there are, and both clients say so — but the percentile
+// envelope, the summary row and the min/max extremes are computed from finished
+// runs only. Removing it from the chart instead was the other option and is
+// worse in the same direction as the original defect: it makes the longest run
+// on the machine the one thing the section cannot show.
+//
+// A LOWER-BOUND START is treated differently, and the asymmetry is the point. A
+// run Irrlicht met already in progress has FINISHED: its length is known to
+// within however long it had been going when Irrlicht started watching, which
+// is bounded by the daemon's own uptime. It is a sample, and it is marked.
+// Dropping those would re-create the under-count exactly — every long run that
+// crosses a restart is one of them.
+func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyDurationResponse {
 	n := 0
 	if bucketSeconds > 0 && end > start {
 		n = int((end - start + bucketSeconds - 1) / bucketSeconds)
@@ -448,6 +490,9 @@ func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int6
 	byBucket := make([][]float64, n)
 	all := make([]float64, 0, len(res.Spans))
 	for _, s := range res.Spans {
+		if s.Running {
+			continue
+		}
 		d := float64(s.Duration())
 		if d <= 0 {
 			continue
@@ -485,7 +530,8 @@ func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int6
 		EarliestSpan:  res.EarliestStart,
 		TotalRecorded: res.TotalRecorded,
 		Provenance:    autonomyProvenanceFrom(res.Provenance),
-		Kinds:         autonomyKindsFrom(res.Kinds, includeSubagents),
+		Kinds:         autonomyKindsFrom(res.Kinds),
+		Measurement:   autonomyMeasurementFrom(res.Measurement),
 	}
 }
 
@@ -523,19 +569,25 @@ func autonomySummaryFrom(samples []float64) historyAutonomySummary {
 
 // buildAutonomySpansResponse renders the window's spans plus the strip's row
 // order (most autonomous seconds first, then name for a stable tie-break).
-func buildAutonomySpansResponse(window string, start, end int64, res *outbound.AutonomySpanResult, includeSubagents bool) historyAutonomySpansResponse {
+func buildAutonomySpansResponse(window string, start, end int64, res *outbound.AutonomySpanResult) historyAutonomySpansResponse {
 	rows := make([]historyAutonomySpanRow, 0, len(res.Spans))
 	totals := map[string]int64{}
 	for _, s := range res.Spans {
 		rows = append(rows, historyAutonomySpanRow{
-			Start:   s.Start,
-			End:     s.End,
-			Project: s.Project,
-			Session: s.Session,
-			Reason:  s.Reason,
-			Kind:    session.AutonomyKindOrUnknown(s.Kind),
-			Parent:  s.Parent,
+			Start:           s.Start,
+			End:             s.End,
+			Project:         s.Project,
+			Session:         s.Session,
+			Reason:          s.Reason,
+			Kind:            session.AutonomyKindOrUnknown(s.Kind),
+			Parent:          s.Parent,
+			Running:         s.Running,
+			StartLowerBound: s.StartLowerBound,
 		})
+		// A running run's seconds-so-far DO count towards its project's rank.
+		// The row order is "which projects had the most autonomous time", and
+		// a three-hour run still going is three hours of it — leaving it out
+		// would rank the busiest project below one that merely finished first.
 		totals[s.Project] += s.Duration()
 	}
 	projects := make([]string, 0, len(totals))
@@ -559,6 +611,7 @@ func buildAutonomySpansResponse(window string, start, end int64, res *outbound.A
 		TotalRecorded: res.TotalRecorded,
 		Truncated:     res.Truncated,
 		Provenance:    autonomyProvenanceFrom(res.Provenance),
-		Kinds:         autonomyKindsFrom(res.Kinds, includeSubagents),
+		Kinds:         autonomyKindsFrom(res.Kinds),
+		Measurement:   autonomyMeasurementFrom(res.Measurement),
 	}
 }

--- a/core/cmd/irrlichd/history_autonomy_endpoint_test.go
+++ b/core/cmd/irrlichd/history_autonomy_endpoint_test.go
@@ -21,17 +21,26 @@ type fakeAutonomyStore struct {
 	total      int
 	truncated  bool
 	provenance outbound.AutonomySpanProvenance
-	// kinds is the window's run-kind census (#1905 subagents). The real store
-	// counts it BEFORE the subagent filter, which is why it is a field here
-	// rather than derived from `spans`: the number under test is precisely the
-	// one that describes runs the response does not carry.
-	kinds     outbound.AutonomySpanKinds
-	err       error
-	lastQuery outbound.AutonomySpanQuery
+	// kinds is the window's run-kind census (#1905 subagents). A field rather
+	// than something derived from `spans`, because the handler's job is to
+	// carry the store's census onto the wire, not to recompute it.
+	kinds outbound.AutonomySpanKinds
+	// measurement is the window's lower-bound census (#1905 recording): how
+	// many of the runs are still going, and how many started before Irrlicht
+	// was watching. A field for the same reason `kinds` is one — the handler's
+	// job is to carry it onto the wire, not to recompute it.
+	measurement outbound.AutonomySpanMeasurement
+	err         error
+	lastQuery   outbound.AutonomySpanQuery
 }
 
-func (f *fakeAutonomyStore) RecordSpan(outbound.AutonomySpan) error { return nil }
-func (f *fakeAutonomyStore) Prune(int) error                        { return nil }
+func (f *fakeAutonomyStore) RecordSpan(outbound.AutonomySpan) error     { return nil }
+func (f *fakeAutonomyStore) RecordOpenSpan(outbound.AutonomySpan) error { return nil }
+func (f *fakeAutonomyStore) SyncOpenSpans([]outbound.AutonomySpan) error {
+	return nil
+}
+func (f *fakeAutonomyStore) OpenSpans() ([]outbound.AutonomySpan, error) { return nil, nil }
+func (f *fakeAutonomyStore) Prune(int) error                             { return nil }
 func (f *fakeAutonomyStore) SpansInWindow(q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, error) {
 	f.lastQuery = q
 	if f.err != nil {
@@ -44,6 +53,7 @@ func (f *fakeAutonomyStore) SpansInWindow(q outbound.AutonomySpanQuery) (*outbou
 		Truncated:     f.truncated,
 		Provenance:    f.provenance,
 		Kinds:         f.kinds,
+		Measurement:   f.measurement,
 	}, nil
 }
 

--- a/core/cmd/irrlichd/history_autonomy_kinds_test.go
+++ b/core/cmd/irrlichd/history_autonomy_kinds_test.go
@@ -8,77 +8,80 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
-// The API half of the run-kind classification (#1905 subagents).
+// The API half of the run-kind classification (#1905 subagents), retargeted at
+// the FIELD after the filter was removed (#1905 recording).
 //
-// Two things have to be true of every Autonomy payload: the store was asked for
-// the mode the caller wanted, and the payload says which mode produced it. The
-// second is what keeps "42 runs" from meaning two different things depending on
-// a control the reader may have moved after the request went out.
+// The classification is still real data and every row still carries it. What no
+// longer exists is a mode: subagent runs are always counted, so a payload has
+// nothing to declare about which runs it chose, and there is no request the
+// caller can make that changes the answer.
 
-// THE DEFAULT IS TOP-LEVEL RUNS. Absent means false, and so does anything that
-// is not an affirmative — guessing "true" would drag the headline median down
-// with short nested runs that were already counted inside their parents'.
-func TestAutonomyIncludeSubagents_DefaultsToTopLevelRunsOnly(t *testing.T) {
-	cases := []struct {
-		query string
-		want  bool
-	}{
-		{"chart=autonomy_duration&window=30d", false},
-		{"chart=autonomy_duration&window=30d&include_subagents=false", false},
-		{"chart=autonomy_duration&window=30d&include_subagents=", false},
-		{"chart=autonomy_duration&window=30d&include_subagents=maybe", false},
-		{"chart=autonomy_duration&window=30d&include_subagents=true", true},
-		{"chart=autonomy_duration&window=30d&include_subagents=1", true},
-		{"chart=autonomy_spans&window=24h&include_subagents=true", true},
-		{"chart=autonomy_spans&window=24h", false},
+// The section counts every run, whatever the request says. An old client still
+// sending ?include_subagents= gets the same payload as one that does not —
+// answered, never rejected, because a parameter that no longer exists is not a
+// bad request.
+func TestAutonomy_CountsEveryRunWhateverTheQueryAsksFor(t *testing.T) {
+	queries := []string{
+		"chart=autonomy_duration&window=30d",
+		"chart=autonomy_duration&window=30d&include_subagents=false",
+		"chart=autonomy_duration&window=30d&include_subagents=true",
+		"chart=autonomy_spans&window=24h",
+		"chart=autonomy_spans&window=24h&include_subagents=false",
+		"chart=autonomy_spans&window=24h&include_subagents=true",
 	}
-	for _, tc := range cases {
-		t.Run(tc.query, func(t *testing.T) {
-			store := &fakeAutonomyStore{}
-			if rec := getAutonomy(t, store, tc.query); rec.Code != 200 {
+	for _, q := range queries {
+		t.Run(q, func(t *testing.T) {
+			store := &fakeAutonomyStore{
+				spans: []outbound.AutonomySpan{
+					{Start: 100, End: 200, Project: "p", Session: "child",
+						Kind: session.AutonomyKindSubagent, Parent: "top-1"},
+				},
+				kinds: outbound.AutonomySpanKinds{Subagent: 1},
+			}
+			rec := getAutonomy(t, store, q)
+			if rec.Code != 200 {
 				t.Fatalf("status = %d, want 200", rec.Code)
 			}
-			if store.lastQuery.IncludeSubagents != tc.want {
-				t.Fatalf("IncludeSubagents = %v, want %v — the store, not the client, is what filters",
-					store.lastQuery.IncludeSubagents, tc.want)
+			// The mutation this pins: reintroducing any per-request subagent
+			// filter would have to reach the store as a query field, and the
+			// query the handler builds carries none.
+			if store.lastQuery != (outbound.AutonomySpanQuery{
+				Start: store.lastQuery.Start,
+				End:   store.lastQuery.End,
+				Limit: store.lastQuery.Limit,
+			}) {
+				t.Fatalf("query = %+v — it carries something beyond the window and the limit, "+
+					"which is how a per-request filter would come back", store.lastQuery)
 			}
 		})
 	}
 }
 
-// The payload STATES the mode and the window's census, on both elements, so a
-// client can say what it counted and what it left out without recomputing
-// either from rows it does not have.
-func TestAutonomyPayloadsCarryTheModeAndTheCensus(t *testing.T) {
+// The payload STATES the window's census on both elements, so a client can say
+// how much of a window was subagent work without recomputing it from rows it
+// does not have (the duration chart carries no rows at all).
+func TestAutonomyPayloadsCarryTheCensus(t *testing.T) {
 	kinds := outbound.AutonomySpanKinds{TopLevel: 7, Subagent: 5, Unknown: 3}
 
-	t.Run("duration, default mode", func(t *testing.T) {
+	t.Run("duration", func(t *testing.T) {
 		store := &fakeAutonomyStore{kinds: kinds}
 		rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
 		var got historyAutonomyDurationResponse
 		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if got.Kinds.Mode != autonomyModeTopLevel {
-			t.Fatalf("mode = %q, want %q", got.Kinds.Mode, autonomyModeTopLevel)
-		}
 		if got.Kinds.Subagent != 5 || got.Kinds.Unknown != 3 || got.Kinds.TopLevel != 7 {
 			t.Fatalf("kinds = %+v, want the store's census verbatim", got.Kinds)
 		}
 	})
 
-	t.Run("spans, include mode", func(t *testing.T) {
+	t.Run("spans", func(t *testing.T) {
 		store := &fakeAutonomyStore{kinds: kinds}
-		rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h&include_subagents=true")
+		rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
 		var got historyAutonomySpansResponse
 		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		if got.Kinds.Mode != autonomyModeAll {
-			t.Fatalf("mode = %q, want %q", got.Kinds.Mode, autonomyModeAll)
-		}
-		// The census does NOT change with the mode: the same window holds the
-		// same runs whichever ones were asked for.
 		if got.Kinds.Subagent != 5 {
 			t.Fatalf("subagent count = %d, want 5", got.Kinds.Subagent)
 		}
@@ -99,7 +102,7 @@ func TestAutonomySpanRowsCarryAResolvedKind(t *testing.T) {
 				Kind: session.AutonomyKindTopLevel},
 		},
 	}
-	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h&include_subagents=true")
+	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
 	var got historyAutonomySpansResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)

--- a/core/cmd/irrlichd/history_autonomy_measurement_test.go
+++ b/core/cmd/irrlichd/history_autonomy_measurement_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// The measurement half of #1905's recording fix, at the API: what a run whose
+// duration is a FLOOR rather than a measurement does to the figures.
+//
+// Two kinds of floor and they are treated differently on purpose:
+//
+//   - a RUNNING run has not ended, so its length is unknowable — it is counted
+//     and drawn, and kept out of every percentile;
+//   - a LOWER-BOUND START has ended, and its length is known to within the
+//     daemon's own uptime — it is a sample, and it is marked.
+//
+// Mutation fixtures: neither had a "before the fix" to run red against, so each
+// drives the wrong answer into its own assertion.
+
+// runningSpan is a run that has not ended, `length` seconds in so far.
+func runningSpan(end, length int64, project string) outbound.AutonomySpan {
+	s := spanEndingAt(end, length, project, "")
+	s.Running = true
+	return s
+}
+
+// A RUNNING RUN IS NOT A PERCENTILE SAMPLE.
+//
+// MUTATION CAUGHT: folding it in. The fixture is built so the wrong answer is a
+// different number rather than a rounding difference — four finished 60s runs
+// and one 4-hour run still going. Counted, the p95 leaps from 60 to over 11000;
+// left out, it stays 60 and the run is reported separately as still going.
+func TestAutonomyDuration_RunningRunIsCountedButNotAveraged(t *testing.T) {
+	const end = 1_700_000_000
+	store := &fakeAutonomyStore{
+		spans: []outbound.AutonomySpan{
+			spanEndingAt(end-4000, 60, "p", session.StateReady),
+			spanEndingAt(end-3000, 60, "p", session.StateReady),
+			spanEndingAt(end-2000, 60, "p", session.StateReady),
+			spanEndingAt(end-1000, 60, "p", session.StateReady),
+			runningSpan(end-10, 4*3600, "p"),
+		},
+		measurement: outbound.AutonomySpanMeasurement{Running: 1},
+	}
+
+	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	var got historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Summary.Count != 4 {
+		t.Fatalf("summary count = %d, want 4 — a run that has not ended is a LOWER BOUND on its own "+
+			"length, and folding it into a percentile treats a floor as a measurement", got.Summary.Count)
+	}
+	if got.Summary.P95 != 60 || got.Summary.Max != 60 {
+		t.Fatalf("p95/max = %.0f/%.0f, want 60/60 — the 4h run still in progress reached the "+
+			"envelope", got.Summary.P95, got.Summary.Max)
+	}
+	// …but it is not hidden. The payload says it is there, which is what lets
+	// both clients state the gap between what is drawn and what is measured.
+	if got.Measurement.Running != 1 {
+		t.Errorf("measurement.running = %d, want 1 — a running run excluded from the percentiles "+
+			"and not reported anywhere is a run that was silently dropped", got.Measurement.Running)
+	}
+	for _, b := range got.Buckets {
+		if b.Max > 60 {
+			t.Fatalf("bucket at %d has max %.0f — the running run reached a bucket envelope", b.TS, b.Max)
+		}
+	}
+}
+
+// A LOWER-BOUND START IS A SAMPLE. It is a finished run whose start Irrlicht
+// did not see, and dropping such runs is the under-count this whole change
+// exists to end — a restart re-discovers every live session as one of these.
+//
+// MUTATION CAUGHT: treating it like a running run (excluding it) takes the
+// count from 2 back to 1 and removes the longest run in the window.
+func TestAutonomyDuration_LowerBoundStartIsStillASample(t *testing.T) {
+	const end = 1_700_000_000
+	bounded := spanEndingAt(end-100, 7200, "p", session.AutonomyReasonUnknown)
+	bounded.StartLowerBound = true
+	store := &fakeAutonomyStore{
+		spans:       []outbound.AutonomySpan{spanEndingAt(end-1000, 60, "p", session.StateReady), bounded},
+		measurement: outbound.AutonomySpanMeasurement{LowerBoundStart: 1},
+	}
+
+	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	var got historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Summary.Count != 2 {
+		t.Fatalf("summary count = %d, want 2 — a run whose start was not measured has still "+
+			"FINISHED, and dropping it is the under-count this fix is about", got.Summary.Count)
+	}
+	if got.Summary.Max != 7200 {
+		t.Errorf("max = %.0f, want 7200", got.Summary.Max)
+	}
+	if got.Measurement.LowerBoundStart != 1 {
+		t.Errorf("measurement.start_lower_bound = %d, want 1 — the panel cannot mark what the "+
+			"payload does not carry", got.Measurement.LowerBoundStart)
+	}
+}
+
+// Every span row carries both marks, so a client can tell a run in progress
+// from a finished one without recomputing anything.
+//
+// MUTATION CAUGHT: dropping either flag from the row leaves the strip drawing a
+// still-running run exactly like a completed one.
+func TestAutonomySpanRows_CarryRunningAndLowerBound(t *testing.T) {
+	const end = 1_700_000_000
+	bounded := spanEndingAt(end-500, 300, "p", session.StateReady)
+	bounded.Session = "bounded"
+	bounded.StartLowerBound = true
+	running := runningSpan(end-10, 900, "p")
+	running.Session = "running"
+
+	store := &fakeAutonomyStore{
+		spans: []outbound.AutonomySpan{
+			spanEndingAt(end-900, 60, "p", session.StateReady),
+			bounded,
+			running,
+		},
+	}
+	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
+	var got historyAutonomySpansResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Spans) != 3 {
+		t.Fatalf("got %d spans, want 3", len(got.Spans))
+	}
+	byID := map[string]historyAutonomySpanRow{}
+	for _, r := range got.Spans {
+		byID[r.Session] = r
+	}
+	if !byID["running"].Running {
+		t.Error("the in-progress row is not marked `running` on the wire")
+	}
+	if byID["running"].StartLowerBound {
+		t.Error("the in-progress row claims an unmeasured start it does not have")
+	}
+	if !byID["bounded"].StartLowerBound {
+		t.Error("the unmeasured-start row lost its mark on the wire")
+	}
+	if byID["bounded"].Running {
+		t.Error("a finished row is marked running")
+	}
+	// The two marks are omitempty, so an ordinary finished run carries neither
+	// key — a client testing for presence must not see one on every row.
+	var raw struct {
+		Spans []map[string]any `json:"spans"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	plain := raw.Spans[0]
+	if _, present := plain["running"]; present {
+		t.Errorf("an ordinary finished run carries a `running` key: %v", plain)
+	}
+	if _, present := plain["start_lower_bound"]; present {
+		t.Errorf("an ordinary finished run carries a `start_lower_bound` key: %v", plain)
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -512,6 +512,15 @@ type SessionState struct {
 	// so the row is not written until the grace has passed. Nil whenever
 	// AutonomySpanStart is nil.
 	AutonomySpanPendingEnd *int64 `json:"autonomy_span_pending_end,omitempty"`
+
+	// AutonomySpanStartLowerBound marks an open span whose start Irrlicht did
+	// not measure: the session was ALREADY working when it was discovered, so
+	// the run began at or before AutonomySpanStart (#1905 recording).
+	//
+	// It rides on the session next to the start it qualifies, rather than
+	// being recomputed at close time, because by then the only thing that
+	// remembers how the span opened is the span itself. Cleared with the span.
+	AutonomySpanStartLowerBound bool `json:"autonomy_span_start_lower_bound,omitempty"`
 }
 
 // IsStale reports whether the session's last update is older than maxAge.

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -502,6 +502,31 @@ type AutonomySpan struct {
 	// it. Empty on a subagent run whose source knew it was a child but never
 	// named the parent.
 	Parent string
+
+	// Running marks a run that HAS NOT ENDED. End is then the instant the run
+	// was last observed still going, so Duration() is how long it has lasted
+	// SO FAR — a lower bound on its own length, not a measurement of it.
+	//
+	// Recording only finished runs is how the feature lost the long ones
+	// (#1905 recording): a three-hour run that is still going contributes
+	// nothing at all, and it is exactly the run the section exists to report.
+	// So it is carried, marked, and kept OUT of every percentile — see
+	// buildAutonomyDurationResponse, where that choice is made and stated.
+	Running bool
+
+	// StartLowerBound marks a run whose START was not measured: Irrlicht began
+	// watching a session that was already working, so the run began at or
+	// BEFORE the recorded Start and Duration() is a lower bound.
+	//
+	// The alternative to carrying such runs is dropping them, and dropping
+	// them is what produced the under-count this field exists to end: a
+	// restart re-discovers every live session as "already working", so on a
+	// day with ten restarts nearly every long run is one of these.
+	//
+	// Never set on a run whose opening transition the daemon actually saw, and
+	// never set on a run recovered from the open-run journal — that start was
+	// measured by the daemon that died, which is why the journal exists.
+	StartLowerBound bool
 }
 
 // Duration is the span's length in seconds, floored at 0 so a clock that
@@ -525,16 +550,13 @@ type AutonomySpanQuery struct {
 	// instead of quietly drawing a partial window as if it were whole.
 	Limit int
 
-	// IncludeSubagents adds runs classified session.AutonomyKindSubagent to the
-	// result. FALSE IS THE DEFAULT, and the default is the point (#1905
-	// subagents): the daemon holds a parent `working` while its children run,
-	// so a subagent's span is a nested interval inside its parent's and
-	// counting both counts one stretch twice.
-	//
-	// It never excludes a run of UNKNOWN kind. Excluding those would delete
-	// most of a back-filled history on a guess; they are counted, and the
-	// result says how many there are so a client can say so on screen.
-	IncludeSubagents bool
+	// There is deliberately NO subagent filter here (#1905 recording). Every
+	// run is counted, subagent runs included, because they are recorded by
+	// Irrlicht itself and are part of what it did. The `Kind` and `Parent`
+	// fields stay on every row — a subagent run is still identifiable as one,
+	// and can still be shown against the run that contains it — but which runs
+	// a window HOLDS is no longer a question the caller gets to answer
+	// differently from one request to the next.
 }
 
 // AutonomySpanResult carries one window read plus the two facts the "no data"
@@ -561,12 +583,35 @@ type AutonomySpanResult struct {
 	// measured — the fact both clients need to mark a back-filled view.
 	Provenance AutonomySpanProvenance
 
-	// Kinds counts the window by run kind, BEFORE the subagent filter drops
-	// anything. That order is the whole point: the number a client prints is
-	// "N subagent runs excluded", which cannot be counted off a result those
-	// runs have already been removed from.
+	// Kinds counts the window by run kind. Nothing is dropped for its kind any
+	// more (#1905 recording), so these three now add up to the returned rows —
+	// they say what the window is MADE OF rather than what was left out of it.
 	Kinds AutonomySpanKinds
+
+	// Measurement says how much of this window is not a finished, fully
+	// measured run — the two facts a percentile cannot carry on its own.
+	Measurement AutonomySpanMeasurement
 }
+
+// AutonomySpanMeasurement counts the runs in one window whose duration is a
+// LOWER BOUND rather than a measurement (#1905 recording).
+//
+// Both kinds are returned, always: dropping them is what produced the
+// under-count. What they must never do is pass as measured, which is why they
+// are counted separately and said out loud by both clients.
+type AutonomySpanMeasurement struct {
+	// Running is how many of the returned runs have not ended yet.
+	Running int
+
+	// LowerBoundStart is how many of the returned runs began before Irrlicht
+	// was watching, so their recorded start is the moment it started watching
+	// and not the moment the run began.
+	LowerBoundStart int
+}
+
+// Any reports whether the window holds a run whose duration is a lower bound —
+// the single condition under which a client has something extra to say.
+func (m AutonomySpanMeasurement) Any() bool { return m.Running > 0 || m.LowerBoundStart > 0 }
 
 // AutonomySpanKinds is one window's census by run kind (#1905 subagents).
 //
@@ -577,8 +622,9 @@ type AutonomySpanKinds struct {
 	// TopLevel is runs of sessions with no parent.
 	TopLevel int
 
-	// Subagent is runs of child sessions — excluded from Spans unless the
-	// query set IncludeSubagents.
+	// Subagent is runs of child sessions. Always counted and always returned
+	// (#1905 recording) — they are runs Irrlicht recorded, and which ones a
+	// window holds is not a per-request choice.
 	Subagent int
 
 	// Unknown is runs whose kind nothing established: rows written before the
@@ -638,13 +684,43 @@ func (p AutonomySpanProvenance) LiveSince() int64 { return p.EraStarts[""] }
 // a normal user nothing while looking exactly like a chart of "you did
 // nothing". This store follows the cost log instead — written unconditionally,
 // pruned on the same schedule (#1905).
+// It also keeps the OPEN-RUN JOURNAL — the runs that have started and not
+// finished. That journal is not a convenience: it is the only thing that
+// survives the daemon process, and a run's whole life is inside one daemon's
+// process lifetime only for the short runs. A restart used to end every open
+// run silently, so the longer a run was, the likelier it was never recorded at
+// all (#1905 recording).
 type AutonomySpanStore interface {
-	// RecordSpan appends one closed span. Implementations may no-op on a span
-	// with no project or a non-positive duration.
+	// RecordSpan appends one closed span, and clears whatever open-run entry
+	// that session had. Implementations may no-op on a span with no project or
+	// a non-positive duration — but the open-run entry is cleared either way,
+	// because the run is over whether or not it was worth filing.
 	RecordSpan(span AutonomySpan) error
 
-	// SpansInWindow returns the spans that ended inside the query window,
-	// plus the log-wide earliest start and total count.
+	// RecordOpenSpan records (or refreshes) ONE run that is currently under
+	// way, keyed by its session. Called the instant a run opens, so a daemon
+	// that dies seconds later still leaves the run recoverable.
+	//
+	// span.End is the instant the run was last observed alive; it moves
+	// forward on every refresh and is where an unrecovered run is finally
+	// closed.
+	RecordOpenSpan(span AutonomySpan) error
+
+	// SyncOpenSpans replaces the whole journal with exactly these runs.
+	//
+	// The authoritative reconciliation, run on the detector's refresh ticker:
+	// it refreshes every live run's last-seen instant AND drops entries for
+	// sessions that no longer exist, in one write, so the journal cannot
+	// accumulate runs nothing will ever close.
+	SyncOpenSpans(spans []AutonomySpan) error
+
+	// OpenSpans returns every run in the journal, each with Running set and
+	// End at the instant it was last observed alive.
+	OpenSpans() ([]AutonomySpan, error)
+
+	// SpansInWindow returns the spans that ended inside the query window —
+	// plus the runs still in progress that overlap it — with the log-wide
+	// earliest start and total count.
 	SpansInWindow(q AutonomySpanQuery) (*AutonomySpanResult, error)
 
 	// Prune drops span rows older than the given number of days.

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -49,63 +49,60 @@ enum HistoryAutonomySpanWindow: String, CaseIterable, Identifiable {
     }
 }
 
-/// Which runs the section counts (#1905 subagents) — the section-wide control,
-/// unlike Range and Span, which each drive one element.
+/// There is NO run-scope control any more (#1905 recording). The section counts
+/// every run, subagent runs included, because Irrlicht recorded them — so there
+/// is nothing to pick, and no mode a reader has to remember before reading a
+/// figure. Each row still carries its `kind` and `parent`, which is what keeps
+/// a subagent's run identifiable; what went is the choice, not the
+/// classification.
+
+/// What one Autonomy payload is made of, by run kind (#1905 subagents).
 ///
-/// `topLevel` is the default because a subagent's run is a NESTED INTERVAL
-/// inside its parent's: the daemon deliberately holds a parent `working` while
-/// its children run, so counting both counts one stretch of wall clock twice
-/// and drags the headline median down with short nested runs.
-enum HistoryAutonomyRunScope: String, CaseIterable, Identifiable {
-    case topLevel = "top"
-    case all
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .topLevel: return "Top-level"
-        case .all: return "+ subagents"
-        }
-    }
-
-    /// What to send as `?include_subagents=`. Only the affirmative case sends
-    /// anything: the daemon's default is top-level runs, so the default view
-    /// asks for nothing extra and an older daemon behaves the same way rather
-    /// than silently including runs the panel says it excluded.
-    var includeSubagentsParam: String? { self == .all ? "true" : nil }
-}
-
-/// What one Autonomy payload counted, and what it left out (#1905 subagents).
-///
-/// The three counts describe the WINDOW, not the returned rows: `subagent` is
-/// how many subagent runs the window holds whether or not they were returned,
-/// which is exactly the number the panel prints as "N excluded". The mode
-/// travels with them so a panel drawn from a response that predates the last
-/// toggle still labels that response correctly.
+/// The three counts describe the window, and — nothing being dropped for its
+/// kind — the returned rows with it. They are still worth carrying: "42 runs"
+/// reads differently once you know how many of them happened inside another.
 struct HistoryAutonomyKinds: Codable, Equatable {
-    /// `"top_level"` or `"all"` — mirrors the daemon's autonomyModeName.
-    let mode: String
     let topLevel: Int
     let subagent: Int
     /// Runs whose kind nothing established: rows written before the
     /// classification existed, and rows the back-fill rebuilt from a source
-    /// carrying no parent information. ALWAYS counted in the figures, and
-    /// always named in the panel — a view that folded them silently into
-    /// either of the other two would report a number nobody could check.
+    /// carrying no parent information. Counted like the rest, and always named
+    /// in the panel — a view that folded them silently into either of the other
+    /// two would report a number nobody could check.
     let unknown: Int
 
     enum CodingKeys: String, CodingKey {
-        case mode, subagent, unknown
+        case subagent, unknown
         case topLevel = "top_level"
     }
+}
 
-    var includesSubagents: Bool { mode == "all" }
+/// How many of the runs in one payload have a duration that is a FLOOR rather
+/// than a measurement (#1905 recording).
+///
+/// Two kinds, kept apart because they are two different limits and a reader who
+/// merged them would misread the chart in opposite directions:
+///
+///   - `running` — the run has not ended, so its length is unknowable. Shown on
+///     the strip, and deliberately absent from the percentiles.
+///   - `lowerBoundStart` — the run has FINISHED, but Irrlicht met it already in
+///     progress, so its start is where the watching began. Those are samples;
+///     dropping them is what left 5 of a day's 35 runs on the record.
+struct HistoryAutonomyMeasurement: Codable, Equatable {
+    let running: Int
+    let lowerBoundStart: Int
 
-    /// What a daemon that predates the field amounts to: nothing known, so
-    /// nothing claimed. `AutonomyFormat.modeLine` returns nil for it rather
-    /// than asserting a mode this payload never stated.
-    static let unavailable = HistoryAutonomyKinds(mode: "", topLevel: 0, subagent: 0, unknown: 0)
+    enum CodingKeys: String, CodingKey {
+        case running
+        case lowerBoundStart = "start_lower_bound"
+    }
+
+    /// What a daemon that predates the field amounts to: nothing marked.
+    static let none = HistoryAutonomyMeasurement(running: 0, lowerBoundStart: 0)
+
+    /// Whether anything in view is a floor — the single condition under which
+    /// the panel has something extra to say.
+    var any: Bool { running > 0 || lowerBoundStart > 0 }
 }
 
 /// How a span ended — the state the session left `working` for. Raw values
@@ -335,14 +332,17 @@ struct HistoryAutonomyDurationResponse: Codable {
     /// rather than failing outright — `provenanceOrNone` collapses the two
     /// "say nothing" cases into one.
     let provenance: HistoryAutonomyProvenance?
-    /// What this payload counted (#1905 subagents). Optional for the same
-    /// reason as `provenance`, and absent means SAY NOTHING — never "it counted
-    /// top-level runs", which is a claim a daemon that predates the field
-    /// cannot make.
+    /// What this payload is made of, by run kind (#1905 subagents). Optional
+    /// for the same reason as `provenance`, and absent means SAY NOTHING —
+    /// which is not the same claim as "there were none".
     let kinds: HistoryAutonomyKinds?
+    /// How many of the runs in view are floors rather than measurements
+    /// (#1905 recording). Optional for the same reason; absent means nothing
+    /// was marked.
+    let measurement: HistoryAutonomyMeasurement?
 
     enum CodingKeys: String, CodingKey {
-        case window, chart, start, end, buckets, summary, provenance, kinds
+        case window, chart, start, end, buckets, summary, provenance, kinds, measurement
         case bucketSeconds = "bucket_seconds"
         case bucketStarts = "bucket_starts"
         case sampleFloor = "sample_floor"
@@ -352,7 +352,7 @@ struct HistoryAutonomyDurationResponse: Codable {
 
     var hasData: Bool { !buckets.isEmpty }
     var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
-    var kindsOrUnavailable: HistoryAutonomyKinds { kinds ?? .unavailable }
+    var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
 
     /// The source boundaries that fall inside the DRAWN domain, so the chart
     /// marks only what the reader can actually see.
@@ -487,14 +487,27 @@ struct HistoryAutonomySpanRow: Codable, Identifiable {
     let kind: String?
     /// The parent session id of a subagent run; absent otherwise.
     let parent: String?
+    /// Whether this run has NOT ended (#1905 recording): `end` is where it had
+    /// got to when the window was taken, so its length is a floor. Absent on
+    /// every finished row and on a payload that predates the field.
+    let running: Bool?
+    /// Whether Irrlicht met this run already in progress, so `start` is when it
+    /// began WATCHING rather than when the run began.
+    let startLowerBound: Bool?
 
-    /// Spelled out rather than left to the synthesized memberwise init, so
-    /// `kind` and `parent` can default — the same reason
+    enum CodingKeys: String, CodingKey {
+        case start, end, project, session, reason, kind, parent, running
+        case startLowerBound = "start_lower_bound"
+    }
+
+    /// Spelled out rather than left to the synthesized memberwise init, so the
+    /// trailing fields can default — the same reason
     /// `HistoryAutonomyProvenance` spells its own out. A call site that says
     /// nothing about the kind means exactly what a row that says nothing means:
     /// nobody established it.
     init(start: Int64, end: Int64, project: String, session: String,
-         reason: String?, kind: String? = nil, parent: String? = nil) {
+         reason: String?, kind: String? = nil, parent: String? = nil,
+         running: Bool? = nil, startLowerBound: Bool? = nil) {
         self.start = start
         self.end = end
         self.project = project
@@ -502,16 +515,27 @@ struct HistoryAutonomySpanRow: Codable, Identifiable {
         self.reason = reason
         self.kind = kind
         self.parent = parent
+        self.running = running
+        self.startLowerBound = startLowerBound
     }
+
+    /// Whether the run is still going. Absent reads as finished, which is the
+    /// only thing it can mean: a build that could not record a run in progress
+    /// never wrote one.
+    var isRunning: Bool { running == true }
+
+    /// Whether the run's start is an estimate. Absent reads as measured, for
+    /// the same reason.
+    var hasLowerBoundStart: Bool { startLowerBound == true }
 
     var id: String { "\(project)|\(session)|\(start)|\(end)" }
 
     var endReason: AutonomyEndReason? { reason.flatMap(AutonomyEndReason.init(rawValue:)) }
     var duration: Int64 { Swift.max(0, end - start) }
     /// Whether this run belonged to a subagent. FALSE for a row that never said
-    /// — which is "nothing established it", not "it was top-level"; the strip
-    /// draws such a row either way, and the panel's mode line is where the
-    /// unknown count is stated.
+    /// — which is "nothing established it", not "it was top-level". Every run
+    /// is drawn either way (#1905 recording); this is what makes a nested run
+    /// identifiable, not what excludes it.
     var isSubagentRun: Bool { kind == "sub" }
 }
 
@@ -529,16 +553,17 @@ struct HistoryAutonomySpansResponse: Codable {
     let truncated: Bool
     let provenance: HistoryAutonomyProvenance?
     let kinds: HistoryAutonomyKinds?
+    let measurement: HistoryAutonomyMeasurement?
 
     enum CodingKeys: String, CodingKey {
-        case window, chart, start, end, spans, projects, truncated, provenance, kinds
+        case window, chart, start, end, spans, projects, truncated, provenance, kinds, measurement
         case earliestSpan = "earliest_span"
         case totalRecorded = "total_recorded"
     }
 
     var hasData: Bool { !spans.isEmpty }
     var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
-    var kindsOrUnavailable: HistoryAutonomyKinds { kinds ?? .unavailable }
+    var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
 
     func spans(for project: String) -> [HistoryAutonomySpanRow] {
         spans.filter { $0.project == project }

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -241,12 +241,18 @@ struct HistoryAutonomyContentView: View {
     /// back-filled, says that too.
     private var collectionProvenance: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp1) {
-            // What these figures counted, and what the active mode left out
-            // (#1905 subagents). Above the provenance line because it qualifies
-            // every number in the section, where provenance qualifies where
-            // they came from.
-            if let mode = AutonomyFormat.modeLine(duration.kindsOrUnavailable) {
-                Text(mode)
+            // What these figures counted (#1905 subagents). Above the
+            // provenance line because it qualifies every number in the section,
+            // where provenance qualifies where they came from.
+            if let counting = AutonomyFormat.countingLine(duration.kinds) {
+                Text(counting)
+            }
+            // …and which of them are floors rather than measurements (#1905
+            // recording). Same register, same reason: a lower bound rendered as
+            // a measurement is a wrong number with nothing on screen saying it
+            // is wrong. Silent when every run in view is finished and measured.
+            if let measurement = AutonomyFormat.measurementLine(duration.measurementOrNone) {
+                Text(measurement)
             }
             Text(AutonomyFormat.provenance(earliest: duration.earliestSpan,
                                            total: duration.totalRecorded,
@@ -761,38 +767,67 @@ enum AutonomyFormat {
         return "Collecting since \(since) · \(total) runs recorded."
     }
 
-    /// States WHICH RUNS the figures counted and how many the active mode left
-    /// out (#1905 subagents). `nil` only for a payload from a daemon that
-    /// predates the field — absence there means "this response never said",
-    /// which is not the same claim as "it counted top-level runs".
+    /// States WHAT the figures counted (#1905 subagents, retargeted by #1905
+    /// recording). `nil` only for a payload from a daemon that predates the
+    /// census — absence there means "this response never said", which is not
+    /// the same claim as "there were none".
     ///
-    /// THE UNKNOWN CLAUSE IS THE LOAD-BEARING PART. A row written before
-    /// Irrlicht told the two apart carries no classification, and such a row is
-    /// COUNTED — excluding it would delete most of a back-filled history on a
-    /// guess. Counting it in silence is the failure this section exists to
-    /// prevent: the view would claim to exclude subagent runs while including
-    /// every historical one, with nothing on screen saying so. So it says how
-    /// many.
-    static func modeLine(_ k: HistoryAutonomyKinds) -> String? {
-        guard !k.mode.isEmpty else { return nil }
-        var out: String
-        if k.includesSubagents {
-            out = k.subagent > 0
-                ? "Counting every run, including \(k.subagent) subagent run\(k.subagent == 1 ? "" : "s") "
-                    + "— each of which happened inside its parent's run."
-                : "Counting every run, subagent runs included. This window holds none."
-        } else {
-            out = k.subagent > 0
-                ? "Counting top-level runs only · \(k.subagent) subagent run\(k.subagent == 1 ? "" : "s") "
-                    + "excluded, because each already happened inside its parent's run."
-                : "Counting top-level runs only. This window holds no subagent runs."
-        }
+    /// THERE IS NO MODE ANY MORE. Every run counts, subagent runs included,
+    /// because Irrlicht recorded them — so no excluded count is reported and
+    /// there is no control whose position a reader has to remember. What the
+    /// sentence still does is describe the window's MAKEUP.
+    ///
+    /// THE UNKNOWN CLAUSE STAYS LOAD-BEARING. A row written before Irrlicht
+    /// told the two apart carries no classification, and it is counted like the
+    /// rest — but counting it in silence would let the panel imply a
+    /// classification nobody made. So it says how many.
+    static func countingLine(_ k: HistoryAutonomyKinds?) -> String? {
+        guard let k else { return nil }
+        var out = k.subagent > 0
+            ? "Counting every run, including \(k.subagent) subagent run\(k.subagent == 1 ? "" : "s") "
+                + "— each of which happened inside its parent's run."
+            : "Counting every run, subagent runs included. This window holds none."
         if k.unknown > 0 {
             out += " \(k.unknown) run\(k.unknown == 1 ? " was" : "s were") recorded before Irrlicht told "
                 + "top-level and subagent runs apart, so which they were is unknown — those are counted "
                 + "either way."
         }
         return out
+    }
+
+    /// Marks the runs in view whose duration is a FLOOR rather than a
+    /// measurement (#1905 recording). `nil` when every run in view is finished
+    /// and fully measured — the quiet case on a machine whose daemon has been
+    /// up all day.
+    ///
+    /// Two kinds, two sentences, because they are two different limits and a
+    /// reader who merged them would misread the chart in opposite directions:
+    ///
+    ///   - STILL RUNNING. The run has not ended, so its length is unknowable.
+    ///     It is shown, and deliberately kept out of the percentiles — folding
+    ///     a floor into a p95 as though it were final always shortens, and
+    ///     shortens the longest runs hardest. Both halves are said, so a reader
+    ///     who can see a 3-hour run on the strip is not left wondering why the
+    ///     median did not move.
+    ///   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its
+    ///     start is where the watching began. Those ARE samples; dropping them
+    ///     is what left 5 of a day's 35 runs on the record.
+    static func measurementLine(_ m: HistoryAutonomyMeasurement) -> String? {
+        guard m.any else { return nil }
+        var parts: [String] = []
+        if m.running > 0 {
+            let one = m.running == 1
+            parts.append("\(m.running) run\(one ? " is" : "s are") still going: "
+                + "\(one ? "its length is" : "their lengths are") how long \(one ? "it has" : "they have") "
+                + "lasted SO FAR, so \(one ? "it is" : "they are") shown but left out of the percentiles.")
+        }
+        if m.lowerBoundStart > 0 {
+            let one = m.lowerBoundStart == 1
+            parts.append("\(m.lowerBoundStart) run\(one ? "" : "s") already going when Irrlicht started "
+                + "watching — \(one ? "its" : "their") start is when it started watching, not when the run "
+                + "began, so \(one ? "that length is a minimum" : "those lengths are minimums").")
+        }
+        return parts.joined(separator: " ")
     }
 
     /// Marks a view that is showing back-filled history (#1905). `nil` when

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -98,10 +98,9 @@ struct HistoryView: View {
     // stateGranularity's same-looking keys, which are bucket widths).
     @State private var autonomyRange: HistoryAutonomyRange = .days30
     @State private var autonomySpanWindow: HistoryAutonomySpanWindow = .hours24
-    // …and one SECTION-WIDE control: which runs both elements count (#1905
-    // subagents). Top-level only by default — a subagent's run happens inside
-    // its parent's, so counting both counts one stretch twice.
-    @State private var autonomyRunScope: HistoryAutonomyRunScope = .topLevel
+    // There is no section-wide run-scope state any more (#1905 recording): the
+    // section counts every run, subagent runs included, so there is nothing to
+    // hold and nothing for the query key below to vary on.
 
     // Activity is opt-in (#1075): the matrix is reconstructed from recordings,
     // and a bucket that was never recorded looks exactly like an idle one, so
@@ -129,7 +128,7 @@ struct HistoryView: View {
     /// This is the macOS equivalent of the web's manual `historyFetchSeq`
     /// dedup — `.task(id:)` cancels the in-flight request when the key changes.
     private var queryKey: String {
-        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)-\(autonomyRange.rawValue)-\(autonomySpanWindow.rawValue)-\(autonomyRunScope.rawValue)"
+        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)-\(autonomyRange.rawValue)-\(autonomySpanWindow.rawValue)"
         if range == .custom {
             return "custom-\(appliedCustomStart ?? 0)-\(appliedCustomEnd ?? 0)-\(dims)"
         }
@@ -343,16 +342,11 @@ struct HistoryView: View {
             }
             .labelsHidden()
             .fixedSize()
-            // Which runs BOTH elements count. It belongs on the section's own
-            // control row rather than in either element's header precisely
-            // because it changes both at once — the distinction Span was moved
-            // out of this row to make.
-            Text("Runs").foregroundColor(.secondary)
-            Picker("Runs", selection: $autonomyRunScope) {
-                ForEach(HistoryAutonomyRunScope.allCases) { Text($0.label).tag($0) }
-            }
-            .labelsHidden()
-            .fixedSize()
+            // There is no Runs picker (#1905 recording). The section counts
+            // every run, subagent runs included, because Irrlicht recorded
+            // them — so there is no choice to offer, and no mode a reader has
+            // to remember before reading a figure. The panel says how much of a
+            // window was subagent work.
             Spacer(minLength: 0)
         }
         .pickerStyle(.menu)
@@ -655,18 +649,14 @@ struct HistoryView: View {
     /// what an incomplete pair means, rather than each half guessing.
     private func fetchAutonomyPart<T: Decodable>(chart: String, window: String) async -> T? {
         var comps = URLComponents(string: "\(DaemonEndpoint.httpBase)/api/v1/history")
-        var items = [
+        // The chart and its window, and nothing else (#1905 recording). Every
+        // run counts, so there is nothing to ask for — and sending the retired
+        // run-scope parameter would leave an OLD daemon serving a filtered
+        // payload while this panel's sentence said it counted everything.
+        comps?.queryItems = [
             URLQueryItem(name: "chart", value: chart),
             URLQueryItem(name: "window", value: window),
         ]
-        // Sent only when it is ON: the daemon's default is top-level runs, so
-        // the default view asks for nothing extra and an older daemon behaves
-        // exactly as this one does rather than silently including subagent runs
-        // the panel says it excluded.
-        if let include = autonomyRunScope.includeSubagentsParam {
-            items.append(URLQueryItem(name: "include_subagents", value: include))
-        }
-        comps?.queryItems = items
         guard let url = comps?.url else { return nil }
         do {
             let (data, resp) = try await URLSession.shared.data(from: url)

--- a/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import Irrlicht
+
+/// The panel's marking for runs whose duration is a FLOOR rather than a
+/// measurement (#1905 recording).
+///
+/// Two kinds, and they are two different limits:
+///
+///   - STILL RUNNING — the run has not ended, so its length is unknowable.
+///     Shown on the strip, deliberately absent from the percentiles.
+///   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
+///     start is where Irrlicht began watching. Those ARE samples; dropping them
+///     is what left 5 of a day's 35 runs on the record.
+///
+/// A reader who conflated the two would misread the chart in opposite
+/// directions, which is why the sentence never merges them.
+final class HistoryAutonomyMeasurementTests: XCTestCase {
+
+    // MARK: Decoding
+
+    func testMeasurementAndRowMarksDecode() throws {
+        let json = """
+        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
+         "spans":[{"start":1,"end":9,"project":"a","session":"done","reason":"ready","kind":"top"},
+                  {"start":20,"end":100,"project":"a","session":"live","kind":"top","running":true},
+                  {"start":30,"end":60,"project":"a","session":"partial","reason":"unknown",
+                   "kind":"top","start_lower_bound":true}],
+         "projects":["a"],"earliest_span":1,"total_recorded":3,"truncated":false,
+         "measurement":{"running":1,"start_lower_bound":1}}
+        """
+        let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(s.measurementOrNone.running, 1)
+        XCTAssertEqual(s.measurementOrNone.lowerBoundStart, 1)
+
+        // A finished, fully measured row claims neither.
+        XCTAssertFalse(s.spans[0].isRunning)
+        XCTAssertFalse(s.spans[0].hasLowerBoundStart)
+        // The in-progress row is marked, and only as running.
+        XCTAssertTrue(s.spans[1].isRunning)
+        XCTAssertFalse(s.spans[1].hasLowerBoundStart)
+        // The unmeasured-start row is marked, and only as that.
+        XCTAssertTrue(s.spans[2].hasLowerBoundStart)
+        XCTAssertFalse(s.spans[2].isRunning)
+    }
+
+    /// A payload from a daemon that predates the field decodes, and reads as
+    /// "nothing marked" — the only thing absence can mean, since a build that
+    /// could not record a run in progress never wrote one.
+    func testAnAbsentMeasurementBlockReadsAsNothingMarked() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"buckets":[],
+         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
+         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33}
+        """
+        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertNil(d.measurement)
+        XCTAssertEqual(d.measurementOrNone, .none)
+        XCTAssertFalse(d.measurementOrNone.any)
+        XCTAssertNil(AutonomyFormat.measurementLine(d.measurementOrNone))
+    }
+
+    // MARK: The sentence
+
+    private func measurement(running: Int = 0, lowerBound: Int = 0) -> HistoryAutonomyMeasurement {
+        HistoryAutonomyMeasurement(running: running, lowerBoundStart: lowerBound)
+    }
+
+    /// The quiet case, and the one that must stay quiet: a machine whose daemon
+    /// has been up all day, every run in view finished and fully measured.
+    func testSaysNothingWhenEveryRunIsFinishedAndMeasured() {
+        XCTAssertNil(AutonomyFormat.measurementLine(measurement()))
+    }
+
+    /// A running run is SHOWN and left OUT of the percentiles, and the sentence
+    /// has to say both — otherwise a reader who can see a 3-hour run on the
+    /// strip is left wondering why the median did not move.
+    func testARunningRunIsNamedAsGoingAndAsAbsentFromThePercentiles() throws {
+        let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 1)))
+        XCTAssertTrue(line.contains("1 run is still going"), line)
+        XCTAssertTrue(line.contains("SO FAR"), line)
+        XCTAssertTrue(line.contains("left out of the percentiles"), line)
+    }
+
+    func testAnUnmeasuredStartSaysWhichEndIsTheEstimate() throws {
+        let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 4)))
+        XCTAssertTrue(line.contains("4 runs already going when Irrlicht started watching"), line)
+        XCTAssertTrue(line.contains("not when the run began"), line)
+        XCTAssertTrue(line.contains("minimums"), line)
+        // It must NOT claim those runs were dropped from the figures: they are
+        // finished runs, and they are samples.
+        XCTAssertFalse(line.contains("left out of the percentiles"), line)
+    }
+
+    func testBothAtOnceReadAsTwoSeparateFacts() throws {
+        let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 2, lowerBound: 3)))
+        XCTAssertTrue(line.contains("2 runs are still going"), line)
+        XCTAssertTrue(line.contains("3 runs already going when Irrlicht started watching"), line)
+    }
+
+    func testSingularAndPluralBothReadAsEnglish() throws {
+        let one = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 1)))
+        XCTAssertTrue(one.contains("1 run is still going"), one)
+        let two = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 2)))
+        XCTAssertTrue(two.contains("2 runs are still going"), two)
+        let oneBound = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 1)))
+        XCTAssertTrue(oneBound.contains("that length is a minimum"), oneBound)
+        let twoBound = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 2)))
+        XCTAssertTrue(twoBound.contains("those lengths are minimums"), twoBound)
+    }
+
+    /// COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get this
+    /// wrong, and each passes at least one assertion above on its own.
+    func testProductionTellsTheTwoLimitsApartAndBothFromSilence() {
+        let running = measurement(running: 3)
+        let bounded = measurement(lowerBound: 3)
+        let clean = measurement()
+
+        // Merged: a run still going and a run whose start was guessed read
+        // identically, so the reader cannot tell which figure to distrust.
+        let merged: (HistoryAutonomyMeasurement) -> String = {
+            "\($0.running + $0.lowerBoundStart) runs are approximate."
+        }
+        XCTAssertEqual(merged(running), merged(bounded))
+        XCTAssertNotEqual(AutonomyFormat.measurementLine(running),
+                          AutonomyFormat.measurementLine(bounded))
+
+        // Never-silent: a fully measured window carries a caveat it does not
+        // need, and the caveat stops meaning anything.
+        let always: (HistoryAutonomyMeasurement) -> String = { _ in "Some runs are approximate." }
+        XCTAssertEqual(always(clean), always(running))
+        XCTAssertNil(AutonomyFormat.measurementLine(clean))
+    }
+}

--- a/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
@@ -1,31 +1,15 @@
 import XCTest
 @testable import Irrlicht
 
-/// Which runs the Autonomy section counts (#1905 subagents).
+/// What the Autonomy section counts (#1905 subagents), retargeted at the FIELD
+/// after the control was removed (#1905 recording).
 ///
-/// The daemon holds a parent `working` while its children run, so a subagent's
-/// span is a NESTED INTERVAL inside its parent's: counting both counts one
-/// stretch of wall clock twice and drags the headline median down with short
-/// nested runs. Top-level runs only is therefore the default, and the panel has
-/// to SAY which mode produced the figures above it.
+/// The maintainer's decision: every run counts, subagent runs included, because
+/// Irrlicht recorded them. So there is no mode, no picker and no excluded
+/// count. The classification survives on every row — a subagent's run is still
+/// identifiable, and still attributable to the run that contains it — and the
+/// panel still describes a window's MAKEUP.
 final class HistoryAutonomySubagentTests: XCTestCase {
-
-    // MARK: The control
-
-    /// The default view asks for NOTHING extra. The daemon's own default is
-    /// top-level runs, so an older daemon serving a newer app behaves
-    /// identically rather than silently including runs the panel says it
-    /// excluded.
-    func testOnlyTheIncludingModeSendsAParameter() {
-        XCTAssertNil(HistoryAutonomyRunScope.topLevel.includeSubagentsParam)
-        XCTAssertEqual(HistoryAutonomyRunScope.all.includeSubagentsParam, "true")
-    }
-
-    func testBothModesAreOfferedAndTopLevelIsFirst() {
-        XCTAssertEqual(HistoryAutonomyRunScope.allCases.map(\.rawValue), ["top", "all"])
-        XCTAssertEqual(HistoryAutonomyRunScope.topLevel.label, "Top-level")
-        XCTAssertEqual(HistoryAutonomyRunScope.all.label, "+ subagents")
-    }
 
     // MARK: Decoding
 
@@ -35,13 +19,13 @@ final class HistoryAutonomySubagentTests: XCTestCase {
          "bucket_starts":[1],"buckets":[],
          "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
          "sample_floor":20,"earliest_span":1700000000,"total_recorded":33,
-         "kinds":{"mode":"top_level","top_level":20,"subagent":9,"unknown":4}}
+         "kinds":{"top_level":20,"subagent":9,"unknown":4}}
         """
         let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(durationJSON.utf8))
-        XCTAssertEqual(d.kindsOrUnavailable.topLevel, 20)
-        XCTAssertEqual(d.kindsOrUnavailable.subagent, 9)
-        XCTAssertEqual(d.kindsOrUnavailable.unknown, 4)
-        XCTAssertFalse(d.kindsOrUnavailable.includesSubagents)
+        let dk = try XCTUnwrap(d.kinds)
+        XCTAssertEqual(dk.topLevel, 20)
+        XCTAssertEqual(dk.subagent, 9)
+        XCTAssertEqual(dk.unknown, 4)
 
         let spansJSON = """
         {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
@@ -50,10 +34,11 @@ final class HistoryAutonomySubagentTests: XCTestCase {
                   {"start":20,"end":30,"project":"a","session":"boss","reason":"ready","kind":"top"},
                   {"start":40,"end":50,"project":"a","session":"old","reason":"ready","kind":"unknown"}],
          "projects":["a"],"earliest_span":1,"total_recorded":3,"truncated":false,
-         "kinds":{"mode":"all","top_level":1,"subagent":1,"unknown":1}}
+         "kinds":{"top_level":1,"subagent":1,"unknown":1}}
         """
         let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(spansJSON.utf8))
-        XCTAssertTrue(s.kindsOrUnavailable.includesSubagents)
+        // The subagent's run is RETURNED, and it says so about itself.
+        XCTAssertEqual(s.spans.count, 3)
         XCTAssertTrue(s.spans[0].isSubagentRun)
         XCTAssertEqual(s.spans[0].parent, "boss")
         XCTAssertFalse(s.spans[1].isSubagentRun)
@@ -72,64 +57,55 @@ final class HistoryAutonomySubagentTests: XCTestCase {
         """
         let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
         XCTAssertNil(s.kinds)
-        XCTAssertEqual(s.kindsOrUnavailable, .unavailable)
         XCTAssertNil(s.spans[0].kind)
         XCTAssertFalse(s.spans[0].isSubagentRun)
-        // …and the panel says nothing rather than asserting a mode this
-        // response never stated.
-        XCTAssertNil(AutonomyFormat.modeLine(s.kindsOrUnavailable))
+        // …and the panel says nothing rather than asserting a census this
+        // response never carried.
+        XCTAssertNil(AutonomyFormat.countingLine(s.kinds))
     }
 
     // MARK: The sentence
 
-    private func kinds(mode: String = "top_level",
-                       topLevel: Int = 10,
+    private func kinds(topLevel: Int = 10,
                        subagent: Int = 0,
                        unknown: Int = 0) -> HistoryAutonomyKinds {
-        HistoryAutonomyKinds(mode: mode, topLevel: topLevel, subagent: subagent, unknown: unknown)
+        HistoryAutonomyKinds(topLevel: topLevel, subagent: subagent, unknown: unknown)
     }
 
-    func testTheDefaultModeNamesItselfEvenWithNothingToExclude() throws {
-        let line = try XCTUnwrap(AutonomyFormat.modeLine(kinds()))
-        XCTAssertTrue(line.contains("top-level runs only"), line)
-        XCTAssertTrue(line.contains("no subagent runs"), line)
-    }
-
-    func testTheDefaultModeSaysHowManyItLeftOut() throws {
-        let line = try XCTUnwrap(AutonomyFormat.modeLine(kinds(subagent: 37)))
-        XCTAssertTrue(line.contains("37 subagent runs"), line)
-        XCTAssertTrue(line.contains("excluded"), line)
-    }
-
-    func testSingularAndPluralBothReadAsEnglish() throws {
-        let one = try XCTUnwrap(AutonomyFormat.modeLine(kinds(subagent: 1)))
-        XCTAssertTrue(one.contains("1 subagent run excluded"), one)
-        let two = try XCTUnwrap(AutonomyFormat.modeLine(kinds(subagent: 2)))
-        XCTAssertTrue(two.contains("2 subagent runs excluded"), two)
-    }
-
-    func testTheIncludingModeSaysWhatItAdded() throws {
-        let line = try XCTUnwrap(AutonomyFormat.modeLine(kinds(mode: "all", subagent: 37)))
+    func testAWindowWithNoSubagentRunsSaysSo() throws {
+        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds()))
         XCTAssertTrue(line.contains("Counting every run"), line)
+        XCTAssertTrue(line.contains("holds none"), line)
+    }
+
+    /// The word that has to be GONE. Nothing is excluded any more, and a
+    /// sentence still claiming so would describe a filter that no longer exists.
+    func testItSaysHowManyRunsWereSubagentsAndExcludesNothing() throws {
+        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 37)))
         XCTAssertTrue(line.contains("37 subagent runs"), line)
+        XCTAssertTrue(line.contains("inside its parent"), line)
         XCTAssertFalse(line.contains("excluded"), line)
     }
 
-    /// THE TRAP THIS SENTENCE EXISTS FOR. A row written before Irrlicht told
-    /// the two apart carries no classification. It is COUNTED — excluding it
-    /// would delete most of a back-filled history on a guess — and counting it
-    /// in SILENCE is the failure #1905 exists to prevent: the view would claim
-    /// to exclude subagent runs while including every historical one.
-    func testUnknownKindRunsAreNamedInBothModes() throws {
-        for mode in ["top_level", "all"] {
-            let line = try XCTUnwrap(AutonomyFormat.modeLine(kinds(mode: mode, subagent: 3, unknown: 8148)))
-            XCTAssertTrue(line.contains("8148 runs were recorded before Irrlicht told"), line)
-            XCTAssertTrue(line.contains("counted either way"), line)
-        }
+    func testSingularAndPluralBothReadAsEnglish() throws {
+        let one = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 1)))
+        XCTAssertTrue(one.contains("1 subagent run —"), one)
+        let two = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 2)))
+        XCTAssertTrue(two.contains("2 subagent runs —"), two)
+    }
+
+    /// THE TRAP THIS CLAUSE EXISTS FOR. A row written before Irrlicht told the
+    /// two apart carries no classification. It is counted like the rest — and
+    /// counting it in SILENCE would let the panel imply a classification nobody
+    /// made.
+    func testUnknownKindRunsAreNamed() throws {
+        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 3, unknown: 8148)))
+        XCTAssertTrue(line.contains("8148 runs were recorded before Irrlicht told"), line)
+        XCTAssertTrue(line.contains("counted either way"), line)
     }
 
     func testAWindowWithNoUnknownRunsSaysNothingAboutThem() throws {
-        let line = try XCTUnwrap(AutonomyFormat.modeLine(kinds(subagent: 3)))
+        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 3)))
         XCTAssertFalse(line.contains("unknown"), line)
     }
 
@@ -137,26 +113,22 @@ final class HistoryAutonomySubagentTests: XCTestCase {
     /// is a plausible way to get the sentence wrong and each passes at least one
     /// assertion above on its own, so production has to be shown to tell the
     /// fixtures apart rather than merely to produce a string.
-    func testProductionTellsTheModesAndTheUnknownCaseApart() throws {
-        let topOnly = kinds(subagent: 5, unknown: 9)
-        let withSubs = kinds(mode: "all", subagent: 5, unknown: 9)
+    func testProductionTellsTheCensusCasesApart() throws {
+        let withSubs = kinds(subagent: 5, unknown: 9)
+        let noSubs = kinds(subagent: 0, unknown: 9)
         let noUnknown = kinds(subagent: 5, unknown: 0)
 
-        // Mode-blind: both modes read identically, so a reader could not tell
-        // which produced the figures.
-        let modeBlind: (HistoryAutonomyKinds) -> String = { "\($0.subagent) subagent runs." }
-        XCTAssertEqual(modeBlind(topOnly), modeBlind(withSubs))
-        XCTAssertNotEqual(AutonomyFormat.modeLine(topOnly), AutonomyFormat.modeLine(withSubs))
+        // Subagent-blind: a window full of nested runs reads exactly like one
+        // with none.
+        let subBlind: (HistoryAutonomyKinds) -> String = { _ in "Counting every run." }
+        XCTAssertEqual(subBlind(withSubs), subBlind(noSubs))
+        XCTAssertNotEqual(AutonomyFormat.countingLine(withSubs), AutonomyFormat.countingLine(noSubs))
 
-        // Unknown-blind: the silent inclusion.
+        // Unknown-blind: the silent classification.
         let unknownBlind: (HistoryAutonomyKinds) -> String = {
-            "Counting top-level runs only · \($0.subagent) excluded."
+            "Counting every run, including \($0.subagent)."
         }
-        XCTAssertEqual(unknownBlind(topOnly), unknownBlind(noUnknown))
-        XCTAssertNotEqual(AutonomyFormat.modeLine(topOnly), AutonomyFormat.modeLine(noUnknown))
-
-        // Always-speaks: one sentence for every input.
-        let constant: (HistoryAutonomyKinds) -> String = { _ in "Counting runs." }
-        XCTAssertEqual(constant(topOnly), constant(withSubs))
+        XCTAssertEqual(unknownBlind(withSubs), unknownBlind(noUnknown))
+        XCTAssertNotEqual(AutonomyFormat.countingLine(withSubs), AutonomyFormat.countingLine(noUnknown))
     }
 }

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -91,12 +91,10 @@ const historyState = {
   // autonomyData holds BOTH responses, since the section renders both at once.
   autonomyRange: '30d',
   autonomySpan: '24h',
-  // Which runs the section counts (#1905 subagents). 'top' — top-level runs
-  // only — is the default because a subagent's run is a NESTED INTERVAL inside
-  // its parent's: the daemon deliberately holds a parent `working` while its
-  // children run, so counting both counts one stretch of wall clock twice and
-  // pulls the headline median down with short nested runs.
-  autonomyRuns: 'top',
+  // There is no run-scope key here any more (#1905 recording): the section
+  // counts every run, subagent runs included, because Irrlicht recorded them.
+  // Each row still carries its `kind` and `parent`, so a subagent's run stays
+  // identifiable — what went is the choice, not the classification.
   autonomyData: null,
   filters: { provider: [], token_type: [], project: [] },
   known: { provider: [], project: [] },
@@ -290,11 +288,11 @@ export function autonomyQuery(element, state = historyState) {
     p.set('chart', 'autonomy_duration');
     p.set('window', state.autonomyRange);
   }
-  // Sent on BOTH elements, and only when it is on: the daemon's default is
-  // top-level runs, so the default view sends nothing extra and an older
-  // daemon serving a newer dashboard behaves exactly as this one does rather
-  // than silently including subagent runs the panel says it excluded.
-  if (state.autonomyRuns === 'all') p.set('include_subagents', 'true');
+  // No run-scope parameter (#1905 recording). Every run counts, so there is
+  // nothing to ask for — and sending the retired one would leave an OLD daemon
+  // serving a filtered payload while this panel's sentence said otherwise,
+  // which is the exact "wrong number, nothing on screen saying so" the section
+  // is built to avoid.
   return p.toString();
 }
 
@@ -839,41 +837,73 @@ export function autonomyReconstructionNote(duration) {
   return parts.join(' ');
 }
 
-// autonomyModeLine states, in words, WHICH RUNS the figures above it counted
-// and how many the active mode left out (#1905 subagents).
+// autonomyCountingLine states, in words, WHAT the figures above it counted
+// (#1905 subagents, retargeted by #1905 recording).
 //
-// It is never blank, and that is the rule: the number "42 runs" means two
-// different things under the two modes, and a reader cannot tell which by
-// looking. The mode ships in the payload rather than being read off local
-// state, so a panel drawn from a response that predates the last toggle still
-// labels that response correctly.
+// THERE IS NO MODE ANY MORE. Every run counts, subagent runs included, because
+// Irrlicht recorded them — so the sentence no longer reports an excluded count,
+// and there is no control whose position a reader has to remember. What it
+// still does is describe the window's MAKEUP, because "42 runs" reads
+// differently once you know how many of them were nested inside another.
 //
-// THE UNKNOWN CLAUSE IS THE LOAD-BEARING PART. A row written before Irrlicht
-// told the two apart carries no classification, and such a row is COUNTED here
-// — excluding it would delete most of a back-filled history on a guess. But
-// counting it silently is the exact failure this section exists to prevent: the
-// view would claim to exclude subagent runs while including every historical
-// one, with nothing on screen saying so. So the sentence says how many.
-export function autonomyModeLine(payload) {
+// THE UNKNOWN CLAUSE STAYS LOAD-BEARING. A row written before Irrlicht told the
+// two apart carries no classification, and such a row is counted like the rest
+// — but counting it silently would let the panel imply a classification nobody
+// made. So the sentence says how many.
+//
+// '' only for a payload that carries no census at all, which is a daemon older
+// than the field: absence there means "this response never said", which is not
+// the same claim as "there were none".
+export function autonomyCountingLine(payload) {
   const k = payload?.kinds;
   if (!k) return '';
   const sub = Number(k.subagent) || 0;
   const unknown = Number(k.unknown) || 0;
-  const parts = [];
-  if (k.mode === 'all') {
-    parts.push(sub > 0
-      ? 'Counting every run, including ' + sub + ' subagent run' + (sub === 1 ? '' : 's')
-        + ' — each of which happened inside its parent’s run.'
-      : 'Counting every run, subagent runs included. This window holds none.');
-  } else {
-    parts.push(sub > 0
-      ? 'Counting top-level runs only · ' + sub + ' subagent run' + (sub === 1 ? '' : 's')
-        + ' excluded, because each already happened inside its parent’s run.'
-      : 'Counting top-level runs only. This window holds no subagent runs.');
-  }
+  const parts = [sub > 0
+    ? 'Counting every run, including ' + sub + ' subagent run' + (sub === 1 ? '' : 's')
+      + ' — each of which happened inside its parent’s run.'
+    : 'Counting every run, subagent runs included. This window holds none.'];
   if (unknown > 0) {
     parts.push(unknown + ' run' + (unknown === 1 ? ' was' : 's were') + ' recorded before Irrlicht told '
       + 'top-level and subagent runs apart, so which they were is unknown — those are counted either way.');
+  }
+  return parts.join(' ');
+}
+
+// autonomyMeasurementNote marks the runs in view whose duration is a FLOOR
+// rather than a measurement (#1905 recording). '' when every run in view is
+// finished and fully measured, which is the quiet case on a machine whose
+// daemon has been up all day.
+//
+// Two kinds, two sentences, because they are two different limits and a reader
+// who conflated them would misread the chart in opposite directions:
+//
+//   - STILL RUNNING. The run has not ended, so its length is unknowable — it is
+//     shown, and deliberately left out of the percentiles, because folding a
+//     floor into a p95 as though it were final always shortens, and shortens
+//     the longest runs hardest. The sentence says both halves, so a reader who
+//     can see a 3-hour run on the strip is not left wondering why the median
+//     did not move.
+//   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its start
+//     is where Irrlicht began watching rather than where the run began — a
+//     restart re-discovers every live session this way. Those ARE samples;
+//     dropping them is what left 5 of a day's 35 runs on the record.
+export function autonomyMeasurementNote(payload) {
+  const m = payload?.measurement || {};
+  const running = Number(m.running) || 0;
+  const lowerBound = Number(m.start_lower_bound) || 0;
+  const parts = [];
+  if (running > 0) {
+    parts.push(running + ' run' + (running === 1 ? ' is' : 's are') + ' still going: '
+      + (running === 1 ? 'its length is' : 'their lengths are') + ' how long '
+      + (running === 1 ? 'it has' : 'they have') + ' lasted SO FAR, so '
+      + (running === 1 ? 'it is' : 'they are') + ' shown but left out of the percentiles.');
+  }
+  if (lowerBound > 0) {
+    parts.push(lowerBound + ' run' + (lowerBound === 1 ? '' : 's') + ' already going when Irrlicht '
+      + 'started watching — ' + (lowerBound === 1 ? 'its' : 'their') + ' start is when it started '
+      + 'watching, not when the run began, so ' + (lowerBound === 1 ? 'that length is a' : 'those lengths are')
+      + ' minimum' + (lowerBound === 1 ? '' : 's') + '.');
   }
   return parts.join(' ');
 }
@@ -1693,11 +1723,17 @@ function renderAutonomyPanel() {
         + 'that bucket’s longest run and p5 its shortest — not percentiles.');
     }
   }
-  // What these figures counted, and what the active mode left out (#1905
-  // subagents). Above the provenance line because it qualifies every number in
-  // the panel, where provenance qualifies where they came from.
-  const modeLine = autonomyModeLine(duration);
-  if (modeLine) appendHistoryEmpty(listEl, modeLine);
+  // What these figures counted (#1905 subagents). Above the provenance line
+  // because it qualifies every number in the panel, where provenance qualifies
+  // where they came from.
+  const countingLine = autonomyCountingLine(duration);
+  if (countingLine) appendHistoryEmpty(listEl, countingLine);
+  // …and which of them are floors rather than measurements (#1905 recording).
+  // Same register, and the same reason: a lower bound rendered as a measurement
+  // is a wrong number with nothing on screen saying it is wrong. Silent when
+  // every run in view is finished and fully measured.
+  const measurement = autonomyMeasurementNote(duration);
+  if (measurement) appendHistoryEmpty(listEl, measurement);
   // The provenance line is part of the feature: "no data" must never read as
   // "you did nothing".
   appendHistoryEmpty(listEl, autonomyProvenanceLine(duration));
@@ -2574,7 +2610,6 @@ export function initHistoryTab() {
   };
   wireAutonomyPicker('history-autonomy-range-sel', 'autonomy-range', 'autonomyRange', 'autonomyRange');
   wireAutonomyPicker('history-autonomy-span-sel', 'autonomy-span', 'autonomySpan', 'autonomySpan');
-  wireAutonomyPicker('history-autonomy-runs-sel', 'autonomy-runs', 'autonomyRuns', 'autonomyRuns');
 
   const histDoraProjectSel = document.getElementById('history-dora-project');
   if (histDoraProjectSel) histDoraProjectSel.addEventListener('change', () => {

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -291,23 +291,12 @@
             <button type="button" data-autonomy-range="30d" class="active">30 days</button>
             <button type="button" data-autonomy-range="1y">Year</button>
           </fieldset>
-          <!-- Which runs the section counts (#1905 subagents). Section-wide, so
-               it sits on the section's own control row rather than in either
-               element's header: it changes the chart AND the strip at once,
-               unlike Range and Span, which each drive one element.
-
-               Default is top-level only. A subagent's run happens INSIDE its
-               parent's — the daemon holds a parent `working` while its children
-               run — so counting both counts one stretch twice and drags the
-               median down with short nested runs. The panel states which mode
-               is active and how many runs it left out. -->
-          <span class="history-ctl-label">Runs</span>
-          <fieldset class="history-seg" id="history-autonomy-runs-sel" aria-label="Which runs the Autonomy figures count">
-            <button type="button" data-autonomy-runs="top" class="active"
-                    title="Count only runs of sessions that report to you">Top-level</button>
-            <button type="button" data-autonomy-runs="all"
-                    title="Also count subagent runs, which happen inside their parent's run">+ subagents</button>
-          </fieldset>
+          <!-- There is no Runs control (#1905 recording). The section counts
+               every run, subagent runs included, because Irrlicht recorded
+               them — so there is no choice to offer, and no mode a reader has
+               to remember before reading a figure. Each row still carries its
+               kind and parent, and the panel says how much of a window was
+               subagent work. -->
         </div>
         <div class="history-ctl-row" id="history-granularity-row" hidden>
           <span class="history-ctl-label">Granularity</span>

--- a/platforms/web/irrlicht.history.autonomy.measurement.test.js
+++ b/platforms/web/irrlicht.history.autonomy.measurement.test.js
@@ -1,0 +1,84 @@
+import { describe, test, expect } from 'vitest'
+
+import { autonomyMeasurementNote } from './historyTab.js'
+
+// The panel's marking for runs whose duration is a FLOOR rather than a
+// measurement (#1905 recording).
+//
+// Two kinds, and they are two different limits:
+//
+//   - STILL RUNNING — the run has not ended, so its length is unknowable. Shown
+//     on the strip, deliberately absent from the percentiles.
+//   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
+//     start is where Irrlicht began watching. Those ARE samples; dropping them
+//     is what left 5 of a day's 35 runs on the record.
+//
+// A reader who conflated the two would misread the chart in opposite
+// directions, which is why the sentence never merges them.
+
+const payload = (measurement) => ({ measurement })
+
+describe('autonomyMeasurementNote', () => {
+  // The quiet case, and the one that must stay quiet: a machine whose daemon
+  // has been up all day, with every run in view finished and fully measured.
+  test('says nothing when every run in view is finished and measured', () => {
+    expect(autonomyMeasurementNote(payload({ running: 0, start_lower_bound: 0 }))).toBe('')
+    expect(autonomyMeasurementNote({})).toBe('')
+    expect(autonomyMeasurementNote(null)).toBe('')
+    expect(autonomyMeasurementNote(undefined)).toBe('')
+  })
+
+  // A running run is SHOWN and left OUT of the percentiles, and the sentence
+  // has to say both — otherwise a reader who can see a 3-hour run on the strip
+  // is left wondering why the median did not move.
+  test('a running run is named as still going AND as absent from the percentiles', () => {
+    const line = autonomyMeasurementNote(payload({ running: 1 }))
+    expect(line).toContain('1 run is still going')
+    expect(line).toContain('SO FAR')
+    expect(line).toContain('left out of the percentiles')
+  })
+
+  test('an unmeasured start says which end of the run is the estimate', () => {
+    const line = autonomyMeasurementNote(payload({ start_lower_bound: 4 }))
+    expect(line).toContain('4 runs already going when Irrlicht started watching')
+    expect(line).toContain('not when the run began')
+    expect(line).toContain('minimums')
+    // It must NOT claim those runs were dropped from the figures: they are
+    // finished runs and they are samples.
+    expect(line).not.toContain('left out of the percentiles')
+  })
+
+  test('both at once read as two separate facts', () => {
+    const line = autonomyMeasurementNote(payload({ running: 2, start_lower_bound: 3 }))
+    expect(line).toContain('2 runs are still going')
+    expect(line).toContain('3 runs already going when Irrlicht started watching')
+  })
+
+  test('singular and plural both read as English', () => {
+    expect(autonomyMeasurementNote(payload({ running: 1 }))).toContain('1 run is still going')
+    expect(autonomyMeasurementNote(payload({ running: 2 }))).toContain('2 runs are still going')
+    expect(autonomyMeasurementNote(payload({ start_lower_bound: 1 }))).toContain('that length is a minimum')
+    expect(autonomyMeasurementNote(payload({ start_lower_bound: 2 }))).toContain('those lengths are minimums')
+  })
+
+  // COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get this wrong,
+  // and each passes at least one assertion above on its own.
+  test('production tells the two limits apart, and both from silence', () => {
+    const running = payload({ running: 3 })
+    const bounded = payload({ start_lower_bound: 3 })
+    const clean = payload({ running: 0, start_lower_bound: 0 })
+
+    // A mutant that merges the two into one count: a run still going and a run
+    // whose start was guessed read identically, so the reader cannot tell which
+    // figure to distrust.
+    const merged = (p) => `${(p.measurement.running || 0) + (p.measurement.start_lower_bound || 0)} runs are approximate.`
+    expect(merged(running)).toBe(merged(bounded))
+    expect(autonomyMeasurementNote(running)).not.toBe(autonomyMeasurementNote(bounded))
+
+    // A mutant that never falls silent: a fully measured window carries a
+    // caveat it does not need, and the caveat stops meaning anything.
+    const always = () => 'Some runs are approximate.'
+    expect(always(clean)).toBe(always(running))
+    expect(autonomyMeasurementNote(clean)).toBe('')
+  })
+})

--- a/platforms/web/irrlicht.history.autonomy.subagents.test.js
+++ b/platforms/web/irrlicht.history.autonomy.subagents.test.js
@@ -3,152 +3,138 @@ import { join } from 'node:path'
 import { describe, test, expect } from 'vitest'
 
 import { WEB_DIR } from './shippedFiles.testutil.js'
-import { autonomyModeLine, autonomyQuery } from './historyTab.js'
+import { autonomyCountingLine, autonomyQuery } from './historyTab.js'
 
-// Which runs the Autonomy section counts (#1905 subagents).
+// What the Autonomy section counts (#1905 subagents), retargeted at the FIELD
+// after the control was removed (#1905 recording).
 //
-// The daemon holds a parent `working` while its children run, so a subagent's
-// span is a NESTED INTERVAL inside its parent's. Counting both counts one
-// stretch of wall clock twice and — because subagent runs are short and
-// numerous — drags the headline median down. Top-level runs only is therefore
-// the default, and the panel has to SAY which mode produced the numbers above
-// it, because "42 runs" means two different things under the two modes.
+// The maintainer's decision: every run counts, subagent runs included, because
+// Irrlicht recorded them. So there is no mode, no control, and no excluded
+// count. The classification survives on every row, and the panel still
+// describes a window's MAKEUP — "42 runs" reads differently once you know how
+// many of them were nested inside another.
 
 const state = (over = {}) => ({
   autonomyRange: '30d',
   autonomySpan: '24h',
-  autonomyRuns: 'top',
   ...over,
 })
 
-const kinds = (over = {}) => ({ mode: 'top_level', top_level: 10, subagent: 0, unknown: 0, ...over })
+const kinds = (over = {}) => ({ top_level: 10, subagent: 0, unknown: 0, ...over })
 
-describe('autonomyQuery — the mode reaches the daemon', () => {
-  // The daemon's own default is top-level runs, so the default view sends
-  // NOTHING extra. That is what makes an older daemon serving a newer dashboard
-  // behave identically instead of silently including runs the panel says it
-  // excluded.
-  test('the default mode adds no parameter at all', () => {
+describe('autonomyQuery — no run-scope parameter reaches the daemon', () => {
+  // Sending the old parameter would leave an OLD daemon serving a filtered
+  // payload while this panel's sentence said it counted everything — the exact
+  // "wrong number with nothing on screen saying so" the section exists to
+  // avoid. So the query is exactly the chart and its window, and nothing else.
+  test('the query is the chart and its window, and nothing else', () => {
     expect(autonomyQuery('duration', state())).toBe('chart=autonomy_duration&window=30d')
     expect(autonomyQuery('spans', state())).toBe('chart=autonomy_spans&window=24h')
   })
 
-  test('including subagents is sent on BOTH elements', () => {
+  test('no leftover state key can revive the parameter', () => {
+    // The mutation this catches: a stale `autonomyRuns` left in local state (a
+    // stored preference, a resumed session) silently re-filtering the view.
     const s = state({ autonomyRuns: 'all' })
-    expect(autonomyQuery('duration', s)).toContain('include_subagents=true')
-    expect(autonomyQuery('spans', s)).toContain('include_subagents=true')
-    // …and neither element loses its own window doing it: the two vocabularies
-    // are different sets and neither endpoint accepts the other's keys.
+    expect(autonomyQuery('duration', s)).not.toContain('include_subagents')
+    expect(autonomyQuery('spans', s)).not.toContain('include_subagents')
+    // …and neither element loses its own window: the two vocabularies are
+    // different sets and neither endpoint accepts the other's keys.
     expect(autonomyQuery('duration', s)).toContain('window=30d')
     expect(autonomyQuery('spans', s)).toContain('window=24h')
   })
 })
 
-// The control has to exist in the markup AND be read by the wiring. Those are
-// two files, and a rename in either one produces a control that looks right and
-// does nothing — which is indistinguishable, on screen, from a window that
-// genuinely holds no subagent runs.
-describe('the control and the wiring name the same thing', () => {
+// The control is GONE from both files. Two files, and a leftover in either one
+// is its own failure: markup without wiring is a control that does nothing,
+// wiring without markup is a listener attached to a state key no request reads.
+describe('the Runs control is gone from the markup and the wiring', () => {
   const html = readFileSync(join(WEB_DIR, 'index.html'), 'utf8')
   const js = readFileSync(join(WEB_DIR, 'historyTab.js'), 'utf8')
 
-  test('the markup was actually read', () => {
+  test('the files were actually read', () => {
     // A file that failed to load would make every assertion below vacuous —
     // absence of a finding and inability to look must not read the same.
     expect(html.length).toBeGreaterThan(1000)
     expect(js.length).toBeGreaterThan(1000)
+    // A positive control: the row the Runs picker used to sit in is still
+    // there, so "not found" below means removed rather than mis-pathed.
     expect(html).toContain('history-autonomy-range-row')
+    expect(js).toContain("wireAutonomyPicker('history-autonomy-range-sel'")
   })
 
-  test('both modes are offered, with top-level pre-selected', () => {
-    expect(html).toContain('id="history-autonomy-runs-sel"')
-    expect(html).toContain('data-autonomy-runs="top"')
-    expect(html).toContain('data-autonomy-runs="all"')
-    // The default has to be the pre-selected button too, or the panel would
-    // say "top-level only" beside a control showing the other choice.
-    expect(html).toMatch(/data-autonomy-runs="top"[^>]*class="active"/)
-  })
-
-  test('the wiring reads that exact attribute into that exact state key', () => {
-    expect(js).toContain("wireAutonomyPicker('history-autonomy-runs-sel', 'autonomy-runs', 'autonomyRuns', 'autonomyRuns')")
+  test('no Runs fieldset, buttons or wiring survive', () => {
+    expect(html).not.toContain('history-autonomy-runs-sel')
+    expect(html).not.toContain('data-autonomy-runs')
+    expect(js).not.toContain('history-autonomy-runs-sel')
+    expect(js).not.toContain('autonomyRuns')
+    expect(js).not.toContain('include_subagents')
   })
 })
 
-describe('autonomyModeLine — the panel states what it counted', () => {
-  test('says nothing when the payload never stated a mode', () => {
-    // An older daemon. Absence is not "it counted top-level runs" — that is a
-    // claim this payload cannot make.
-    expect(autonomyModeLine({})).toBe('')
-    expect(autonomyModeLine(null)).toBe('')
-    expect(autonomyModeLine(undefined)).toBe('')
+describe('autonomyCountingLine — the panel states what it counted', () => {
+  test('says nothing when the payload carries no census', () => {
+    // An older daemon. Absence is "this response never said", which is not the
+    // same claim as "there were none".
+    expect(autonomyCountingLine({})).toBe('')
+    expect(autonomyCountingLine(null)).toBe('')
+    expect(autonomyCountingLine(undefined)).toBe('')
   })
 
-  test('the default mode names itself even when nothing was excluded', () => {
-    const line = autonomyModeLine({ kinds: kinds() })
-    expect(line).toContain('top-level runs only')
-    expect(line).toContain('no subagent runs')
-  })
-
-  test('the default mode says HOW MANY runs it left out', () => {
-    const line = autonomyModeLine({ kinds: kinds({ subagent: 37 }) })
-    expect(line).toContain('37 subagent runs')
-    expect(line).toContain('excluded')
-  })
-
-  test('singular and plural both read as English', () => {
-    expect(autonomyModeLine({ kinds: kinds({ subagent: 1 }) })).toContain('1 subagent run excluded')
-    expect(autonomyModeLine({ kinds: kinds({ subagent: 2 }) })).toContain('2 subagent runs excluded')
-  })
-
-  test('the including mode says what it added', () => {
-    const line = autonomyModeLine({ kinds: kinds({ mode: 'all', subagent: 37 }) })
+  test('a window with no subagent runs says so', () => {
+    const line = autonomyCountingLine({ kinds: kinds() })
     expect(line).toContain('Counting every run')
+    expect(line).toContain('holds none')
+  })
+
+  test('it says how many of the runs were subagents', () => {
+    const line = autonomyCountingLine({ kinds: kinds({ subagent: 37 }) })
     expect(line).toContain('37 subagent runs')
+    expect(line).toContain('inside its parent')
+    // The word that has to be gone: nothing is excluded any more, and a
+    // sentence still claiming so would describe a filter that no longer exists.
     expect(line).not.toContain('excluded')
   })
 
-  // THE TRAP THIS SENTENCE EXISTS FOR. A row written before Irrlicht told the
-  // two apart carries no classification. It is COUNTED — excluding it would
-  // delete most of a back-filled history on a guess — and counting it in
-  // SILENCE is the failure #1905 exists to prevent: the view would claim to
-  // exclude subagent runs while including every historical one.
-  test('unknown-kind runs are named, in both modes', () => {
-    for (const mode of ['top_level', 'all']) {
-      const line = autonomyModeLine({ kinds: kinds({ mode, subagent: 3, unknown: 8148 }) })
-      expect(line).toContain('8148 runs were recorded before Irrlicht told')
-      expect(line).toContain('counted either way')
-    }
+  test('singular and plural both read as English', () => {
+    expect(autonomyCountingLine({ kinds: kinds({ subagent: 1 }) })).toContain('1 subagent run —')
+    expect(autonomyCountingLine({ kinds: kinds({ subagent: 2 }) })).toContain('2 subagent runs —')
+  })
+
+  // THE TRAP THIS CLAUSE EXISTS FOR. A row written before Irrlicht told the two
+  // apart carries no classification. It is counted like the rest — and counting
+  // it in SILENCE would let the panel imply a classification nobody made.
+  test('unknown-kind runs are named', () => {
+    const line = autonomyCountingLine({ kinds: kinds({ subagent: 3, unknown: 8148 }) })
+    expect(line).toContain('8148 runs were recorded before Irrlicht told')
+    expect(line).toContain('counted either way')
   })
 
   test('a window with no unknown runs says nothing about them', () => {
-    expect(autonomyModeLine({ kinds: kinds({ subagent: 3 }) })).not.toContain('unknown')
+    expect(autonomyCountingLine({ kinds: kinds({ subagent: 3 }) })).not.toContain('unknown')
   })
 
   test('one unknown run reads as singular', () => {
-    expect(autonomyModeLine({ kinds: kinds({ unknown: 1 }) })).toContain('1 run was recorded before')
+    expect(autonomyCountingLine({ kinds: kinds({ unknown: 1 }) })).toContain('1 run was recorded before')
   })
 
-  // COMMITTED IN-LANGUAGE MUTANTS. Each of these is a plausible way to get the
-  // sentence wrong, and each passes at least one of the assertions above on its
-  // own — so the suite has to be shown to tell them apart from production.
-  test('production tells the modes and the unknown case apart', () => {
-    const topOnly = { kinds: kinds({ subagent: 5, unknown: 9 }) }
-    const withSubs = { kinds: kinds({ mode: 'all', subagent: 5, unknown: 9 }) }
+  // COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get the sentence
+  // wrong and each passes at least one assertion above on its own, so the suite
+  // has to be shown to tell them apart from production.
+  test('production tells the census cases apart', () => {
+    const withSubs = { kinds: kinds({ subagent: 5, unknown: 9 }) }
+    const noSubs = { kinds: kinds({ subagent: 0, unknown: 9 }) }
     const noUnknown = { kinds: kinds({ subagent: 5, unknown: 0 }) }
 
-    // A mutant that ignores the mode: both modes read identically, so a reader
-    // could not tell which produced the figures.
-    const modeBlind = (p) => `${p.kinds.subagent} subagent runs.`
-    expect(modeBlind(topOnly)).toBe(modeBlind(withSubs))
-    expect(autonomyModeLine(topOnly)).not.toBe(autonomyModeLine(withSubs))
+    // A mutant blind to the subagent count: a window full of nested runs reads
+    // exactly like one with none.
+    const subBlind = () => 'Counting every run.'
+    expect(subBlind(withSubs)).toBe(subBlind(noSubs))
+    expect(autonomyCountingLine(withSubs)).not.toBe(autonomyCountingLine(noSubs))
 
-    // A mutant that drops the unknown clause: the silent inclusion.
-    const unknownBlind = (p) => `Counting top-level runs only · ${p.kinds.subagent} excluded.`
-    expect(unknownBlind(topOnly)).toBe(unknownBlind(noUnknown))
-    expect(autonomyModeLine(topOnly)).not.toBe(autonomyModeLine(noUnknown))
-
-    // A mutant that always speaks the same sentence.
-    const constant = () => 'Counting runs.'
-    expect(constant(topOnly)).toBe(constant(withSubs))
+    // A mutant that drops the unknown clause: the silent classification.
+    const unknownBlind = (p) => `Counting every run, including ${p.kinds.subagent}.`
+    expect(unknownBlind(withSubs)).toBe(unknownBlind(noUnknown))
+    expect(autonomyCountingLine(withSubs)).not.toBe(autonomyCountingLine(noUnknown))
   })
 })

--- a/tools/autonomy-backfill/kinds_test.go
+++ b/tools/autonomy-backfill/kinds_test.go
@@ -80,7 +80,7 @@ func readBackfilled(t *testing.T, dir string) map[string]outbound.AutonomySpan {
 	t.Helper()
 	tracker := filesystem.NewAutonomySpanTrackerWithDir(filepath.Join(dir, autonomyDirName))
 	res, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{
-		Start: 0, End: math.MaxInt64, IncludeSubagents: true,
+		Start: 0, End: math.MaxInt64,
 	})
 	if err != nil {
 		t.Fatalf("SpansInWindow: %v", err)
@@ -132,10 +132,16 @@ func TestBackfillClassifiesEachReconstructedRun(t *testing.T) {
 	}
 }
 
-// THE DEFAULT VIEW, over the rows the back-fill actually wrote. Reading the log
-// back the way the daemon serves it must leave the subagent's run out and still
-// report that it was left out.
-func TestBackfilledSubagentRunIsExcludedFromTheDefaultView(t *testing.T) {
+// THE SERVED VIEW, over the rows the back-fill actually wrote. Retargeted at
+// the FIELD (#1905 recording): reading the log back the way the daemon serves
+// it returns the reconstructed subagent's run like any other, CARRYING its
+// classification and its parent, and the census names it.
+//
+// What the back-fill has to get right is unchanged — it is the only producer
+// that can genuinely fail to classify a run, because the cost log carries no
+// parentage at all. What changed is that its verdict is no longer a reason to
+// drop a row.
+func TestBackfilledSubagentRunIsServedWithItsClassification(t *testing.T) {
 	dir := writeSubagentFixtureDataDir(t)
 	runBackfill(t, options{dataDir: dir, gapSeconds: costGapSeconds, apply: true})
 
@@ -144,13 +150,21 @@ func TestBackfilledSubagentRunIsExcludedFromTheDefaultView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SpansInWindow: %v", err)
 	}
-	for _, s := range res.Spans {
-		if s.Session == "kid" {
-			t.Fatalf("the default view returned the subagent's run: %+v", s)
+	var kid *outbound.AutonomySpan
+	for i := range res.Spans {
+		if res.Spans[i].Session == "kid" {
+			kid = &res.Spans[i]
 		}
 	}
+	if kid == nil {
+		t.Fatalf("the subagent's reconstructed run is missing: %+v", res.Spans)
+	}
+	if kid.Kind != session.AutonomyKindSubagent || kid.Parent != "boss" {
+		t.Fatalf("the subagent's run lost its classification on the way back: kind=%q parent=%q",
+			kid.Kind, kid.Parent)
+	}
 	if res.Kinds.Subagent != 1 {
-		t.Fatalf("Kinds.Subagent = %d, want 1 — an exclusion nothing counts cannot be stated on screen",
+		t.Fatalf("Kinds.Subagent = %d, want 1 — a kind nothing counts cannot be stated on screen",
 			res.Kinds.Subagent)
 	}
 	if res.Kinds.Unknown < 1 {
@@ -175,7 +189,7 @@ func TestBackfillReplaceReclassifiesInsteadOfDoubling(t *testing.T) {
 	}
 
 	runBackfill(t, options{dataDir: dir, gapSeconds: costGapSeconds, apply: true})
-	first, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: math.MaxInt64, IncludeSubagents: true})
+	first, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: math.MaxInt64})
 	if err != nil {
 		t.Fatalf("SpansInWindow: %v", err)
 	}
@@ -187,7 +201,7 @@ func TestBackfillReplaceReclassifiesInsteadOfDoubling(t *testing.T) {
 	}
 
 	runBackfill(t, options{dataDir: dir, gapSeconds: costGapSeconds, apply: true, replace: true})
-	second, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: math.MaxInt64, IncludeSubagents: true})
+	second, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: math.MaxInt64})
 	if err != nil {
 		t.Fatalf("SpansInWindow: %v", err)
 	}

--- a/tools/lib/autonomy-backfill-mutations_test.sh
+++ b/tools/lib/autonomy-backfill-mutations_test.sh
@@ -223,17 +223,17 @@ assert_go_test_goes_red \
 # whole third state exists for:
 #
 #   7. ABSENCE READS AS TOP-LEVEL. There are 10k rows on the maintainer's disk
-#      written before a run carried a kind. If a blank resolved to "top", the
-#      default view would claim to exclude subagent runs while including every
-#      historical one, and nothing on screen would say so.
+#      written before a run carried a kind. A blank resolving to "top" is a
+#      claim about a row nothing classified, made on the writer's behalf.
 #
-#   8. THE DEFAULT VIEW STOPS EXCLUDING. Subagent runs rejoin the headline, and
-#      every nested stretch is counted twice — the double-count this section is
-#      about, in its live form rather than the back-fill's.
+#   8. A SUBAGENT FILTER COMES BACK. Retargeted (#1905 recording): the
+#      maintainer's decision is that every run counts, subagent runs included,
+#      because Irrlicht recorded them. Reinstating a filter silently drops the
+#      nested runs from every window again.
 #
-#   9. THE EXCLUSION STOPS BEING COUNTED. The runs are left out but the census
-#      does not say how many, so the panel's sentence has no number and a
-#      silently smaller figure is indistinguishable from a quieter week.
+#   9. THE CENSUS STOPS COUNTING A KIND. The three counts are what a client
+#      says out loud about a window's makeup, so a kind that stops being
+#      counted is a kind nobody can see was there.
 #
 #  10. THE LIVE PATH STOPS STAMPING THE KIND. Every span the daemon measures
 #      from now on lands unclassified, and the session state that knew the
@@ -270,25 +270,33 @@ assert_go_test_goes_red \
   "TestAutonomyKindOrUnknown_AbsenceIsNeverTopLevel|TestAutonomySpanTracker_LegacyRowIsNeverSilentlyClassified" \
   "absence must never resolve to a claim"
 
-# ── 8. The default view stops excluding subagent runs ───────────────────────
+# ── 8. A subagent filter comes back ─────────────────────────────────────────
+#
+# RETARGETED (#1905 recording). The maintainer's decision is that subagent runs
+# are ALWAYS counted — they are runs Irrlicht recorded — so what used to be the
+# default behaviour is now the mutation: this reinstates a filter and the window
+# read stops returning the two nested runs.
 assert_go_test_goes_red \
-  "the default view leaves subagent runs out" \
+  "every run is returned, subagent runs included" \
   "core/adapters/outbound/filesystem/autonomy_tracker.go" \
-  $'\tif kind == session.AutonomyKindSubagent && !q.IncludeSubagents {\n\t\treturn\n\t}' \
-  $'\tif kind == session.AutonomyKindSubagent && !q.IncludeSubagents && false {\n\t\treturn\n\t}' \
+  $'\tkind := session.AutonomyKindOrUnknown(r.Kind)\n\tcountSpanKind(kind, res)' \
+  $'\tkind := session.AutonomyKindOrUnknown(r.Kind)\n\tcountSpanKind(kind, res)\n\tif kind == session.AutonomyKindSubagent {\n\t\treturn\n\t}' \
   "./core/adapters/outbound/filesystem/..." \
-  "TestAutonomySpanTracker_DefaultExcludesSubagentsButStillCountsThem" \
-  "want 2 (the top-level one and the unknown one)"
+  "TestAutonomySpanTracker_ReturnsEveryRunIncludingSubagents" \
+  "nothing is dropped for its kind"
 
-# ── 9. The exclusion stops being counted ────────────────────────────────────
+# ── 9. The census stops counting a kind ─────────────────────────────────────
+#
+# The three counts are what a client says out loud about a window's makeup. A
+# kind that stops being counted is a kind nobody can see was there.
 assert_go_test_goes_red \
-  "what the mode left out is counted before the filter drops it" \
+  "the window census counts every kind it holds" \
   "core/adapters/outbound/filesystem/autonomy_tracker.go" \
   $'\tcase session.AutonomyKindSubagent:\n\t\tres.Kinds.Subagent++' \
-  $'\tcase session.AutonomyKindSubagent:\n\t\tif q.IncludeSubagents {\n\t\t\tres.Kinds.Subagent++\n\t\t}' \
+  $'\tcase session.AutonomyKindSubagent:\n\t\t_ = res' \
   "./core/adapters/outbound/filesystem/..." \
-  "TestAutonomySpanTracker_DefaultExcludesSubagentsButStillCountsThem" \
-  "the census counts the"
+  "TestAutonomySpanTracker_ReturnsEveryRunIncludingSubagents" \
+  "want {TopLevel:1 Subagent:2 Unknown:1}"
 
 # ── 10. The live path stops stamping the kind ───────────────────────────────
 assert_go_test_goes_red \


### PR DESCRIPTION
Autonomy recorded **5** spans over a day whose `logs/events.log` implies **35** runs, and it lost the long ones hardest: longest recorded 35m30s, longest in the log 1h05m, and a session the maintainer knows ran over 3 hours appears in neither. The bias is the defect — the longer a run, the likelier it crosses a daemon restart, so the feature systematically lost precisely the long autonomous runs it exists to report.

Three compounding causes, plus one found on the way. Also in this PR, per the maintainer's decision: subagent runs are now always counted and the `Runs` control is gone from both surfaces.

## The three red-first tests

Each was written before the fix and **seen to fail on behaviour, not on a build error**. The two `services` tests use a store double that carries the journal methods from the start — a Go value may hold methods beyond the interface it satisfies — so the committed files are byte-identical to the ones that ran red. The store-level one writes `open.json` as raw bytes, so it never depended on the writer it was checking the reader against.

| Test | Red (before) | Green (after) |
|---|---|---|
| `TestAutonomySpan_SessionBornWorkingOpensASpan` | `AutonomySpanStart = nil` | opens at discovery time, marked as a lower bound |
| `TestAutonomySpan_OpenRunSurvivesADaemonRestart` | `spans recorded = 0, want 1` | one span, `Start` = the **first** daemon's start |
| `TestAutonomySpan_RunInProgressIsVisible` (services) | `open runs = 0, want 1` | the journal holds it |
| `TestSpansInWindow_ReturnsTheRunStillInProgress` (store) | `spans in window = 0, want 1` | returned, marked `running` |

What they proved:

1. **A session born `working` opened no span.** `shouldClassifyAtBirth` (`session_detector_activity.go:380`) births such a session by assigning `state.State` **directly**, bypassing `applyStateTransition` — whose single call to `applyAutonomySpanTransition` was the only place a span could open. The fix is at the birth site (`openAutonomySpanAtBirth`), not folded into the transition path, because the session does not yet exist for anything to transition.
2. **Nothing survived a restart.** Every restart rediscovers every live session as "already working", which is cause 1 again — about ten times that day.
3. **A span reached the log only when it CLOSED.** A run still going was worth nothing, so the longest run on the machine was the one guaranteed to be missing.

**Found en route (4th leak, own fixture):** `settleAutonomySpanOnTeardown` settled only a *pending* end, so a session torn down while still `working` — the agent's process exiting mid-run, which is how most sessions actually end — filed nothing at all. `TestAutonomySpan_TeardownWhileWorkingStillFilesTheRun`.

## How an open span survives a restart

A new **open-run journal**, `<dataDir>/autonomy/open.json` — one file, rewritten whole, because it is a keyed set with deletes rather than a history; its size is bounded by how many sessions are working at once.

- **Journalled the instant a run opens** (`RecordOpenSpan`), so a daemon dying seconds later still leaves it recoverable.
- **Reconciled on the 5s refresh ticker** (`SyncOpenSpans`) — a *replace*, not a merge, which is what stops a vanished session leaving an entry nothing will ever close. Throttled on two conditions: written immediately when the open **set changes**, otherwise once per 30s to push last-seen forward. That interval bounds what a crash costs, since an unrecovered run closes at last-seen.
- **Adopted on rediscovery.** A restarting daemon loads the journal and holds each entry for a 2-minute adoption window; a session rediscovered as `working` takes its **measured** start back, so a 3-hour run crossing four restarts is one 3-hour run.
- **Never resurrected.** An entry nobody claims inside the window is closed **at its last-seen instant** with reason `unknown` — not at `now` (that credits the run with the downtime: a 30-minute run interrupted by an overnight reboot would become an 8-hour one) and not never (it would be "in progress" forever). Past the window it can no longer be adopted at all.

`RecordSpan` clears the session's journal entry first and **unconditionally**, ahead of its "nothing useful to store" no-op — the run is over whether or not it was worth filing, and a leftover entry would be adopted as a live run by the next daemon.

## What a still-running run does to p95/p50/p5

**It is excluded from every percentile, and said so out loud.** Stated at the decision site, in `buildAutonomyDurationResponse`:

> A run three hours in and continuing has a duration of *at least* three hours. Folding that into a percentile treats a floor as a measurement, and the error is not random: it always shortens, and it shortens the longest runs hardest — the exact bias this fix removes.

So a running run is **counted, returned, drawn, and named** (`measurement.running` on both payloads; `running: true` per row), while the envelope, the summary row and the min/max extremes come from finished runs only. Both panels say both halves — "shown but left out of the percentiles" — so a reader who can see a 3-hour run on the strip is not left wondering why the median did not move. Its seconds-so-far *do* count toward its project's strip rank, since that ranks total autonomous time.

**A lower-bound start is treated the opposite way, deliberately.** Such a run has *finished*; only its start is unknown, bounded by the daemon's own uptime. It **is** a percentile sample, and it is marked (`start_lower_bound`). Excluding those would re-create the under-count exactly — every long run crossing a restart is one of them.

**Recovering the start** is an evidence ladder, documented at `openAutonomySpanAtBirth`: (1) the journal, a start the previous daemon *measured*, not marked; (2) discovery time, **marked as a lower bound**. There is no transcript rung today and the code says why rather than leaving it implicit: `SessionMetrics` carries no turn-start instant (checked `core/domain/session/metrics.go`), and the two session-scope times that exist would date a run to the start of the whole *session* — hours early on a session that has taken twenty turns. Overstating is the one direction that turns a missing number into a wrong one.

## Always counting subagent runs

`IncludeSubagents` is gone from the query, the store's filter, `?include_subagents=`, and the payload's `kinds.mode`. The `Runs: Top-level | + subagents` control is removed from `index.html`/`historyTab.js` and from `HistoryView.swift` (`HistoryAutonomyRunScope` deleted). An old client still sending the parameter is answered with every run — never rejected; a parameter that no longer exists is not a bad request.

`kind`/`parent` stay on every row and #1916's classification is untouched. Its tests are **retargeted at the field, not deleted**: `…_DefaultExcludesSubagentsButStillCountsThem` → `…_ReturnsEveryRunIncludingSubagents`, `TestBackfilledSubagentRunIsExcludedFromTheDefaultView` → `…IsServedWithItsClassification`, `autonomyModeLine` → `autonomyCountingLine` (both surfaces), each keeping its unknown-clause and in-language-mutant assertions.

## Mutation fixture per new check

Everything this change *adds* has no "before the fix" to run red, so each is committed with the mutation it catches. Two were driven live and confirmed red (output in the checklist below); the rest are committed table cases whose failure message computes the wrong answer.

| New check | Mutation fixture |
|---|---|
| lower-bound marking | `TestAutonomySpanLowerBound_MarksExactlyTheUnmeasuredStarts` — three cases: mark nothing / mark everything / mark a recovered run. **Verified red**: dropping `AutonomySpanStartLowerBound = false` failed 2 of 3 subtests. |
| close an unadopted run at last-seen | `TestAutonomySpanRecovery_UnadoptedRunClosesWhereItWasLastSeen`. **Verified red**: closing at `now` reported *"closed at 1700030721 (a 30721s run), want 1700001800 (a 1800s run)"*. |
| running run vs. percentiles | `TestAutonomyDuration_RunningRunIsCountedButNotAveraged` — four 60s runs + one 4h run still going. **Verified red**: folding it in gave `summary count = 5, want 4`. |
| lower-bound run *is* a sample | `TestAutonomyDuration_LowerBoundStartIsStillASample` — excluding it drops the count 2→1 and loses the window's longest run. |
| journal is reconciled, not merged | `TestSyncOpenAutonomySpans_WritesExactlyTheRunsThatAreOpen`, `TestSyncOpenSpans_ReplacesRatherThanMerges`. |
| teardown while working | `TestAutonomySpan_TeardownWhileWorkingStillFilesTheRun`. |
| `RecordSpan` clears the open entry | `TestRecordSpan_ClearsTheSessionsOpenRun` + `…EvenWhenItFilesNothing` (the natural bug: putting the clear behind the early return). |
| open runs selected by overlap | `TestOpenRun_IsSelectedByOverlapNotByItsEnd` — reusing the closed log's "ended inside the window" rule silently drops every open run from a trailing window. |
| journal ≠ a project log | `TestOpenJournal_IsNotReadAsAProjectLog` — naming it `.jsonl` would file every open run twice. |
| corrupt journal | `TestOpenJournal_CorruptFileDoesNotBreakTheWindowRead` — a truncated write is exactly what a crash produces, and a crash is when this file matters most. |
| always-on subagents | shell mutants 8 & 9 in `tools/lib/autonomy-backfill-mutations_test.sh`, **retargeted**: reinstating a filter, and dropping a kind from the census. Both `ok`. |
| panel sentences | committed in-language mutants in `irrlicht.history.autonomy.{subagents,measurement}.test.js` and `HistoryAutonomy{Subagent,Measurement}Tests.swift`; plus a markup/wiring tripwire with a positive control, so "not found" means removed rather than mis-pathed. |

## Verification

`tools/preflight.sh` run in `--only` chunks, each a separate foreground call — **all PASS**: `go` (incl. replay fixtures, `of validate`, recording-rig smoke), `web` (both trees, 604 + 120), `swift` (627 tests), `tools`, `arch` (ARS 7.93257 → 7.93297, no regression), `bash`, `posix`, `skills`, `security`. `--linux` not run (needs Docker). `bash tools/lib/autonomy-backfill-mutations_test.sh`: ALL PASS, 13 mutants.

Nothing was run against the maintainer's real data directory.

## Scope

The band, the key, the boundary markers, the control placement and the run strip are untouched — the strip is being redesigned separately. The strip's rendering is unchanged even for running runs: the row carries `running: true` on the wire for that redesign to use, and the still-running count is marked in the **panel sentence** instead. Worth a look during QA.

Closes part of #1905.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
