### PR TITLE
feat(history): rebuild Autonomy as five per-project panels (#1905)

### DIFF
--- a/core/application/services/autonomy_span_test.go
+++ b/core/application/services/autonomy_span_test.go
@@ -295,38 +295,6 @@ func TestAutonomySpan_NoStoreStillClearsTheOpenSpan(t *testing.T) {
 	}
 }
 
-// TestAutonomyReasonLadderMatchesHistoryBar pins the strip's collapse ladder
-// against the session-history strip's (#1805), which is where the order came
-// from. Two hand-written ladders in one repo is one too many; this is what
-// stops them drifting.
-func TestAutonomyReasonLadderMatchesHistoryBar(t *testing.T) {
-	pairs := []struct {
-		state       string
-		historyBar  int8
-		autonomyBar int
-	}{
-		{session.StateError, statePriorityError, session.AutonomyReasonPriority(session.StateError)},
-		{session.StateWaiting, statePriorityWaiting, session.AutonomyReasonPriority(session.StateWaiting)},
-		{session.StateReady, statePriorityReady, session.AutonomyReasonPriority(session.StateReady)},
-	}
-	for i := 1; i < len(pairs); i++ {
-		prev, cur := pairs[i-1], pairs[i]
-		if prev.historyBar <= cur.historyBar {
-			t.Fatalf("the history bar's ladder no longer ranks %q above %q — this test's premise is gone",
-				prev.state, cur.state)
-		}
-		if prev.autonomyBar <= cur.autonomyBar {
-			t.Errorf("the autonomy strip ranks %q (%d) at or below %q (%d), but the history bar ranks it "+
-				"above — one error in a column must paint the whole column",
-				prev.state, prev.autonomyBar, cur.state, cur.autonomyBar)
-		}
-	}
-	if session.AutonomyReasonPriority("nonsense") >= session.AutonomyReasonPriority(session.StateReady) {
-		t.Error("an unrecognized reason must rank below every real one, or a build that cannot name a " +
-			"state outranks activity it can")
-	}
-}
-
 func TestAutonomyEndReasons_DerivedFromTheVocabulary(t *testing.T) {
 	reasons := session.AutonomyEndReasons()
 	if len(reasons) != len(session.CanonicalStates())-1 {

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -507,8 +507,8 @@ func historyChartKnown(w http.ResponseWriter, chart string) bool {
 	case "state":
 		// implemented (#981, the "Activity Matrix" — time-in-state, the
 		// optional second half of #751) — handled after range resolution below
-	case chartAutonomyDuration, chartAutonomySpans:
-		// implemented (#1905, the Autonomy section's two elements) — each
+	case chartAutonomyProjects:
+		// implemented (#1905, the Autonomy section's per-project panels) — it
 		// brings its OWN ?window= vocabulary, resolved in resolveHistoryQuery
 	default:
 		http.Error(w, "unknown chart: "+chart, http.StatusBadRequest)
@@ -713,11 +713,11 @@ func resolveHistoryWindow(w http.ResponseWriter, q url.Values, chart string) (ra
 	case isAutonomyChart(chart):
 		window := q.Get("window")
 		if window == "" {
-			window = autonomyDefaultWindow(chart)
+			window = autonomyDefaultWindow()
 		}
-		bs, s, e, known := resolveAutonomyWindow(chart, window)
+		bs, s, e, known := resolveAutonomyWindow(window)
 		if !known {
-			http.Error(w, autonomyWindowError(chart), http.StatusBadRequest)
+			http.Error(w, autonomyWindowError(), http.StatusBadRequest)
 			return "", 0, 0, 0, false
 		}
 		return window, s, e, bs, true
@@ -823,12 +823,12 @@ type historyChartDeps struct {
 // why they resolve here rather than downstream of it.
 func serveNonCostHistoryChart(w http.ResponseWriter, r *http.Request, hq historyQuery, deps historyChartDeps) bool {
 	switch hq.chart {
-	case chartAutonomyDuration:
+	case chartAutonomyProjects:
 		// Autonomy (#1905) reads the always-on span log, never the opt-in
-		// recordings — see outbound.AutonomySpanStore for why that matters.
-		serveHistoryAutonomyDurationChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
-	case chartAutonomySpans:
-		serveHistoryAutonomySpansChart(w, deps.autonomy, hq.rangeKey, hq.start, hq.end)
+		// recordings — see outbound.AutonomySpanStore for why that matters, and
+		// history_autonomy_concurrency.go for why the concurrency figure is
+		// derived from those same spans rather than from ConcurrencyReader.
+		serveHistoryAutonomyProjectsChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
 	case "yield":
 		// A per-project aggregate over completed sessions, not a time series (#373).
 		writeHistoryJSON(w, buildYieldResponse(hq.rangeKey, hq.group, hq.start, hq.end, deps.sessions))

--- a/core/cmd/irrlichd/history_autonomy.go
+++ b/core/cmd/irrlichd/history_autonomy.go
@@ -5,205 +5,261 @@ import (
 	"sort"
 	"time"
 
-	"irrlicht/core/domain/session"
-	"irrlicht/core/pkg/stats"
 	"irrlicht/core/ports/outbound"
 )
 
-// Autonomy (#1905) — the History view's own top-level section, two elements
-// over one data source: a percentile line chart of autonomous run duration
-// over time, and a per-project run strip.
+// Autonomy (#1905) — the History view's own top-level section: FIVE PER-PROJECT
+// PANELS, one per project, stacked, each carrying the same two things.
 //
-// Both are served from the always-on span log (outbound.AutonomySpanStore),
-// never from the opt-in lifecycle recordings that back chart=agents/state.
-
-const (
-	// chartAutonomyDuration is element 1: one entry per time bucket carrying
-	// p95/p50/p5 plus the true min/max and the sample count.
-	chartAutonomyDuration = "autonomy_duration"
-
-	// chartAutonomySpans is element 2: the individual spans in a trailing
-	// window, for the per-project run strip.
-	chartAutonomySpans = "autonomy_spans"
-)
-
-// autonomySampleFloor is the minimum number of spans a bucket needs before its
-// p95 and p5 are percentiles rather than restatements of its own max and min.
+//	A LINE — the longest run in each time bucket. Only `working` matters here;
+//	how a run ended is recorded but no longer drawn.
+//	A HISTOGRAM under it — how many runs were working AT THE SAME TIME in that
+//	bucket, derived from the span log by overlap.
 //
-// It bites harder than a p90 would, which is why it exists at all: at n < 20
-// the R-7 p95 of a bucket interpolates within its top pair and the p5 within
-// its bottom pair, so the two outer lines collapse onto the min/max envelope
-// element 1 explicitly rejected — three lines drawn from what are really two
-// points. A bucket under the floor is MARKED (see historyAutonomyBucket.Thin)
-// and drawn differently by both clients, never hidden and never smoothed:
-// hiding it would turn a low-activity day into a gap, which reads as "no
-// runs", which is a different and false claim.
-const autonomySampleFloor = 20
+// WHAT THIS REPLACED, and why the replacement is smaller rather than richer:
+//
+//   - The p5–p95 band and the p50 line are gone. The section reports the
+//     LONGEST run now, so a percentile envelope has nothing left to describe.
+//   - The per-project run strip, its end-reason colours and its legend are
+//     gone with them: the strip's whole subject was how a run ENDED.
+//   - The sample floor and the thin-bucket marking went with the percentiles.
+//     They existed because a p95 over four samples is not a percentile — it is
+//     that bucket's maximum wearing a percentile's name. A MAXIMUM over one run
+//     is simply that run, so there is nothing left for a floor to protect, and
+//     carrying it over as decoration would mark buckets whose figure is exact.
+//
+// `Reason` stays on the wire and in the store. Nothing renders it today; it
+// costs one string per row and it is the one field that cannot be recovered
+// after the fact, so it keeps being recorded.
+//
+// Everything is served from the always-on span log (outbound.AutonomySpanStore),
+// never from the opt-in lifecycle recordings that back chart=agents/state — the
+// concurrency figure included. That is not a preference: on a machine with no
+// `recordings` directory the lifecycle-derived Agents chart is blank while the
+// span log is complete, so a concurrency number taken from recordings would be
+// missing exactly where this one is not.
+const chartAutonomyProjects = "autonomy_projects"
 
-// autonomySpanLimit caps how many spans one strip request returns. A year of
-// heavy use is tens of thousands of spans, and the strip cannot draw more than
-// its own pixel width anyway; the cap keeps the payload bounded. When it bites
-// the response says so (Truncated), because a strip silently drawn from part
-// of its window is exactly the "wrong number with nothing on screen saying so"
-// this feature is supposed to avoid.
-const autonomySpanLimit = 20000
+// autonomyPanelCount is how many project panels the section draws.
+//
+// FIVE, and the number is the design rather than a cap bolted onto an unbounded
+// list: the section is a per-project view of the five most important projects,
+// so the daemon computes five panels and says how many projects it left out.
+// Both clients draw what they are sent, which is why they cannot disagree about
+// how many panels a stack has (the run strip they replaced shipped twelve rows
+// on the web against six on macOS).
+//
+// "MOST IMPORTANT" IS GREATEST TOTAL AUTONOMOUS TIME IN THE WINDOW, never
+// longest single run: one lucky overnight run would otherwise promote a project
+// nobody has touched in a month over the one that has been working all week.
+// The rank is stated on the wire (historyAutonomyPanel.TotalSeconds) so it can
+// be checked rather than trusted.
+const autonomyPanelCount = 5
 
-// autonomyDurationSpec pairs one Range's bucket width with its bucket count.
+// autonomyWindowSpec pairs one Range's bucket width with its bucket count.
 //
 // SEPARATE FROM historyGranularitySpecs ON PURPOSE, and the separation is
 // load-bearing (#1905). The keys look alike and mean opposite things: there, a
 // key names a BUCKET WIDTH which is then multiplied by a count, so "24h"
-// resolves to a THIRTY-DAY window. Here and in autonomySpanWindowSeconds a key
-// names the WINDOW ITSELF. Merging the two tables in a later refactor would
-// silently redefine what a user's "24h" means;
-// TestAutonomyWindows_AreNotHistoryGranularities is the tripwire.
-type autonomyDurationSpec struct {
+// resolves to a THIRTY-DAY window. Here a key names the WINDOW ITSELF. Merging
+// the two tables in a later refactor would silently redefine what a user's
+// "24h" means; TestAutonomyWindows_AreNotHistoryGranularities is the tripwire.
+type autonomyWindowSpec struct {
 	bucketSeconds int64
 	buckets       int64
 }
 
-// autonomyDurationSpecs is element 1's Range vocabulary. Two ranges, and 30
-// days is the floor: anything shorter has too few spans per bucket for a
-// percentile to mean anything.
-var autonomyDurationSpecs = map[string]autonomyDurationSpec{
+// autonomyWindowSpecs is the section's Range vocabulary. Two ranges — the
+// section's only control now that the run strip's Span has gone with the strip.
+var autonomyWindowSpecs = map[string]autonomyWindowSpec{
 	"30d": {86400, 30},     // 30 daily buckets
 	"1y":  {7 * 86400, 52}, // 52 weekly buckets
 }
 
-// autonomySpanWindowSeconds is element 2's Span vocabulary — WINDOW LENGTHS,
-// each the whole trailing period the strip draws.
-var autonomySpanWindowSeconds = map[string]int64{
-	"8h":   8 * 3600,
-	"24h":  24 * 3600,
-	"7d":   7 * 86400,
-	"30d":  30 * 86400,
-	"12mo": 365 * 86400,
-}
-
-// isAutonomyChart reports whether a ?chart= value is one of the two autonomy
-// elements — both of which resolve their window from ?window= instead of the
-// usual ?range=/?bucket= pair.
-func isAutonomyChart(chart string) bool {
-	return chart == chartAutonomyDuration || chart == chartAutonomySpans
-}
+// isAutonomyChart reports whether a ?chart= value is the Autonomy section's,
+// which resolves its window from ?window= instead of the usual ?range=/?bucket=
+// pair.
+func isAutonomyChart(chart string) bool { return chart == chartAutonomyProjects }
 
 // autonomyDefaultWindow is the ?window= value assumed when the client sends
-// none, per chart.
-func autonomyDefaultWindow(chart string) string {
-	if chart == chartAutonomySpans {
-		return "24h"
-	}
-	return "30d"
-}
+// none.
+func autonomyDefaultWindow() string { return "30d" }
 
-// resolveAutonomyWindow resolves a chart's ?window= into a trailing
-// [start, end) window plus, for the duration chart, its bucket width. ok is
-// false for a window the chart does not offer — the two charts have different
-// vocabularies and neither accepts the other's keys.
-func resolveAutonomyWindow(chart, window string) (bucketSeconds, start, end int64, ok bool) {
-	end = time.Now().Unix()
-	if chart == chartAutonomySpans {
-		secs, known := autonomySpanWindowSeconds[window]
-		if !known {
-			return 0, 0, 0, false
-		}
-		return 0, end - secs, end, true
-	}
-	spec, known := autonomyDurationSpecs[window]
+// resolveAutonomyWindow resolves ?window= into a trailing [start, end) window
+// plus its bucket width. ok is false for a window the section does not offer.
+func resolveAutonomyWindow(window string) (bucketSeconds, start, end int64, ok bool) {
+	spec, known := autonomyWindowSpecs[window]
 	if !known {
 		return 0, 0, 0, false
 	}
+	end = time.Now().Unix()
 	return spec.bucketSeconds, end - spec.bucketSeconds*spec.buckets, end, true
 }
 
-// autonomyWindowError is the 400 body for an unrecognized ?window=, naming the
-// vocabulary the requested chart actually has.
-func autonomyWindowError(chart string) string {
-	if chart == chartAutonomySpans {
-		return "invalid window for chart=autonomy_spans: use 8h|24h|7d|30d|12mo"
-	}
-	return "invalid window for chart=autonomy_duration: use 30d|1y"
+// autonomyWindowError is the 400 body for an unrecognized ?window=.
+func autonomyWindowError() string {
+	return "invalid window for chart=autonomy_projects: use 30d|1y"
 }
 
-// historyAutonomyBucket is one time bucket of element 1. Buckets with no spans
-// are OMITTED from the response entirely rather than sent with zeros — a day
-// with no runs is a gap, not a run of length zero, and a zero would pull the
-// line to the axis (the same rule appendSparsePoints applies to the cost
-// series). Count is therefore always ≥ 1 on a bucket that is present.
-type historyAutonomyBucket struct {
-	TS    int64   `json:"ts"`
-	P95   float64 `json:"p95"`
-	P50   float64 `json:"p50"`
-	P5    float64 `json:"p5"`
-	Min   float64 `json:"min"`
-	Max   float64 `json:"max"`
-	Count int     `json:"count"`
-	// Thin marks a bucket below autonomySampleFloor, whose p95/p5 are its own
-	// max/min. Both clients render such buckets visibly differently.
-	Thin bool `json:"thin,omitempty"`
+// historyAutonomyPanelBucket is one time bucket of one project's panel.
+//
+// A BUCKET WITH NOTHING IN IT IS OMITTED, never emitted with zeros — a day with
+// no runs is a gap, not a run of length zero next to nobody working. The line
+// breaks there and the histogram draws nothing, because a zero bar sitting on
+// the axis looks measured and a zero point pulls the line down to it. So a
+// bucket that is PRESENT has Longest > 0 or Peak > 0.
+type historyAutonomyPanelBucket struct {
+	TS int64 `json:"ts"`
+
+	// Longest is the length in seconds of the longest run that ENDED in this
+	// bucket, and 0 when no run ended here.
+	//
+	// BY END, matching the store's own window semantics (a span is selected by
+	// where it ended, since that is the only timestamp every row is guaranteed
+	// to have). The consequence is worth stating: a run that merely passed
+	// THROUGH a bucket raises that bucket's concurrency without putting a point
+	// on its line, so a bucket can carry a bar and no line point. That is the
+	// honest pair of facts — something was working, nothing finished — and the
+	// alternative, crediting a run to every bucket it touched, would draw one
+	// 11-hour run as two 11-hour days.
+	Longest float64 `json:"longest"`
+
+	// Running marks a bucket whose longest run HAS NOT ENDED: its length is how
+	// long it has lasted so far, a floor rather than a measurement. It is still
+	// the longest — "already lasted 3h" is a true statement about the longest
+	// run — and it is marked so nobody reads a floor as final.
+	Running bool `json:"running,omitempty"`
+
+	// Peak is the greatest number of runs working AT THE SAME INSTANT anywhere
+	// in this bucket. PEAK, not average: peak answers "how wide did I go", where
+	// an average over a day is dominated by the hours nothing ran.
+	Peak int `json:"peak"`
+
+	// PeakTop and PeakSub split Peak at the instant it was reached. Meaningful
+	// only when PeakSplit is true.
+	PeakTop int `json:"peak_top"`
+	PeakSub int `json:"peak_sub"`
+
+	// PeakSplit reports that every run alive at the peak instant said which kind
+	// it was, so PeakTop + PeakSub is a derivation rather than a guess.
+	//
+	// False is the normal case for old data: rows written before #1916, and rows
+	// the back-fill rebuilt from a source with no parent information, carry
+	// session.AutonomyKindUnknown. A client shows the total alone there — never
+	// a split with an invented denominator.
+	PeakSplit bool `json:"peak_split,omitempty"`
 }
 
-// historyAutonomySummary is the window-wide figure row under the chart: the
-// drawn envelope's percentiles plus the true extremes, which are figures and
-// deliberately NOT lines (one overnight run would otherwise redraw the whole
-// Y scale and flatten every other bucket onto the floor).
+// historyAutonomyPanel is one project's panel: its two window-wide figures and
+// its per-bucket series.
+type historyAutonomyPanel struct {
+	Project string `json:"project"`
+
+	// Longest is the longest run in the whole window, in seconds, and
+	// LongestRunning marks it as one that has not ended.
+	//
+	// A STILL-RUNNING RUN COUNTS TOWARDS IT, unlike its old effect on a
+	// percentile. "The longest run already lasted 3h" is true and useful; a p95
+	// that folded the same floor in would have claimed the top 5% of runs were
+	// shorter than they were.
+	Longest        float64 `json:"longest"`
+	LongestRunning bool    `json:"longest_running,omitempty"`
+
+	// TotalSeconds is the sum of every run's length — the figure the panels are
+	// RANKED by. On the wire so the ranking can be checked against the panels
+	// rather than taken on trust.
+	TotalSeconds float64 `json:"total_seconds"`
+
+	// Runs is how many runs the window holds for this project, of every kind.
+	Runs int `json:"runs"`
+
+	// Peak is the most runs this project had working at once anywhere in the
+	// window, split the same way a bucket's is when the split is derivable.
+	Peak      int  `json:"peak"`
+	PeakTop   int  `json:"peak_top"`
+	PeakSub   int  `json:"peak_sub"`
+	PeakSplit bool `json:"peak_split,omitempty"`
+
+	Buckets []historyAutonomyPanelBucket `json:"buckets"`
+}
+
+// historyAutonomySummary is the window-wide figure row: the section's two
+// headline numbers across EVERY project, not just the five drawn.
 type historyAutonomySummary struct {
-	P95   float64 `json:"p95"`
-	P50   float64 `json:"p50"`
-	P5    float64 `json:"p5"`
-	Min   float64 `json:"min"`
-	Max   float64 `json:"max"`
-	Count int     `json:"count"`
+	// Longest is the longest run anywhere in the window, and LongestProject
+	// names where it happened.
+	Longest        float64 `json:"longest"`
+	LongestRunning bool    `json:"longest_running,omitempty"`
+	LongestProject string  `json:"longest_project,omitempty"`
+
+	// Peak is the highest per-project concurrency in the window — the widest any
+	// ONE project went, never a sum across projects, which would be a different
+	// and much larger number.
+	Peak        int    `json:"peak"`
+	PeakProject string `json:"peak_project,omitempty"`
+
+	// Runs and Projects count the window.
+	Runs     int `json:"runs"`
+	Projects int `json:"projects"`
 }
 
-// historyAutonomyDurationResponse is the chart=autonomy_duration payload.
-type historyAutonomyDurationResponse struct {
-	Window        string                  `json:"window"`
-	Chart         string                  `json:"chart"`
-	Start         int64                   `json:"start"`
-	End           int64                   `json:"end"`
-	BucketSeconds int64                   `json:"bucket_seconds"`
-	BucketStarts  []int64                 `json:"bucket_starts"`
-	Buckets       []historyAutonomyBucket `json:"buckets"`
-	Summary       historyAutonomySummary  `json:"summary"`
-	SampleFloor   int                     `json:"sample_floor"`
-	// EarliestSpan is the earliest span on record across the WHOLE log, not
-	// this window — 0 when nothing has ever been recorded. It is what lets
-	// both clients say "collecting since <date>" instead of leaving an empty
-	// chart to be read as "you did nothing" (#1905).
+// historyAutonomyProjectsResponse is the chart=autonomy_projects payload.
+type historyAutonomyProjectsResponse struct {
+	Window        string  `json:"window"`
+	Chart         string  `json:"chart"`
+	Start         int64   `json:"start"`
+	End           int64   `json:"end"`
+	BucketSeconds int64   `json:"bucket_seconds"`
+	BucketStarts  []int64 `json:"bucket_starts"`
+
+	// Panels are the five most important projects, most autonomous time first.
+	Panels []historyAutonomyPanel `json:"panels"`
+	// PanelLimit is how many panels the daemon draws — on the wire so a client
+	// renders what it was sent rather than re-deciding the number itself.
+	PanelLimit int `json:"panel_limit"`
+	// MoreProjects is how many projects the window holds beyond the panels, all
+	// of them with less autonomous time than every panel above.
+	MoreProjects int `json:"more_projects"`
+
+	Summary historyAutonomySummary `json:"summary"`
+
+	// EarliestSpan is the earliest span on record across the WHOLE log, not this
+	// window — 0 when nothing has ever been recorded. It is what lets both
+	// clients say "collecting since <date>" instead of leaving an empty section
+	// to be read as "you did nothing" (#1905).
 	EarliestSpan  int64 `json:"earliest_span"`
 	TotalRecorded int   `json:"total_recorded"`
+
 	// Provenance marks how much of THIS window was reconstructed rather than
-	// measured (#1905 back-fill). Always present, zero-valued when the whole
-	// window was measured live.
+	// measured (#1905 back-fill), and carries the source boundaries the panels
+	// draw a rule at. Always present, zero-valued when the whole window was
+	// measured live.
 	Provenance historyAutonomyProvenance `json:"provenance"`
 	// Kinds says what this payload is made of, by run kind (#1905 subagents).
-	// Always present.
 	Kinds historyAutonomyKinds `json:"kinds"`
 	// Measurement says how many of the runs in view have a duration that is a
-	// floor rather than a measurement (#1905 recording). Always present,
-	// zero-valued when every run in view is finished and fully measured.
+	// floor rather than a measurement (#1905 recording).
 	Measurement historyAutonomyMeasurement `json:"measurement"`
 }
 
 // historyAutonomyProvenance is the wire shape of
-// outbound.AutonomySpanProvenance, carried by BOTH autonomy payloads.
+// outbound.AutonomySpanProvenance.
 //
-// It ships even though the back-fill tool never does: the tool is a one-off
-// the maintainer runs by hand on one machine, but the rows it writes are read
-// by every daemon and both clients afterwards, and a reconstructed number
-// rendered as a measured one is precisely the "wrong figure with nothing on
-// screen saying so" this feature was built to avoid.
+// It ships even though the back-fill tool never does: the tool is a one-off the
+// maintainer runs by hand on one machine, but the rows it writes are read by
+// every daemon and both clients afterwards, and a reconstructed number rendered
+// as a measured one is precisely the "wrong figure with nothing on screen saying
+// so" this feature was built to avoid.
 type historyAutonomyProvenance struct {
-	// Reconstructed is how many of the runs in this window were rebuilt from
-	// a log rather than measured as they happened.
+	// Reconstructed is how many of the runs in this window were rebuilt from a
+	// log rather than measured as they happened.
 	Reconstructed int `json:"reconstructed"`
-	// CostDerived is the subset of those whose end reason is unknown and
-	// cannot be recovered — the source records activity, not outcome.
+	// CostDerived is the subset of those whose end reason is unknown and cannot
+	// be recovered — the source records activity, not outcome.
 	CostDerived int `json:"cost_derived"`
-	// LiveSince is the earliest MEASURED span across the whole log: the
-	// instant before which everything on record is reconstructed. 0 when
-	// nothing has ever been measured live.
+	// LiveSince is the earliest MEASURED span across the whole log: the instant
+	// before which everything on record is reconstructed. 0 when nothing has
+	// ever been measured live.
 	LiveSince int64 `json:"live_since"`
 	// Boundaries are the instants where the PROVENANCE of the data changes,
 	// oldest first. Empty when everything on record came from one source.
@@ -211,20 +267,25 @@ type historyAutonomyProvenance struct {
 }
 
 // autonomyEraLive is the wire name for the measured era, whose rows carry no
-// `source` at all. It exists only on the wire and in a label — nothing writes
-// it to a row, and it is deliberately absent from session.AutonomySources() so
-// it can never be mistaken for one.
+// `source` at all. It exists only on the wire and in a label — nothing writes it
+// to a row, and it is deliberately absent from session.AutonomySources() so it
+// can never be mistaken for one.
 const autonomyEraLive = "live"
 
 // historyAutonomyBoundary is one instant where the data's provenance changes —
 // a run drawn to the left of it came from `from`, one to the right from `to`.
 //
 // It exists because the provenance PARAGRAPH cannot fix what the eye reads off
-// the CURVE (#1905 back-fill, QA-2). The cost log cannot see a run shorter than
-// its 60 s write interval; the event log records one-second runs. So the p5
-// line steps at the source boundary and a reader takes a change of instrument
-// for a change of behaviour. The marker puts the explanation where the artefact
-// is.
+// the LINE (#1905 back-fill, QA-2). The cost log cannot see a run shorter than
+// its 60 s write interval; the event log records one-second runs. So the line
+// steps at the source boundary and a reader takes a change of instrument for a
+// change of behaviour. The marker puts the explanation where the artefact is.
+//
+// It survives the redesign for the same reason it was built, and the redesign
+// makes it MORE necessary rather than less: five stacked panels sharing one x
+// axis all step at the same instant, which looks like five findings and is one
+// instrument change. Both clients draw the rule through every panel and caption
+// it once (see the caption rules in each client).
 //
 // TS is the earliest start of the NEWER era. The rules that build the rows
 // guarantee the older source stops there — the cost era ends at the event log's
@@ -238,8 +299,7 @@ type historyAutonomyBoundary struct {
 }
 
 // autonomyProvenanceFrom converts the store's provenance block to the wire
-// shape. One converter, used by both payloads, so the two elements of one
-// section can never disagree about how much of it was reconstructed.
+// shape.
 func autonomyProvenanceFrom(p outbound.AutonomySpanProvenance) historyAutonomyProvenance {
 	return historyAutonomyProvenance{
 		Reconstructed: p.Reconstructed,
@@ -249,17 +309,17 @@ func autonomyProvenanceFrom(p outbound.AutonomySpanProvenance) historyAutonomyPr
 	}
 }
 
-// autonomyBoundariesFrom turns the log's per-source era starts into the
-// instants where one era hands over to the next.
+// autonomyBoundariesFrom turns the log's per-source era starts into the instants
+// where one era hands over to the next.
 //
 // ONE MECHANISM, not a case per pair. Today there are two handovers on a
 // back-filled machine — cost→log and log→live — but nothing here names either:
-// the eras are sorted by when they start and a boundary is emitted between
-// each adjacent pair. A third source, or a machine that only ever had two of
-// them, falls out without another branch.
+// the eras are sorted by when they start and a boundary is emitted between each
+// adjacent pair. A third source, or a machine that only ever had two of them,
+// falls out without another branch.
 //
-// A single era yields no boundary, which is the normal install: nothing to
-// mark, so nothing is drawn.
+// A single era yields no boundary, which is the normal install: nothing to mark,
+// so nothing is drawn.
 func autonomyBoundariesFrom(eraStarts map[string]int64) []historyAutonomyBoundary {
 	type era struct {
 		source string
@@ -302,14 +362,16 @@ func autonomyEraName(source string) string {
 	return source
 }
 
-// historyAutonomyKinds is the wire shape of outbound.AutonomySpanKinds: what
-// the window is made of, by run kind (#1905 subagents).
+// historyAutonomyKinds is the wire shape of outbound.AutonomySpanKinds: what the
+// window is made of, by run kind (#1905 subagents).
 //
-// THERE IS NO MODE ANY MORE (#1905 recording). Subagent runs are always
-// counted — they are runs Irrlicht itself recorded — so "42 runs" means one
-// thing and a client has nothing to remember it asked for. The three counts
-// stay because they still say something a reader wants: how much of a window
-// was subagent work, and how much of it predates the classification.
+// THERE IS NO MODE ANY MORE (#1905 recording). Subagent runs are always counted
+// — they are runs Irrlicht itself recorded — so "42 runs" means one thing and a
+// client has nothing to remember it asked for. The three counts stay because
+// they still say something a reader wants: how much of a window was subagent
+// work, and how much of it predates the classification. The concurrency figure
+// leans on the same field, and the Unknown count is what tells a reader why a
+// panel's `at once` figure sometimes carries no split.
 type historyAutonomyKinds struct {
 	// TopLevel, Subagent and Unknown count the window, and — nothing being
 	// dropped for its kind — the rows returned with them.
@@ -318,9 +380,7 @@ type historyAutonomyKinds struct {
 	Unknown  int `json:"unknown"`
 }
 
-// autonomyKindsFrom converts the store's kind census to the wire shape. One
-// converter for both payloads, so the two elements of one section can never
-// disagree about what they counted.
+// autonomyKindsFrom converts the store's kind census to the wire shape.
 func autonomyKindsFrom(k outbound.AutonomySpanKinds) historyAutonomyKinds {
 	return historyAutonomyKinds{
 		TopLevel: k.TopLevel,
@@ -330,22 +390,21 @@ func autonomyKindsFrom(k outbound.AutonomySpanKinds) historyAutonomyKinds {
 }
 
 // historyAutonomyMeasurement is the wire shape of
-// outbound.AutonomySpanMeasurement: how many of the runs in view have a
-// duration that is a LOWER BOUND rather than a measurement (#1905 recording).
+// outbound.AutonomySpanMeasurement: how many of the runs in view have a duration
+// that is a LOWER BOUND rather than a measurement (#1905 recording).
 //
 // It ships beside Provenance and answers a different question. Provenance asks
 // where a number came from; this asks whether the number is finished. A run
 // still going, and a run Irrlicht met already in progress, are both real runs
-// with real durations — floors, not measurements. Both are counted, returned
-// and named on screen rather than quietly dropped, because dropping them is
-// what left 5 of a day's 35 runs on the record.
+// with real durations — floors, not measurements. Both are counted, returned and
+// named on screen rather than quietly dropped, because dropping them is what
+// left 5 of a day's 35 runs on the record.
 type historyAutonomyMeasurement struct {
 	// Running is how many of the runs in view have not ended.
 	//
-	// They are NOT samples for the percentiles — see
-	// buildAutonomyDurationResponse, where that decision is made and stated —
-	// so this is also the gap between the runs the section shows and the runs
-	// its percentiles were computed from.
+	// They ARE counted towards the longest run now — see historyAutonomyPanel.
+	// What they must never do is pass as finished, which is why they are counted
+	// separately and marked wherever one is the figure being shown.
 	Running int `json:"running"`
 
 	// LowerBoundStart is how many began before Irrlicht was watching, so their
@@ -354,7 +413,7 @@ type historyAutonomyMeasurement struct {
 }
 
 // autonomyMeasurementFrom converts the store's measurement census to the wire
-// shape. One converter for both payloads, same reason as the kinds census.
+// shape.
 func autonomyMeasurementFrom(m outbound.AutonomySpanMeasurement) historyAutonomyMeasurement {
 	return historyAutonomyMeasurement{
 		Running:         m.Running,
@@ -362,77 +421,26 @@ func autonomyMeasurementFrom(m outbound.AutonomySpanMeasurement) historyAutonomy
 	}
 }
 
-// historyAutonomySpanRow is one span on the wire for element 2.
-type historyAutonomySpanRow struct {
-	Start   int64  `json:"start"`
-	End     int64  `json:"end"`
-	Project string `json:"project"`
-	Session string `json:"session"`
-	// Reason is one of session.AutonomyEndReasons(); "" for a span recorded
-	// by a build that could not name it.
-	Reason string `json:"reason,omitempty"`
-	// Kind is one of session.AutonomyKinds(), always resolved — the store
-	// normalizes a blank row to session.AutonomyKindUnknown, so a client never
-	// has to decide what an absent field means.
-	Kind string `json:"kind"`
-	// Parent is the parent session id of a subagent run, "" otherwise.
-	Parent string `json:"parent,omitempty"`
-	// Running marks a run that has not ended: End is where it had got to when
-	// the window was taken, so its length is a floor (#1905 recording). A row
-	// carrying it must never be drawn as a finished run.
-	Running bool `json:"running,omitempty"`
-	// StartLowerBound marks a run Irrlicht met already in progress, so Start
-	// is when it began WATCHING. Its length is a floor for the other reason.
-	StartLowerBound bool `json:"start_lower_bound,omitempty"`
-}
-
-// historyAutonomySpansResponse is the chart=autonomy_spans payload: the spans
-// themselves plus the row order the strip draws them in.
-type historyAutonomySpansResponse struct {
-	Window string                   `json:"window"`
-	Chart  string                   `json:"chart"`
-	Start  int64                    `json:"start"`
-	End    int64                    `json:"end"`
-	Spans  []historyAutonomySpanRow `json:"spans"`
-	// Projects is strip row order — most autonomous seconds first — computed
-	// once here so the two clients cannot order the same strip differently.
-	Projects      []string `json:"projects"`
-	EarliestSpan  int64    `json:"earliest_span"`
-	TotalRecorded int      `json:"total_recorded"`
-	Truncated     bool     `json:"truncated"`
-	// Provenance marks how much of THIS window was reconstructed. Counted
-	// after the limit clips the spans, so it describes the rows above it.
-	Provenance historyAutonomyProvenance `json:"provenance"`
-	// Kinds says what this payload is made of, by run kind (#1905 subagents).
-	Kinds historyAutonomyKinds `json:"kinds"`
-	// Measurement says how many of the returned runs have a duration that is a
-	// floor rather than a measurement (#1905 recording).
-	Measurement historyAutonomyMeasurement `json:"measurement"`
-}
-
-// serveHistoryAutonomyDurationChart serves chart=autonomy_duration. A nil
-// store yields an empty-but-valid payload rather than an error, mirroring
+// serveHistoryAutonomyProjectsChart serves chart=autonomy_projects. A nil store
+// yields an empty-but-valid payload rather than an error, mirroring
 // serveHistoryAgentsChart.
-func serveHistoryAutonomyDurationChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64) {
+func serveHistoryAutonomyProjectsChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64) {
 	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end})
 	if !ok {
 		return
 	}
-	writeHistoryJSON(w, buildAutonomyDurationResponse(window, bucketSeconds, start, end, res))
+	writeHistoryJSON(w, buildAutonomyProjectsResponse(window, bucketSeconds, start, end, res))
 }
 
-// serveHistoryAutonomySpansChart serves chart=autonomy_spans.
-func serveHistoryAutonomySpansChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, start, end int64) {
-	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end, Limit: autonomySpanLimit})
-	if !ok {
-		return
-	}
-	writeHistoryJSON(w, buildAutonomySpansResponse(window, start, end, res))
-}
-
-// readAutonomySpans performs the store read shared by both elements,
-// substituting an empty result for a nil store and writing a 500 on error.
-// ok is false once it has written a response.
+// readAutonomySpans performs the store read, substituting an empty result for a
+// nil store and writing a 500 on error. ok is false once it has written a
+// response.
+//
+// DELIBERATELY UNLIMITED. The run strip capped its read at 20 000 rows because
+// it drew one column per run and could not draw more than its own pixel width;
+// the panels reduce every run to two per-bucket figures, and a concurrency peak
+// computed from a clipped span list is simply wrong — silently, and always
+// downwards. A cap here would be a number nobody could check.
 func readAutonomySpans(w http.ResponseWriter, store outbound.AutonomySpanStore, q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, bool) {
 	if store == nil {
 		return &outbound.AutonomySpanResult{Spans: []outbound.AutonomySpan{}}, true
@@ -448,36 +456,20 @@ func readAutonomySpans(w http.ResponseWriter, store outbound.AutonomySpanStore, 
 	return res, true
 }
 
-// buildAutonomyDurationResponse buckets the window's spans by the bucket their
-// END falls in, and reduces each bucket to its percentile envelope.
-//
-// Every percentile here is computed ONCE, server-side, with the R-7 convention
-// named in stats.Percentile — not because the clients could not divide, but
-// because "the p95" is ambiguous enough that two independent implementations
-// draw two different lines from the same data (#1905 design decision 5).
-// A RUN STILL IN PROGRESS IS NOT A SAMPLE. This is where that is decided
-// (#1905 recording), and it is a decision rather than an omission.
-//
-// A run that is three hours in and continuing has a duration of "at least three
-// hours". Folding that into a percentile treats a floor as a measurement, and
-// the error is not random: it always shortens, and it shortens the longest runs
-// hardest, which is the exact bias this whole fix exists to remove. A p95 that
-// counted it would say the top 5% of runs were shorter than they were.
-//
-// So a running run is COUNTED, RETURNED, DRAWN and NAMED — response.Measurement
-// carries how many there are, and both clients say so — but the percentile
-// envelope, the summary row and the min/max extremes are computed from finished
-// runs only. Removing it from the chart instead was the other option and is
-// worse in the same direction as the original defect: it makes the longest run
-// on the machine the one thing the section cannot show.
-//
-// A LOWER-BOUND START is treated differently, and the asymmetry is the point. A
-// run Irrlicht met already in progress has FINISHED: its length is known to
-// within however long it had been going when Irrlicht started watching, which
-// is bounded by the daemon's own uptime. It is a sample, and it is marked.
-// Dropping those would re-create the under-count exactly — every long run that
-// crosses a restart is one of them.
-func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyDurationResponse {
+// autonomyProjectTotals is one project's window-wide roll-up, accumulated in the
+// single pass that groups the window's spans.
+type autonomyProjectTotals struct {
+	spans          []outbound.AutonomySpan
+	totalSeconds   float64
+	longest        float64
+	longestRunning bool
+	runs           int
+}
+
+// buildAutonomyProjectsResponse groups the window's spans by project, ranks the
+// projects by total autonomous time, and reduces the top autonomyPanelCount of
+// them to a panel each.
+func buildAutonomyProjectsResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyProjectsResponse {
 	n := 0
 	if bucketSeconds > 0 && end > start {
 		n = int((end - start + bucketSeconds - 1) / bucketSeconds)
@@ -487,46 +479,25 @@ func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int6
 		bucketStarts[i] = start + int64(i)*bucketSeconds
 	}
 
-	byBucket := make([][]float64, n)
-	all := make([]float64, 0, len(res.Spans))
-	for _, s := range res.Spans {
-		if s.Running {
-			continue
-		}
-		d := float64(s.Duration())
-		if d <= 0 {
-			continue
-		}
-		all = append(all, d)
-		if n == 0 {
-			continue
-		}
-		idx := int((s.End - start) / bucketSeconds)
-		if idx < 0 || idx >= n {
-			continue
-		}
-		byBucket[idx] = append(byBucket[idx], d)
+	byProject := groupAutonomySpans(res.Spans)
+	ranked := rankAutonomyProjects(byProject)
+
+	panels := make([]historyAutonomyPanel, 0, min(autonomyPanelCount, len(ranked)))
+	for _, project := range ranked[:min(autonomyPanelCount, len(ranked))] {
+		panels = append(panels, buildAutonomyPanel(project, byProject[project], start, bucketSeconds, n))
 	}
 
-	buckets := make([]historyAutonomyBucket, 0, n)
-	for i, samples := range byBucket {
-		// A bucket with no spans is a GAP: omitted, never emitted as a zero.
-		if len(samples) == 0 {
-			continue
-		}
-		buckets = append(buckets, autonomyBucketFrom(bucketStarts[i], samples))
-	}
-
-	return historyAutonomyDurationResponse{
+	return historyAutonomyProjectsResponse{
 		Window:        window,
-		Chart:         chartAutonomyDuration,
+		Chart:         chartAutonomyProjects,
 		Start:         start,
 		End:           end,
 		BucketSeconds: bucketSeconds,
 		BucketStarts:  bucketStarts,
-		Buckets:       buckets,
-		Summary:       autonomySummaryFrom(all),
-		SampleFloor:   autonomySampleFloor,
+		Panels:        panels,
+		PanelLimit:    autonomyPanelCount,
+		MoreProjects:  max(0, len(ranked)-autonomyPanelCount),
+		Summary:       autonomySummaryFrom(ranked, byProject, start, end),
 		EarliestSpan:  res.EarliestStart,
 		TotalRecorded: res.TotalRecorded,
 		Provenance:    autonomyProvenanceFrom(res.Provenance),
@@ -535,83 +506,147 @@ func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int6
 	}
 }
 
-// autonomyBucketFrom reduces one bucket's samples to its envelope. samples is
-// sorted in place, then read five times — one sort per bucket, not per line.
-func autonomyBucketFrom(ts int64, samples []float64) historyAutonomyBucket {
-	sort.Float64s(samples)
-	return historyAutonomyBucket{
-		TS:    ts,
-		P95:   stats.PercentileSorted(samples, 0.95),
-		P50:   stats.PercentileSorted(samples, 0.50),
-		P5:    stats.PercentileSorted(samples, 0.05),
-		Min:   samples[0],
-		Max:   samples[len(samples)-1],
-		Count: len(samples),
-		Thin:  len(samples) < autonomySampleFloor,
-	}
-}
-
-// autonomySummaryFrom reduces the whole window's samples to the figure row.
-func autonomySummaryFrom(samples []float64) historyAutonomySummary {
-	if len(samples) == 0 {
-		return historyAutonomySummary{}
-	}
-	sort.Float64s(samples)
-	return historyAutonomySummary{
-		P95:   stats.PercentileSorted(samples, 0.95),
-		P50:   stats.PercentileSorted(samples, 0.50),
-		P5:    stats.PercentileSorted(samples, 0.05),
-		Min:   samples[0],
-		Max:   samples[len(samples)-1],
-		Count: len(samples),
-	}
-}
-
-// buildAutonomySpansResponse renders the window's spans plus the strip's row
-// order (most autonomous seconds first, then name for a stable tie-break).
-func buildAutonomySpansResponse(window string, start, end int64, res *outbound.AutonomySpanResult) historyAutonomySpansResponse {
-	rows := make([]historyAutonomySpanRow, 0, len(res.Spans))
-	totals := map[string]int64{}
-	for _, s := range res.Spans {
-		rows = append(rows, historyAutonomySpanRow{
-			Start:           s.Start,
-			End:             s.End,
-			Project:         s.Project,
-			Session:         s.Session,
-			Reason:          s.Reason,
-			Kind:            session.AutonomyKindOrUnknown(s.Kind),
-			Parent:          s.Parent,
-			Running:         s.Running,
-			StartLowerBound: s.StartLowerBound,
-		})
-		// A running run's seconds-so-far DO count towards its project's rank.
-		// The row order is "which projects had the most autonomous time", and
-		// a three-hour run still going is three hours of it — leaving it out
-		// would rank the busiest project below one that merely finished first.
-		totals[s.Project] += s.Duration()
-	}
-	projects := make([]string, 0, len(totals))
-	for p := range totals {
-		projects = append(projects, p)
-	}
-	sort.Slice(projects, func(i, j int) bool {
-		if totals[projects[i]] != totals[projects[j]] {
-			return totals[projects[i]] > totals[projects[j]]
+// groupAutonomySpans buckets the window's spans by project and accumulates each
+// project's window-wide roll-up in the same pass.
+//
+// A RUNNING RUN'S SECONDS SO FAR COUNT towards its project's total, and towards
+// its longest. The rank is "which projects had the most autonomous time", and
+// three hours still going is three hours of it; leaving it out would rank the
+// busiest project below one that merely finished first.
+func groupAutonomySpans(spans []outbound.AutonomySpan) map[string]*autonomyProjectTotals {
+	out := map[string]*autonomyProjectTotals{}
+	for _, s := range spans {
+		t := out[s.Project]
+		if t == nil {
+			t = &autonomyProjectTotals{}
+			out[s.Project] = t
 		}
-		return projects[i] < projects[j]
-	})
-	return historyAutonomySpansResponse{
-		Window:        window,
-		Chart:         chartAutonomySpans,
-		Start:         start,
-		End:           end,
-		Spans:         rows,
-		Projects:      projects,
-		EarliestSpan:  res.EarliestStart,
-		TotalRecorded: res.TotalRecorded,
-		Truncated:     res.Truncated,
-		Provenance:    autonomyProvenanceFrom(res.Provenance),
-		Kinds:         autonomyKindsFrom(res.Kinds),
-		Measurement:   autonomyMeasurementFrom(res.Measurement),
+		t.spans = append(t.spans, s)
+		t.runs++
+		d := float64(s.Duration())
+		t.totalSeconds += d
+		if d > t.longest {
+			t.longest = d
+			t.longestRunning = s.Running
+		}
 	}
+	return out
+}
+
+// rankAutonomyProjects orders projects by TOTAL AUTONOMOUS SECONDS, most first,
+// with the project name breaking a tie so the same window ranks the same way on
+// every request rather than following map iteration order.
+//
+// Not by longest run, and the difference is the whole point of ranking at all:
+// a project with one lucky overnight run and nothing else would outrank a
+// project that worked every day of the window.
+func rankAutonomyProjects(byProject map[string]*autonomyProjectTotals) []string {
+	out := make([]string, 0, len(byProject))
+	for project := range byProject {
+		out = append(out, project)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := byProject[out[i]], byProject[out[j]]
+		if a.totalSeconds != b.totalSeconds {
+			return a.totalSeconds > b.totalSeconds
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+// buildAutonomyPanel reduces one project's spans to its panel.
+func buildAutonomyPanel(project string, t *autonomyProjectTotals, start, bucketSeconds int64, n int) historyAutonomyPanel {
+	longest, running := autonomyBucketLongest(t.spans, start, bucketSeconds, n)
+	peaks := autonomyPeaks(t.spans, start, bucketSeconds, n)
+	windowPeak := autonomyWindowPeak(t.spans, start, start+bucketSeconds*int64(n))
+
+	buckets := make([]historyAutonomyPanelBucket, 0, n)
+	for i := 0; i < n; i++ {
+		// The gap rule: nothing finished here AND nothing was working here, so
+		// the bucket is omitted rather than sent as a pair of measured zeros.
+		if longest[i] <= 0 && peaks[i].peak <= 0 {
+			continue
+		}
+		buckets = append(buckets, historyAutonomyPanelBucket{
+			TS:        start + int64(i)*bucketSeconds,
+			Longest:   longest[i],
+			Running:   running[i],
+			Peak:      peaks[i].peak,
+			PeakTop:   peaks[i].topLevel,
+			PeakSub:   peaks[i].subagent,
+			PeakSplit: peaks[i].splitKnown,
+		})
+	}
+
+	return historyAutonomyPanel{
+		Project:        project,
+		Longest:        t.longest,
+		LongestRunning: t.longestRunning,
+		TotalSeconds:   t.totalSeconds,
+		Runs:           t.runs,
+		Peak:           windowPeak.peak,
+		PeakTop:        windowPeak.topLevel,
+		PeakSub:        windowPeak.subagent,
+		PeakSplit:      windowPeak.splitKnown,
+		Buckets:        buckets,
+	}
+}
+
+// autonomyBucketLongest returns, per bucket, the length of the longest run that
+// ENDED in it and whether that run was still going.
+//
+// A run's bucket is the one its END falls in — the store selects spans by their
+// end for the same reason (it is the only timestamp every row is guaranteed to
+// have). A run whose end lands exactly on the window's closing instant is
+// credited to the last bucket rather than dropped: the buckets tile [start, end)
+// so `end` itself is out of range by construction, and a run that finished this
+// very second is not a run that did not happen.
+func autonomyBucketLongest(spans []outbound.AutonomySpan, start, bucketSeconds int64, n int) (longest []float64, running []bool) {
+	longest = make([]float64, n)
+	running = make([]bool, n)
+	if n == 0 || bucketSeconds <= 0 {
+		return longest, running
+	}
+	for _, s := range spans {
+		d := float64(s.Duration())
+		if d <= 0 {
+			continue
+		}
+		idx := int((s.End - start) / bucketSeconds)
+		if idx < 0 {
+			continue
+		}
+		if idx >= n {
+			idx = n - 1
+		}
+		if d > longest[idx] {
+			longest[idx] = d
+			running[idx] = s.Running
+		}
+	}
+	return longest, running
+}
+
+// autonomySummaryFrom reduces every project in the window — not just the five
+// drawn — to the section's two headline figures.
+func autonomySummaryFrom(ranked []string, byProject map[string]*autonomyProjectTotals, start, end int64) historyAutonomySummary {
+	out := historyAutonomySummary{Projects: len(ranked)}
+	for _, project := range ranked {
+		t := byProject[project]
+		out.Runs += t.runs
+		if t.longest > out.Longest {
+			out.Longest = t.longest
+			out.LongestRunning = t.longestRunning
+			out.LongestProject = project
+		}
+		// One sweep per project, over the whole window as a single bucket: the
+		// figure is "the widest any ONE project went", never a sum across
+		// projects, which would be a different and much larger number.
+		if peak := autonomyWindowPeak(t.spans, start, end); peak.peak > out.Peak {
+			out.Peak = peak.peak
+			out.PeakProject = project
+		}
+	}
+	return out
 }

--- a/core/cmd/irrlichd/history_autonomy_concurrency.go
+++ b/core/cmd/irrlichd/history_autonomy_concurrency.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"sort"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Autonomy concurrency (#1905) — how many runs a project had working AT THE
+// SAME TIME, derived from the span log BY OVERLAP.
+//
+// FROM THE SPANS, NOT FROM outbound.ConcurrencyReader, and the choice is not
+// stylistic. That reader is fed by the lifecycle recordings, which are opt-in
+// (--record / IRRLICHT_RECORD=1); a machine with no `recordings` directory has a
+// blank Agents chart and a complete span log at the same moment. A concurrency
+// figure taken from the recordings would therefore be missing on exactly the
+// installs where every other figure in this section is present, and a missing
+// number that renders as zero is indistinguishable from a measured one.
+//
+// WHAT THE NUMBER MEANS, and the caveat both clients print beside it: the daemon
+// deliberately holds a PARENT session in `working` while its subagents run, so
+// one agent with three subagents overlaps as four. Four things really were
+// working — the number is not wrong — but they are not four independent agents,
+// which is why the split into `3 + 2 sub` is shown wherever the data supports it
+// rather than left for the reader to guess at.
+
+// autonomyConcurrency is one peak reading: how many runs were working at the
+// same instant, and — when every one of them said which kind it was — how that
+// number splits between top-level sessions and subagents.
+type autonomyConcurrency struct {
+	peak     int
+	topLevel int
+	subagent int
+
+	// splitKnown reports that topLevel + subagent == peak is a DERIVATION rather
+	// than a guess: every run alive at the peak instant carried a kind this
+	// build recognizes.
+	//
+	// False whenever one of them did not. Most rows written before 18 Aug 2026
+	// carry session.AutonomyKindUnknown — they predate the classification, or
+	// the back-fill rebuilt them from a source with no parent information — and
+	// there is no way to recover which they were. A client shows the total alone
+	// there. Splitting anyway would mean inventing the answer for the half of
+	// the history that cannot answer.
+	splitKnown bool
+}
+
+// autonomyEvent is one endpoint of one run on the sweep line.
+type autonomyEvent struct {
+	ts    int64
+	delta int
+	kind  string
+}
+
+// autonomyEventsOf builds the sorted endpoint list for one project's runs.
+//
+// HALF-OPEN INTERVALS. A run occupies [start, end): ends are applied before
+// starts at the same instant, so a run that ends exactly as another begins is a
+// handover and not an overlap. Getting that backwards would report a lone
+// session working through a chain of turns as two agents at once.
+//
+// A run of no length is SKIPPED rather than given an instant of its own. It
+// cannot overlap anything for a positive stretch of time, and an interval whose
+// start and end coincide would otherwise be closed before it opened — driving
+// the running count to -1 under the ordering above.
+func autonomyEventsOf(spans []outbound.AutonomySpan) []autonomyEvent {
+	out := make([]autonomyEvent, 0, len(spans)*2)
+	for _, s := range spans {
+		if s.End <= s.Start {
+			continue
+		}
+		kind := session.AutonomyKindOrUnknown(s.Kind)
+		out = append(out, autonomyEvent{ts: s.Start, delta: 1, kind: kind})
+		out = append(out, autonomyEvent{ts: s.End, delta: -1, kind: kind})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ts != out[j].ts {
+			return out[i].ts < out[j].ts
+		}
+		// -1 before +1 at the same instant: see the half-open rule above.
+		return out[i].delta < out[j].delta
+	})
+	return out
+}
+
+// autonomySweep is the running count as the line advances, kept per kind so the
+// composition at a peak can be read off without a second pass.
+type autonomySweep struct {
+	topLevel int
+	subagent int
+	unknown  int
+}
+
+func (s *autonomySweep) apply(e autonomyEvent) {
+	switch e.kind {
+	case session.AutonomyKindTopLevel:
+		s.topLevel += e.delta
+	case session.AutonomyKindSubagent:
+		s.subagent += e.delta
+	default:
+		s.unknown += e.delta
+	}
+}
+
+func (s autonomySweep) total() int { return s.topLevel + s.subagent + s.unknown }
+
+// reading snapshots the sweep as a peak. splitKnown requires BOTH that nothing
+// unclassified is alive and that something is: a "0 (0 + 0 sub)" is not a split
+// anyone asked for.
+func (s autonomySweep) reading() autonomyConcurrency {
+	total := s.total()
+	return autonomyConcurrency{
+		peak:       total,
+		topLevel:   s.topLevel,
+		subagent:   s.subagent,
+		splitKnown: total > 0 && s.unknown == 0,
+	}
+}
+
+// autonomyPeaks returns the peak concurrency in each of n buckets of
+// bucketSeconds starting at start.
+//
+// PEAK PER BUCKET, never an average: peak answers "how wide did I go", and an
+// average over a day is dominated by the hours in which nothing ran at all.
+//
+// One sort and one linear pass over the whole bucket row, so the cost is
+// O(R log R) per project for R runs — the sort — and not O(buckets × runs). Each
+// bucket's peak is the greater of what was already running when the bucket
+// opened (the carry-in) and every count reached at an endpoint inside it.
+func autonomyPeaks(spans []outbound.AutonomySpan, start, bucketSeconds int64, n int) []autonomyConcurrency {
+	out := make([]autonomyConcurrency, n)
+	if n <= 0 || bucketSeconds <= 0 {
+		return out
+	}
+	events := autonomyEventsOf(spans)
+	var sweep autonomySweep
+	ei := 0
+	for i := 0; i < n; i++ {
+		bucketStart := start + int64(i)*bucketSeconds
+		bucketEnd := bucketStart + bucketSeconds
+		// Everything that happened strictly before this bucket is carry-in: a
+		// run that started last week and is still going counts here, which is
+		// the whole reason the sweep is not restarted per bucket.
+		for ei < len(events) && events[ei].ts < bucketStart {
+			sweep.apply(events[ei])
+			ei++
+		}
+		best := sweep.reading()
+		for ei < len(events) && events[ei].ts < bucketEnd {
+			sweep.apply(events[ei])
+			ei++
+			if r := sweep.reading(); r.peak > best.peak {
+				best = r
+			}
+		}
+		out[i] = best
+	}
+	return out
+}
+
+// autonomyWindowPeak is the peak concurrency across one whole window — the
+// figure a panel header states as "N at once".
+//
+// The window as a SINGLE BUCKET, through the same sweep the per-bucket row uses,
+// so the header can never report a number the bars below it contradict. It is
+// also why the figure is bounded by the window: two runs that overlapped only
+// before `start` are not a peak inside it.
+func autonomyWindowPeak(spans []outbound.AutonomySpan, start, end int64) autonomyConcurrency {
+	if end <= start {
+		return autonomyConcurrency{}
+	}
+	return autonomyPeaks(spans, start, end-start, 1)[0]
+}

--- a/core/cmd/irrlichd/history_autonomy_endpoint_test.go
+++ b/core/cmd/irrlichd/history_autonomy_endpoint_test.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -19,7 +19,6 @@ type fakeAutonomyStore struct {
 	spans      []outbound.AutonomySpan
 	earliest   int64
 	total      int
-	truncated  bool
 	provenance outbound.AutonomySpanProvenance
 	// kinds is the window's run-kind census (#1905 subagents). A field rather
 	// than something derived from `spans`, because the handler's job is to
@@ -50,7 +49,6 @@ func (f *fakeAutonomyStore) SpansInWindow(q outbound.AutonomySpanQuery) (*outbou
 		Spans:         f.spans,
 		EarliestStart: f.earliest,
 		TotalRecorded: f.total,
-		Truncated:     f.truncated,
 		Provenance:    f.provenance,
 		Kinds:         f.kinds,
 		Measurement:   f.measurement,
@@ -65,6 +63,32 @@ func getAutonomy(t *testing.T, store outbound.AutonomySpanStore, query string) *
 	return rec
 }
 
+// decodeAutonomy issues one request and decodes the panels payload.
+func decodeAutonomy(t *testing.T, store outbound.AutonomySpanStore, query string) historyAutonomyProjectsResponse {
+	t.Helper()
+	rec := getAutonomy(t, store, query)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s → %d, want 200", query, rec.Code)
+	}
+	var resp historyAutonomyProjectsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+// panelFor returns the panel for one project, failing when it was not drawn.
+func panelFor(t *testing.T, resp historyAutonomyProjectsResponse, project string) historyAutonomyPanel {
+	t.Helper()
+	for _, p := range resp.Panels {
+		if p.Project == project {
+			return p
+		}
+	}
+	t.Fatalf("no panel for %q; drew %d panels", project, len(resp.Panels))
+	return historyAutonomyPanel{}
+}
+
 // spanEndingAt builds a span of the given length that ended at `end`.
 func spanEndingAt(end, length int64, project, reason string) outbound.AutonomySpan {
 	return outbound.AutonomySpan{
@@ -73,23 +97,24 @@ func spanEndingAt(end, length int64, project, reason string) outbound.AutonomySp
 		Project: project,
 		Session: fmt.Sprintf("s-%d", end),
 		Reason:  reason,
+		Kind:    session.AutonomyKindTopLevel,
 	}
 }
 
-// --- The two window vocabularies must stay distinct -------------------------
+// --- The window vocabulary must stay distinct from chart=state's -------------
 
 // TestAutonomyWindows_AreNotHistoryGranularities is the tripwire for the trap
 // the issue calls out by name: chart=state's ?granularity= keys and the
-// autonomy strip's ?window= keys OVERLAP textually and mean different things.
-// A granularity key is a BUCKET WIDTH times a count; a window key is the
-// WINDOW ITSELF.
+// Autonomy section's ?window= keys OVERLAP textually and mean different things.
+// A granularity key is a BUCKET WIDTH times a count; a window key is the WINDOW
+// ITSELF.
 //
 // The committed mutation is mergedResolver below — the refactor this test
 // exists to stop, i.e. "these tables look the same, let's have one". The test
 // asserts production disagrees with it, so the day someone merges them this
-// goes red instead of `24h` silently becoming a 30-day strip.
+// goes red instead of `30d` silently becoming a nine-hundred-day window.
 func TestAutonomyWindows_AreNotHistoryGranularities(t *testing.T) {
-	// The MUTATION: resolve a strip window by reusing chart=state's table.
+	// The MUTATION: resolve an Autonomy window by reusing chart=state's table.
 	mergedResolver := func(key string) (seconds int64, ok bool) {
 		spec, known := historyGranularitySpecs[key]
 		if !known {
@@ -98,50 +123,63 @@ func TestAutonomyWindows_AreNotHistoryGranularities(t *testing.T) {
 		return spec.bucketSeconds * spec.buckets, true
 	}
 
-	shared := []string{"8h", "24h", "7d"}
-	for _, key := range shared {
-		want, ok := autonomySpanWindowSeconds[key]
-		if !ok {
-			t.Fatalf("autonomySpanWindowSeconds is missing %q — the overlap this test guards is gone; "+
-				"re-derive the shared key list rather than deleting the check", key)
+	// The keys the two tables share. Derived by intersecting them rather than
+	// typed, so a table that grows a new collision is covered without anyone
+	// remembering to add it here — and so an EMPTY intersection fails loudly
+	// instead of passing an empty loop (AGENTS.md: a check that cannot run must
+	// not look like a check that found nothing).
+	shared := []string{}
+	for key := range autonomyWindowSpecs {
+		if _, collides := historyGranularitySpecs[key]; collides {
+			shared = append(shared, key)
 		}
+	}
+	if len(shared) == 0 {
+		t.Fatalf("autonomyWindowSpecs %v and historyGranularitySpecs no longer share a key, so this "+
+			"tripwire cannot observe the trap it guards; re-check whether the trap still exists rather "+
+			"than deleting the check", autonomyWindowSpecs)
+	}
+
+	for _, key := range shared {
+		spec := autonomyWindowSpecs[key]
+		want := spec.bucketSeconds * spec.buckets
 		merged, ok := mergedResolver(key)
 		if !ok {
 			t.Fatalf("historyGranularitySpecs no longer has %q, so the two tables can no longer collide "+
 				"on it; re-check whether this tripwire still covers the trap", key)
 		}
 		if merged == want {
-			t.Fatalf("window %q resolves to the same %d seconds under both tables — the strip's window "+
+			t.Fatalf("window %q resolves to the same %d seconds under both tables — the Autonomy window "+
 				"vocabulary has been merged into chart=state's granularity vocabulary, which silently "+
 				"redefines what the user's %q means", key, want, key)
 		}
 	}
 
 	// And spell the headline case out, so the failure message names the bug
-	// rather than only the inequality: 24h is one day here, thirty there.
-	if autonomySpanWindowSeconds["24h"] != 24*3600 {
-		t.Errorf("strip window 24h = %ds, want 86400 (one day)", autonomySpanWindowSeconds["24h"])
+	// rather than only the inequality: 30d is thirty days here, and a bucket
+	// width times thirty there.
+	if spec := autonomyWindowSpecs["30d"]; spec.bucketSeconds*spec.buckets != 30*86400 {
+		t.Errorf("Autonomy window 30d = %ds, want %d (thirty days)",
+			spec.bucketSeconds*spec.buckets, 30*86400)
 	}
-	if merged, _ := mergedResolver("24h"); merged != 30*86400 {
-		t.Errorf("granularity 24h resolves to a %ds window, want 30 days — the trap has changed shape", merged)
-	}
-}
-
-func TestAutonomyWindows_RejectTheOtherElementsVocabulary(t *testing.T) {
-	// The duration chart offers 30d|1y; the strip offers 8h…12mo. Neither
-	// accepts the other's keys, so a client that sends the wrong one is told,
-	// rather than silently served some other window.
-	rec := getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_duration&window=8h")
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("chart=autonomy_duration&window=8h → %d, want 400", rec.Code)
-	}
-	rec = getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_spans&window=1y")
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("chart=autonomy_spans&window=1y → %d, want 400", rec.Code)
+	if merged, _ := mergedResolver("30d"); merged == 30*86400 {
+		t.Errorf("granularity 30d resolves to a %ds window too — the trap has changed shape", merged)
 	}
 }
 
-func TestAutonomyDuration_WindowShapes(t *testing.T) {
+func TestAutonomy_RejectsAnUnknownWindow(t *testing.T) {
+	// The section offers 30d|1y. The run strip's old 8h…12mo vocabulary went
+	// with the strip, so a client still sending one is told rather than
+	// silently served some other window.
+	for _, window := range []string{"8h", "24h", "12mo", "week"} {
+		rec := getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_projects&window="+window)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("window=%s → %d, want 400", window, rec.Code)
+		}
+	}
+}
+
+func TestAutonomy_WindowShapes(t *testing.T) {
 	for _, tc := range []struct {
 		window        string
 		bucketSeconds int64
@@ -151,14 +189,7 @@ func TestAutonomyDuration_WindowShapes(t *testing.T) {
 		{"1y", 7 * 86400, 52},
 	} {
 		store := &fakeAutonomyStore{}
-		rec := getAutonomy(t, store, "chart=autonomy_duration&window="+tc.window)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("window=%s → %d, want 200", tc.window, rec.Code)
-		}
-		var resp historyAutonomyDurationResponse
-		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
+		resp := decodeAutonomy(t, store, "chart=autonomy_projects&window="+tc.window)
 		if resp.BucketSeconds != tc.bucketSeconds {
 			t.Errorf("window=%s bucket_seconds = %d, want %d", tc.window, resp.BucketSeconds, tc.bucketSeconds)
 		}
@@ -168,14 +199,23 @@ func TestAutonomyDuration_WindowShapes(t *testing.T) {
 	}
 }
 
+func TestAutonomy_DefaultWindow(t *testing.T) {
+	resp := decodeAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_projects")
+	if resp.Window != "30d" {
+		t.Errorf("default window = %q, want 30d", resp.Window)
+	}
+}
+
 // --- An empty bucket is a gap, not a zero -----------------------------------
 
-// TestAutonomyDuration_EmptyBucketIsAGapNotAZero pins the honesty rule: a day
-// with no runs must not pull the line to the axis.
+// TestAutonomy_EmptyBucketIsAGapNotAZero pins the honesty rule for BOTH marks a
+// panel draws: a day with no runs must break the line AND draw no bar. A zero
+// bar sitting on the axis looks measured, and a zero point pulls the line down
+// to it.
 //
 // The committed mutation is denseBuckets below — the "just emit every bucket"
-// build that would draw a zero for every quiet day.
-func TestAutonomyDuration_EmptyBucketIsAGapNotAZero(t *testing.T) {
+// build that would draw a zero-height bar and a floor point for every quiet day.
+func TestAutonomy_EmptyBucketIsAGapNotAZero(t *testing.T) {
 	now := time.Now().Unix()
 	// Two spans, both ending today: 29 of the 30 daily buckets are empty.
 	store := &fakeAutonomyStore{
@@ -183,152 +223,303 @@ func TestAutonomyDuration_EmptyBucketIsAGapNotAZero(t *testing.T) {
 			spanEndingAt(now-60, 600, "irrlicht", "ready"),
 			spanEndingAt(now-30, 900, "irrlicht", "waiting"),
 		},
-		earliest: now - 600,
+		earliest: now - 900,
 		total:    2,
 	}
-	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
-	var resp historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
+	resp := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
 	if len(resp.BucketStarts) != 30 {
 		t.Fatalf("bucket_starts = %d, want 30 (the axis is still fully drawn)", len(resp.BucketStarts))
 	}
-	for _, b := range resp.Buckets {
-		if b.Count == 0 {
-			t.Fatalf("bucket ts=%d was emitted with count 0 — an empty bucket must be OMITTED "+
-				"(a gap), never sent as a zero that pulls the line to the axis", b.TS)
+	panel := panelFor(t, resp, "irrlicht")
+	for _, b := range panel.Buckets {
+		if b.Longest <= 0 && b.Peak <= 0 {
+			t.Fatalf("bucket ts=%d was emitted with longest=0 AND peak=0 — an empty bucket must be "+
+				"OMITTED (a gap), never sent as a pair of measured zeros", b.TS)
 		}
 	}
-	if len(resp.Buckets) != 1 {
-		t.Fatalf("got %d non-empty buckets, want 1 (both spans ended today)", len(resp.Buckets))
+	if len(panel.Buckets) != 1 {
+		t.Fatalf("got %d non-empty buckets, want 1 (both spans ended today)", len(panel.Buckets))
 	}
 
 	// The MUTATION: a builder that emits a point per bucket regardless. It has
 	// to differ from production here, or this test proves nothing.
 	denseBuckets := len(resp.BucketStarts)
-	if denseBuckets == len(resp.Buckets) {
-		t.Fatalf("the dense mutation (%d points) is indistinguishable from production (%d) on this "+
-			"fixture — it cannot show that empty buckets are dropped", denseBuckets, len(resp.Buckets))
+	if denseBuckets == len(panel.Buckets) {
+		t.Fatalf("the dense mutation (%d buckets) is indistinguishable from production (%d) on this "+
+			"fixture — it cannot show that empty buckets are dropped", denseBuckets, len(panel.Buckets))
 	}
 }
 
-// --- The sample floor -------------------------------------------------------
+// --- Concurrency comes from overlap -----------------------------------------
 
-// TestAutonomyDuration_SampleFloorMarksThinBuckets pins the floor and the fact
-// that a thin bucket is MARKED rather than hidden or smoothed.
+// TestAutonomyConcurrency_PeakFromOverlap checks the derivation against a
+// hand-built fixture whose answer can be read off the timeline by eye.
 //
-// Both boundary cases are derived from autonomySampleFloor rather than typed,
-// so moving the constant moves the test with it — and the third assertion is
-// the committed mutation: a build that dropped the floor entirely would report
-// thin=false on the under-floor bucket, which is what the second case catches.
-func TestAutonomyDuration_SampleFloorMarksThinBuckets(t *testing.T) {
-	now := time.Now().Unix()
-	// Put everything in "today" so both cases land in one bucket.
-	build := func(n int) *fakeAutonomyStore {
-		spans := make([]outbound.AutonomySpan, 0, n)
-		for i := 0; i < n; i++ {
-			spans = append(spans, spanEndingAt(now-int64(i)-1, int64(60+i*10), "irrlicht", "ready"))
-		}
-		return &fakeAutonomyStore{spans: spans, earliest: now - 86400, total: n}
+// One bucket-day holding four runs, laid out so the peak is unambiguous:
+//
+//	A  ├────────────────────────┤            (t+0    … t+4000)
+//	B      ├──────────┤                      (t+1000 … t+2000)
+//	C          ├──────────────┤              (t+1500 … t+3000)
+//	D                              ├────┤    (t+5000 … t+5500)
+//
+// Between t+1500 and t+2000 three runs overlap; nothing else in the day reaches
+// three. So the peak is 3, and the AVERAGE over the day is far below 1.
+//
+// The committed mutation is meanConcurrency below: the "report the average
+// instead" build the maintainer explicitly rejected, because an average over a
+// day is dominated by the hours nothing ran.
+func TestAutonomyConcurrency_PeakFromOverlap(t *testing.T) {
+	base := time.Now().Unix() - 40000
+	spans := []outbound.AutonomySpan{
+		{Start: base, End: base + 4000, Project: "irrlicht", Session: "a", Kind: session.AutonomyKindTopLevel},
+		{Start: base + 1000, End: base + 2000, Project: "irrlicht", Session: "b", Kind: session.AutonomyKindTopLevel},
+		{Start: base + 1500, End: base + 3000, Project: "irrlicht", Session: "c", Kind: session.AutonomyKindSubagent},
+		{Start: base + 5000, End: base + 5500, Project: "irrlicht", Session: "d", Kind: session.AutonomyKindTopLevel},
 	}
-	for _, tc := range []struct {
-		n        int
-		wantThin bool
-	}{
-		{autonomySampleFloor - 1, true},
-		{autonomySampleFloor, false},
-	} {
-		rec := getAutonomy(t, build(tc.n), "chart=autonomy_duration&window=30d")
-		var resp historyAutonomyDurationResponse
-		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-			t.Fatalf("decode: %v", err)
+	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: 4, earliest: base},
+		"chart=autonomy_projects&window=30d")
+	panel := panelFor(t, resp, "irrlicht")
+	if panel.Peak != 3 {
+		t.Fatalf("window peak = %d, want 3 (A, B and C overlap between +1500 and +2000)", panel.Peak)
+	}
+	if !panel.PeakSplit || panel.PeakTop != 2 || panel.PeakSub != 1 {
+		t.Errorf("peak split = %d + %d sub (known=%v), want 2 + 1 sub known — every run alive at the "+
+			"peak carried a kind, so the split is derivable", panel.PeakTop, panel.PeakSub, panel.PeakSplit)
+	}
+	var bucketPeak int
+	for _, b := range panel.Buckets {
+		if b.Peak > bucketPeak {
+			bucketPeak = b.Peak
 		}
-		if resp.SampleFloor != autonomySampleFloor {
-			t.Errorf("sample_floor = %d, want %d — clients render the floor, so it travels on the wire",
-				resp.SampleFloor, autonomySampleFloor)
-		}
-		if len(resp.Buckets) == 0 {
-			t.Fatalf("n=%d produced no buckets at all — a thin bucket must be MARKED, never hidden", tc.n)
-		}
-		var thinFound bool
-		var total int
-		for _, b := range resp.Buckets {
-			total += b.Count
-			if b.Thin {
-				thinFound = true
+	}
+	if bucketPeak != panel.Peak {
+		t.Errorf("highest bucket peak %d does not match the header's %d — the header must never report "+
+			"a number the bars below it contradict", bucketPeak, panel.Peak)
+	}
+
+	// The MUTATION: mean concurrency over the day, which is what "average" would
+	// produce. Total working-seconds / bucket width.
+	var workingSeconds int64
+	for _, s := range spans {
+		workingSeconds += s.Duration()
+	}
+	meanConcurrency := float64(workingSeconds) / 86400
+	if int(meanConcurrency+0.5) == panel.Peak {
+		t.Fatalf("the mean mutation (%.3f) rounds to the same figure as the peak (%d) on this fixture — "+
+			"it cannot show that the reported number is a PEAK", meanConcurrency, panel.Peak)
+	}
+}
+
+// TestAutonomyConcurrency_HandoverIsNotAnOverlap pins the half-open rule. A run
+// that ends exactly as the next begins is one session working through a chain of
+// turns, not two agents at once.
+//
+// The committed mutation is closedIntervals: apply starts before ends at the
+// same instant, which is the one-character ordering slip that would report every
+// back-to-back turn as concurrency 2.
+func TestAutonomyConcurrency_HandoverIsNotAnOverlap(t *testing.T) {
+	base := time.Now().Unix() - 40000
+	spans := []outbound.AutonomySpan{
+		{Start: base, End: base + 100, Project: "p", Session: "a", Kind: session.AutonomyKindTopLevel},
+		{Start: base + 100, End: base + 200, Project: "p", Session: "b", Kind: session.AutonomyKindTopLevel},
+	}
+	got := autonomyWindowPeak(spans, base, base+86400)
+	if got.peak != 1 {
+		t.Fatalf("peak = %d over two back-to-back runs, want 1 — a handover is not an overlap", got.peak)
+	}
+
+	// The MUTATION: the same sweep with starts applied before ends.
+	closed := 0
+	cur := 0
+	type ev struct {
+		ts    int64
+		delta int
+	}
+	evs := []ev{}
+	for _, s := range spans {
+		evs = append(evs, ev{s.Start, 1}, ev{s.End, -1})
+	}
+	for i := 0; i < len(evs); i++ { // starts first at a tie
+		for j := i + 1; j < len(evs); j++ {
+			if evs[j].ts < evs[i].ts || (evs[j].ts == evs[i].ts && evs[j].delta > evs[i].delta) {
+				evs[i], evs[j] = evs[j], evs[i]
 			}
 		}
-		if total != tc.n {
-			t.Errorf("n=%d: buckets hold %d spans in total, want %d — no sample may be dropped", tc.n, total, tc.n)
+	}
+	for _, e := range evs {
+		cur += e.delta
+		if cur > closed {
+			closed = cur
 		}
-		if thinFound != tc.wantThin {
-			t.Errorf("n=%d: thin=%v, want %v (floor is %d)", tc.n, thinFound, tc.wantThin, autonomySampleFloor)
+	}
+	if closed == got.peak {
+		t.Fatalf("the closed-interval mutation also reports %d — this fixture cannot show that ends "+
+			"are applied before starts", closed)
+	}
+}
+
+// TestAutonomyConcurrency_SplitOnlyWhereKindIsKnown pins the rule that keeps the
+// figure honest across the back-fill boundary: before 18 Aug 2026 most rows
+// carry session.AutonomyKindUnknown, and there is no way to recover which they
+// were. A split is shown only when EVERY run alive at the peak said which kind
+// it was.
+//
+// The committed mutation is unknownAsTopLevel below — reading a blank kind as
+// top-level, which is the exact failure session.AutonomyKindOrUnknown exists to
+// prevent: it would report "5 (5 + 0 sub)" over data that never said.
+func TestAutonomyConcurrency_SplitOnlyWhereKindIsKnown(t *testing.T) {
+	base := time.Now().Unix() - 40000
+	spans := []outbound.AutonomySpan{
+		{Start: base, End: base + 1000, Project: "p", Session: "a", Kind: session.AutonomyKindTopLevel},
+		{Start: base + 100, End: base + 900, Project: "p", Session: "b", Kind: session.AutonomyKindUnknown},
+	}
+	got := autonomyWindowPeak(spans, base, base+86400)
+	if got.peak != 2 {
+		t.Fatalf("peak = %d, want 2 — an unclassified run still counts towards how many were working", got.peak)
+	}
+	if got.splitKnown {
+		t.Fatalf("split reported as known (%d + %d sub) over a window holding an unclassified run — "+
+			"the total must be shown alone rather than a guess", got.topLevel, got.subagent)
+	}
+
+	// The MUTATION: resolve a blank/unknown kind to top-level.
+	unknownAsTopLevel := func(kind string) string {
+		if kind == session.AutonomyKindSubagent {
+			return session.AutonomyKindSubagent
+		}
+		return session.AutonomyKindTopLevel
+	}
+	mutated := make([]outbound.AutonomySpan, len(spans))
+	copy(mutated, spans)
+	for i := range mutated {
+		mutated[i].Kind = unknownAsTopLevel(mutated[i].Kind)
+	}
+	if m := autonomyWindowPeak(mutated, base, base+86400); !m.splitKnown {
+		t.Fatalf("the unknown-as-top-level mutation still reports the split as unknown — this fixture " +
+			"cannot show that an unclassified run suppresses the split")
+	}
+
+	// And the positive half: once both rows say what they were, the split is
+	// shown. Absence of a finding and inability to look must not look alike.
+	spans[1].Kind = session.AutonomyKindSubagent
+	known := autonomyWindowPeak(spans, base, base+86400)
+	if !known.splitKnown || known.topLevel != 1 || known.subagent != 1 {
+		t.Errorf("split = %d + %d sub (known=%v), want 1 + 1 sub known", known.topLevel, known.subagent, known.splitKnown)
+	}
+}
+
+// --- Five panels, ranked by total autonomous time ---------------------------
+
+// TestAutonomy_DrawsFivePanelsAndNamesTheRest pins the section's shape: exactly
+// autonomyPanelCount panels, and everything below them named as a count rather
+// than dropped in silence.
+func TestAutonomy_DrawsFivePanelsAndNamesTheRest(t *testing.T) {
+	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{}
+	// Eight projects, each with a distinct total so the ranking is unambiguous.
+	for i := 1; i <= 8; i++ {
+		spans = append(spans, spanEndingAt(now-int64(i)*10, int64(i)*100, fmt.Sprintf("p%d", i), "ready"))
+	}
+	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: len(spans), earliest: now - 10000},
+		"chart=autonomy_projects&window=30d")
+	if len(resp.Panels) != autonomyPanelCount {
+		t.Fatalf("drew %d panels, want %d", len(resp.Panels), autonomyPanelCount)
+	}
+	if resp.PanelLimit != autonomyPanelCount {
+		t.Errorf("panel_limit = %d, want %d — clients render what they are sent rather than re-deciding "+
+			"the number", resp.PanelLimit, autonomyPanelCount)
+	}
+	if resp.MoreProjects != 3 {
+		t.Errorf("more_projects = %d, want 3 — an omission nothing mentions is indistinguishable from a "+
+			"project that never ran", resp.MoreProjects)
+	}
+	if resp.Summary.Projects != 8 {
+		t.Errorf("summary projects = %d, want 8 (the summary counts every project, not the drawn five)",
+			resp.Summary.Projects)
+	}
+	// p8 has the most seconds, p4 the fifth-most.
+	want := []string{"p8", "p7", "p6", "p5", "p4"}
+	for i, p := range resp.Panels {
+		if p.Project != want[i] {
+			t.Fatalf("panel %d = %q, want %q (order is most autonomous time first)", i, p.Project, want[i])
 		}
 	}
 }
 
-// TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes states the reason
-// the floor exists, as an executable claim rather than a comment: under the
-// floor the p95 IS the max and the p5 IS the min for a small enough sample, so
-// the outer lines stop being percentiles.
-func TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes(t *testing.T) {
+// TestAutonomy_RanksByTotalTimeNotLongestRun is the judgement call made
+// executable: one lucky overnight run must not promote a project nobody has
+// touched, over the project that worked every day.
+//
+// The committed mutation is byLongestRun below — the ranking this test exists to
+// refuse. `steady` has fifty 1-hour runs (50h total, 1h longest); `lucky` has one
+// 11-hour run (11h total, 11h longest). Under production `steady` outranks
+// `lucky`; under the mutation the order flips.
+func TestAutonomy_RanksByTotalTimeNotLongestRun(t *testing.T) {
 	now := time.Now().Unix()
 	spans := []outbound.AutonomySpan{
-		spanEndingAt(now-10, 100, "irrlicht", "ready"),
-		spanEndingAt(now-20, 200, "irrlicht", "ready"),
-		spanEndingAt(now-30, 300, "irrlicht", "waiting"),
+		spanEndingAt(now-3600, 11*3600, "lucky", "ready"),
 	}
-	rec := getAutonomy(t, &fakeAutonomyStore{spans: spans, total: 3, earliest: now - 300},
-		"chart=autonomy_duration&window=30d")
-	var resp historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
+	for i := 0; i < 50; i++ {
+		spans = append(spans, spanEndingAt(now-int64(i)*4000-100, 3600, "steady", "ready"))
 	}
-	if len(resp.Buckets) != 1 {
-		t.Fatalf("want exactly 1 non-empty bucket, got %d", len(resp.Buckets))
+	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: len(spans), earliest: now - 300000},
+		"chart=autonomy_projects&window=30d")
+	if len(resp.Panels) != 2 {
+		t.Fatalf("drew %d panels, want 2", len(resp.Panels))
 	}
-	b := resp.Buckets[0]
-	if !b.Thin {
-		t.Fatalf("a 3-sample bucket must be thin (floor %d)", autonomySampleFloor)
+	if resp.Panels[0].Project != "steady" {
+		t.Fatalf("panels ranked %q first; want steady (50h of autonomous time against lucky's 11h)",
+			resp.Panels[0].Project)
 	}
-	// R-7 over {100,200,300}: p95 = 200 + 0.9*100 = 290; p5 = 100 + 0.1*100 = 110.
-	if math.Abs(b.P95-290) > 1e-9 || math.Abs(b.P5-110) > 1e-9 {
-		t.Errorf("p95/p5 = %v/%v, want 290/110 (R-7 over 3 samples)", b.P95, b.P5)
+
+	// The MUTATION: rank by longest run instead of total time.
+	byLongestRun := func(a, b historyAutonomyPanel) bool { return a.Longest > b.Longest }
+	if !byLongestRun(panelFor(t, resp, "lucky"), panelFor(t, resp, "steady")) {
+		t.Fatalf("the longest-run mutation ranks these two the same way production does — this fixture " +
+			"cannot show that the ranking is by TOTAL autonomous time")
 	}
-	if b.Max != 300 || b.Min != 100 {
-		t.Errorf("max/min = %v/%v, want 300/100", b.Max, b.Min)
-	}
-	if b.P95 <= b.Max*0.9 {
-		t.Errorf("p95 %v is not pinned near the max %v — the reason the floor exists has changed", b.P95, b.Max)
+	// …and the wire carries the rank key, so the order can be checked rather
+	// than trusted.
+	if resp.Panels[0].TotalSeconds <= resp.Panels[1].TotalSeconds {
+		t.Errorf("total_seconds is not descending across the panels (%v then %v)",
+			resp.Panels[0].TotalSeconds, resp.Panels[1].TotalSeconds)
 	}
 }
 
-// --- Percentiles are computed daemon-side -----------------------------------
+// --- A still-running run counts towards the longest, and is marked ----------
 
-func TestAutonomyDuration_SummaryPercentilesAreServerComputed(t *testing.T) {
+func TestAutonomy_RunningRunCountsTowardsLongestAndIsMarked(t *testing.T) {
 	now := time.Now().Unix()
-	// The same 12-sample fixture stats' own test uses, so a convention change
-	// fails in both places rather than only the one nobody reads.
-	spans := make([]outbound.AutonomySpan, 0, 12)
-	for i := 1; i <= 12; i++ {
-		spans = append(spans, spanEndingAt(now-int64(i), int64(i*100), "irrlicht", "ready"))
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-100, 600, "irrlicht", "ready"),
+		{Start: now - 3*3600, End: now, Project: "irrlicht", Session: "live",
+			Kind: session.AutonomyKindTopLevel, Running: true},
 	}
-	rec := getAutonomy(t, &fakeAutonomyStore{spans: spans, total: 12, earliest: now - 1200},
-		"chart=autonomy_duration&window=30d")
-	var resp historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
+	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: 2, earliest: now - 3*3600},
+		"chart=autonomy_projects&window=30d")
+	panel := panelFor(t, resp, "irrlicht")
+	if panel.Longest != float64(3*3600) {
+		t.Fatalf("longest = %v, want %d — a run that has already lasted three hours IS the longest run, "+
+			"unlike its old effect on a percentile", panel.Longest, 3*3600)
 	}
-	if resp.Summary.Count != 12 {
-		t.Fatalf("summary count = %d, want 12", resp.Summary.Count)
+	if !panel.LongestRunning {
+		t.Error("the longest run has not ended and must be marked: its length is a floor, not a measurement")
 	}
-	if math.Abs(resp.Summary.P95-1145) > 1e-9 {
-		t.Errorf("summary p95 = %v, want 1145 (R-7 — nearest rank would give 1200)", resp.Summary.P95)
+	if resp.Summary.Longest != float64(3*3600) || !resp.Summary.LongestRunning {
+		t.Errorf("summary longest = %v (running=%v), want %d running",
+			resp.Summary.Longest, resp.Summary.LongestRunning, 3*3600)
 	}
-	if resp.Summary.Min != 100 || resp.Summary.Max != 1200 {
-		t.Errorf("summary min/max = %v/%v, want 100/1200 — the true extremes stay figures, not lines",
-			resp.Summary.Min, resp.Summary.Max)
+	if resp.Summary.LongestProject != "irrlicht" {
+		t.Errorf("summary longest_project = %q, want irrlicht", resp.Summary.LongestProject)
+	}
+	var marked bool
+	for _, b := range panel.Buckets {
+		if b.Running {
+			marked = true
+		}
+	}
+	if !marked {
+		t.Error("no bucket carries the running mark, so the panel's line would draw a floor as final")
 	}
 }
 
@@ -338,112 +529,47 @@ func TestAutonomy_EmptyWindowStillReportsWhenCollectionStarted(t *testing.T) {
 	now := time.Now().Unix()
 	// Nothing in the window, but the log has been collecting since yesterday.
 	store := &fakeAutonomyStore{earliest: now - 86400, total: 7}
-	for _, chart := range []string{chartAutonomyDuration, chartAutonomySpans} {
-		rec := getAutonomy(t, store, "chart="+chart)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("chart=%s → %d, want 200", chart, rec.Code)
-		}
-		var probe struct {
-			Earliest int64 `json:"earliest_span"`
-			Total    int   `json:"total_recorded"`
-		}
-		if err := json.Unmarshal(rec.Body.Bytes(), &probe); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if probe.Earliest != now-86400 {
-			t.Errorf("chart=%s earliest_span = %d, want %d — without it an empty view cannot "+
-				"distinguish \"nothing ran\" from \"this feature had not shipped yet\"",
-				chart, probe.Earliest, now-86400)
-		}
-		if probe.Total != 7 {
-			t.Errorf("chart=%s total_recorded = %d, want 7", chart, probe.Total)
-		}
+	resp := decodeAutonomy(t, store, "chart=autonomy_projects")
+	if resp.EarliestSpan != now-86400 {
+		t.Errorf("earliest_span = %d, want %d — without it an empty view cannot distinguish "+
+			"\"nothing ran\" from \"this feature had not shipped yet\"", resp.EarliestSpan, now-86400)
+	}
+	if resp.TotalRecorded != 7 {
+		t.Errorf("total_recorded = %d, want 7", resp.TotalRecorded)
+	}
+	if len(resp.Panels) != 0 {
+		t.Errorf("drew %d panels over an empty window, want 0", len(resp.Panels))
 	}
 }
 
 func TestAutonomy_NilStoreServesEmptyButValid(t *testing.T) {
-	for _, chart := range []string{chartAutonomyDuration, chartAutonomySpans} {
-		rec := getAutonomy(t, nil, "chart="+chart)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("chart=%s with no store → %d, want 200", chart, rec.Code)
-		}
-	}
-}
-
-// --- The strip payload ------------------------------------------------------
-
-func TestAutonomySpans_RowOrderAndFields(t *testing.T) {
-	now := time.Now().Unix()
-	store := &fakeAutonomyStore{
-		spans: []outbound.AutonomySpan{
-			spanEndingAt(now-100, 60, "articles", "ready"),
-			spanEndingAt(now-200, 3600, "irrlicht", "waiting"),
-			spanEndingAt(now-300, 120, "articles", "error"),
-		},
-		earliest: now - 4000,
-		total:    3,
-	}
-	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
-	var resp historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(resp.Spans) != 3 {
-		t.Fatalf("spans = %d, want 3", len(resp.Spans))
-	}
-	// irrlicht has 3600 autonomous seconds, articles 180 — busiest row first.
-	if len(resp.Projects) != 2 || resp.Projects[0] != "irrlicht" {
-		t.Errorf("projects = %v, want irrlicht first (most autonomous seconds)", resp.Projects)
-	}
-	if resp.Spans[0].Reason == "" {
-		t.Error("span rows must carry their end reason — it is the signal the strip draws")
-	}
-	if store.lastQuery.Limit != autonomySpanLimit {
-		t.Errorf("strip query Limit = %d, want %d", store.lastQuery.Limit, autonomySpanLimit)
-	}
-	if store.lastQuery.End-store.lastQuery.Start != 24*3600 {
-		t.Errorf("window=24h asked the store for %ds, want 86400",
-			store.lastQuery.End-store.lastQuery.Start)
-	}
-}
-
-func TestAutonomySpans_TruncationIsReported(t *testing.T) {
-	store := &fakeAutonomyStore{truncated: true, total: 99999}
-	rec := getAutonomy(t, store, "chart=autonomy_spans&window=12mo")
-	var resp historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if !resp.Truncated {
-		t.Error("a clipped strip must say so — a partial window drawn as if whole is exactly the " +
-			"silent-wrong-number failure this feature exists to avoid")
-	}
-}
-
-func TestAutonomy_DefaultWindows(t *testing.T) {
-	store := &fakeAutonomyStore{}
-	rec := getAutonomy(t, store, "chart=autonomy_spans")
-	var spans historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &spans); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if spans.Window != "24h" {
-		t.Errorf("default strip window = %q, want 24h", spans.Window)
-	}
-	rec = getAutonomy(t, store, "chart=autonomy_duration")
-	var dur historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &dur); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if dur.Window != "30d" {
-		t.Errorf("default duration window = %q, want 30d", dur.Window)
+	rec := getAutonomy(t, nil, "chart="+chartAutonomyProjects)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no store → %d, want 200", rec.Code)
 	}
 }
 
 func TestAutonomy_StoreErrorIs500(t *testing.T) {
 	store := &fakeAutonomyStore{err: fmt.Errorf("disk on fire")}
-	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	rec := getAutonomy(t, store, "chart=autonomy_projects&window=30d")
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("store error → %d, want 500", rec.Code)
+	}
+}
+
+// TestAutonomy_ReadIsUnlimited pins the read the concurrency figure depends on.
+// The run strip capped its read because it drew one column per run; a peak
+// computed from a clipped span list is simply wrong, silently, and always
+// downwards.
+func TestAutonomy_ReadIsUnlimited(t *testing.T) {
+	store := &fakeAutonomyStore{}
+	_ = decodeAutonomy(t, store, "chart=autonomy_projects&window=1y")
+	if store.lastQuery.Limit != 0 {
+		t.Errorf("store query Limit = %d, want 0 (unlimited) — a clipped read would understate every "+
+			"concurrency peak with nothing on screen saying so", store.lastQuery.Limit)
+	}
+	if store.lastQuery.End-store.lastQuery.Start != 52*7*86400 {
+		t.Errorf("window=1y asked the store for %ds, want %d",
+			store.lastQuery.End-store.lastQuery.Start, 52*7*86400)
 	}
 }

--- a/core/cmd/irrlichd/history_autonomy_kinds_test.go
+++ b/core/cmd/irrlichd/history_autonomy_kinds_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"encoding/json"
 	"testing"
 
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
 
-// The API half of the run-kind classification (#1905 subagents), retargeted at
-// the FIELD after the filter was removed (#1905 recording).
+// The API half of the run-kind classification (#1905 subagents), retargeted
+// twice: at the FIELD after the filter was removed (#1905 recording), and now at
+// the CONCURRENCY SPLIT, which is the first thing that actually renders it.
 //
 // The classification is still real data and every row still carries it. What no
 // longer exists is a mode: subagent runs are always counted, so a payload has
@@ -22,12 +22,9 @@ import (
 // bad request.
 func TestAutonomy_CountsEveryRunWhateverTheQueryAsksFor(t *testing.T) {
 	queries := []string{
-		"chart=autonomy_duration&window=30d",
-		"chart=autonomy_duration&window=30d&include_subagents=false",
-		"chart=autonomy_duration&window=30d&include_subagents=true",
-		"chart=autonomy_spans&window=24h",
-		"chart=autonomy_spans&window=24h&include_subagents=false",
-		"chart=autonomy_spans&window=24h&include_subagents=true",
+		"chart=autonomy_projects&window=30d",
+		"chart=autonomy_projects&window=30d&include_subagents=false",
+		"chart=autonomy_projects&window=30d&include_subagents=true",
 	}
 	for _, q := range queries {
 		t.Run(q, func(t *testing.T) {
@@ -48,89 +45,49 @@ func TestAutonomy_CountsEveryRunWhateverTheQueryAsksFor(t *testing.T) {
 			if store.lastQuery != (outbound.AutonomySpanQuery{
 				Start: store.lastQuery.Start,
 				End:   store.lastQuery.End,
-				Limit: store.lastQuery.Limit,
 			}) {
-				t.Fatalf("query = %+v — it carries something beyond the window and the limit, "+
-					"which is how a per-request filter would come back", store.lastQuery)
+				t.Fatalf("query = %+v — it carries something beyond the window, which is how a "+
+					"per-request filter would come back", store.lastQuery)
 			}
 		})
 	}
 }
 
-// The payload STATES the window's census on both elements, so a client can say
-// how much of a window was subagent work without recomputing it from rows it
-// does not have (the duration chart carries no rows at all).
-func TestAutonomyPayloadsCarryTheCensus(t *testing.T) {
+// The payload STATES the window's census, so a client can say how much of a
+// window was subagent work without recomputing it from rows it does not have —
+// and the panels carry no rows at all.
+func TestAutonomyPayloadCarriesTheCensus(t *testing.T) {
 	kinds := outbound.AutonomySpanKinds{TopLevel: 7, Subagent: 5, Unknown: 3}
-
-	t.Run("duration", func(t *testing.T) {
-		store := &fakeAutonomyStore{kinds: kinds}
-		rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
-		var got historyAutonomyDurationResponse
-		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.Kinds.Subagent != 5 || got.Kinds.Unknown != 3 || got.Kinds.TopLevel != 7 {
-			t.Fatalf("kinds = %+v, want the store's census verbatim", got.Kinds)
-		}
-	})
-
-	t.Run("spans", func(t *testing.T) {
-		store := &fakeAutonomyStore{kinds: kinds}
-		rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
-		var got historyAutonomySpansResponse
-		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		if got.Kinds.Subagent != 5 {
-			t.Fatalf("subagent count = %d, want 5", got.Kinds.Subagent)
-		}
-	})
+	got := decodeAutonomy(t, &fakeAutonomyStore{kinds: kinds}, "chart=autonomy_projects&window=30d")
+	if got.Kinds.Subagent != 5 || got.Kinds.Unknown != 3 || got.Kinds.TopLevel != 7 {
+		t.Fatalf("kinds = %+v, want the store's census verbatim", got.Kinds)
+	}
 }
 
-// Every span row on the wire carries a RESOLVED kind — never a blank the client
-// would have to interpret. A row the store read out of a pre-classification log
-// ships as the literal word "unknown", so no client has to decide for itself
-// what an absent field means, and none can decide differently from the other.
-func TestAutonomySpanRowsCarryAResolvedKind(t *testing.T) {
-	store := &fakeAutonomyStore{
-		spans: []outbound.AutonomySpan{
-			{Start: 100, End: 200, Project: "p", Session: "legacy", Reason: session.StateReady},
-			{Start: 300, End: 400, Project: "p", Session: "child", Reason: session.StateReady,
-				Kind: session.AutonomyKindSubagent, Parent: "top-1"},
-			{Start: 500, End: 600, Project: "p", Session: "top", Reason: session.StateReady,
-				Kind: session.AutonomyKindTopLevel},
-		},
+// A blank `kind` on a row read out of a pre-classification log RESOLVES to
+// unknown, never to top-level — the one thing it must not silently mean. The
+// resolution used to be visible as a per-row field on the strip; the strip is
+// gone, so the place it now shows is the concurrency split, which must refuse to
+// split a peak that a blank row was alive for.
+func TestAutonomy_BlankKindResolvesToUnknownNotTopLevel(t *testing.T) {
+	base := int64(1_700_000_000)
+	spans := []outbound.AutonomySpan{
+		{Start: base, End: base + 1000, Project: "p", Session: "legacy"}, // no Kind at all
+		{Start: base + 100, End: base + 900, Project: "p", Session: "top",
+			Kind: session.AutonomyKindTopLevel},
 	}
-	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
-	var got historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
+	got := autonomyWindowPeak(spans, base, base+86400)
+	if got.peak != 2 {
+		t.Fatalf("peak = %d, want 2", got.peak)
 	}
-	if len(got.Spans) != 3 {
-		t.Fatalf("got %d spans, want 3", len(got.Spans))
+	if got.splitKnown {
+		t.Fatalf("a blank kind was treated as classifiable (%d + %d sub) — reading absence as "+
+			"top-level is the one failure session.AutonomyKindOrUnknown exists to prevent",
+			got.topLevel, got.subagent)
 	}
-	want := []string{session.AutonomyKindUnknown, session.AutonomyKindSubagent, session.AutonomyKindTopLevel}
-	for i, row := range got.Spans {
-		if row.Kind != want[i] {
-			t.Fatalf("span %d (%s) kind = %q, want %q — a blank must reach no client",
-				i, row.Session, row.Kind, want[i])
-		}
-	}
-	if got.Spans[1].Parent != "top-1" {
-		t.Fatalf("subagent row parent = %q, want %q", got.Spans[1].Parent, "top-1")
-	}
-	// A raw check on the JSON: `kind` is not omitempty, so even the unknown row
-	// carries the key. A client testing for presence must never see a hole.
-	var raw struct {
-		Spans []map[string]any `json:"spans"`
-	}
-	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
-		t.Fatalf("decode raw: %v", err)
-	}
-	for i, row := range raw.Spans {
-		if _, present := row["kind"]; !present {
-			t.Fatalf("span %d has no `kind` key on the wire: %v", i, row)
-		}
+	// And the resolution itself, stated where a reader can check it.
+	if session.AutonomyKindOrUnknown("") != session.AutonomyKindUnknown {
+		t.Fatalf("a blank kind resolves to %q, want %q",
+			session.AutonomyKindOrUnknown(""), session.AutonomyKindUnknown)
 	}
 }

--- a/core/cmd/irrlichd/history_autonomy_measurement_test.go
+++ b/core/cmd/irrlichd/history_autonomy_measurement_test.go
@@ -11,12 +11,17 @@ import (
 // The measurement half of #1905's recording fix, at the API: what a run whose
 // duration is a FLOOR rather than a measurement does to the figures.
 //
-// Two kinds of floor and they are treated differently on purpose:
+// THE ANSWER CHANGED WITH THE CHART, and the change is deliberate rather than a
+// relaxation. Against a percentile a running run had to be excluded: folding a
+// floor into a p95 as though it were final always shortens, and shortens the
+// longest runs hardest. Against a MAXIMUM there is nothing to distort — "the
+// longest run has already lasted three hours" is a true statement, and excluding
+// it would make the longest run on the machine the one thing the section cannot
+// show. So it counts, and it is marked.
 //
-//   - a RUNNING run has not ended, so its length is unknowable — it is counted
-//     and drawn, and kept out of every percentile;
-//   - a LOWER-BOUND START has ended, and its length is known to within the
-//     daemon's own uptime — it is a sample, and it is marked.
+// A LOWER-BOUND START has ended, and its length is known to within the daemon's
+// own uptime. It counted before and counts now; dropping those is the
+// under-count this whole change exists to end.
 //
 // Mutation fixtures: neither had a "before the fix" to run red against, so each
 // drives the wrong answer into its own assertion.
@@ -28,59 +33,67 @@ func runningSpan(end, length int64, project string) outbound.AutonomySpan {
 	return s
 }
 
-// A RUNNING RUN IS NOT A PERCENTILE SAMPLE.
+// A RUNNING RUN IS THE LONGEST RUN WHEN IT IS THE LONGEST RUN — and it says so.
 //
-// MUTATION CAUGHT: folding it in. The fixture is built so the wrong answer is a
-// different number rather than a rounding difference — four finished 60s runs
-// and one 4-hour run still going. Counted, the p95 leaps from 60 to over 11000;
-// left out, it stays 60 and the run is reported separately as still going.
-func TestAutonomyDuration_RunningRunIsCountedButNotAveraged(t *testing.T) {
+// MUTATION CAUGHT: excludeRunning below, the rule the percentile chart needed
+// and this one does not. The fixture is built so the wrong answer is a different
+// number rather than a rounding difference — four finished 60 s runs and one
+// 4-hour run still going. Excluded, the longest collapses from 14400 to 60.
+func TestAutonomy_RunningRunIsTheLongestAndIsMarked(t *testing.T) {
 	const end = 1_700_000_000
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(end-4000, 60, "p", session.StateReady),
+		spanEndingAt(end-3000, 60, "p", session.StateReady),
+		spanEndingAt(end-2000, 60, "p", session.StateReady),
+		spanEndingAt(end-1000, 60, "p", session.StateReady),
+		runningSpan(end-10, 4*3600, "p"),
+	}
 	store := &fakeAutonomyStore{
-		spans: []outbound.AutonomySpan{
-			spanEndingAt(end-4000, 60, "p", session.StateReady),
-			spanEndingAt(end-3000, 60, "p", session.StateReady),
-			spanEndingAt(end-2000, 60, "p", session.StateReady),
-			spanEndingAt(end-1000, 60, "p", session.StateReady),
-			runningSpan(end-10, 4*3600, "p"),
-		},
+		spans:       spans,
 		measurement: outbound.AutonomySpanMeasurement{Running: 1},
 	}
 
-	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
-	var got historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	panel := panelFor(t, got, "p")
+	if panel.Longest != 4*3600 {
+		t.Fatalf("longest = %.0f, want %d — a run three hours in is the longest run, whatever a "+
+			"percentile would have done with it", panel.Longest, 4*3600)
+	}
+	if !panel.LongestRunning {
+		t.Fatal("the longest run has not ended and carries no mark — a floor drawn as a measurement")
+	}
+	// …and the payload still says how many runs are floors, which is what lets
+	// both clients state it in words rather than leaving it to the mark.
+	if got.Measurement.Running != 1 {
+		t.Errorf("measurement.running = %d, want 1", got.Measurement.Running)
 	}
 
-	if got.Summary.Count != 4 {
-		t.Fatalf("summary count = %d, want 4 — a run that has not ended is a LOWER BOUND on its own "+
-			"length, and folding it into a percentile treats a floor as a measurement", got.Summary.Count)
-	}
-	if got.Summary.P95 != 60 || got.Summary.Max != 60 {
-		t.Fatalf("p95/max = %.0f/%.0f, want 60/60 — the 4h run still in progress reached the "+
-			"envelope", got.Summary.P95, got.Summary.Max)
-	}
-	// …but it is not hidden. The payload says it is there, which is what lets
-	// both clients state the gap between what is drawn and what is measured.
-	if got.Measurement.Running != 1 {
-		t.Errorf("measurement.running = %d, want 1 — a running run excluded from the percentiles "+
-			"and not reported anywhere is a run that was silently dropped", got.Measurement.Running)
-	}
-	for _, b := range got.Buckets {
-		if b.Max > 60 {
-			t.Fatalf("bucket at %d has max %.0f — the running run reached a bucket envelope", b.TS, b.Max)
+	// The MUTATION: the percentile chart's exclusion rule, applied here.
+	excludeRunning := func(in []outbound.AutonomySpan) float64 {
+		var longest float64
+		for _, s := range in {
+			if s.Running {
+				continue
+			}
+			if d := float64(s.Duration()); d > longest {
+				longest = d
+			}
 		}
+		return longest
+	}
+	if excludeRunning(spans) == panel.Longest {
+		t.Fatalf("the exclude-running mutation reports the same longest (%.0f) on this fixture — it "+
+			"cannot show that a run in progress counts", panel.Longest)
 	}
 }
 
-// A LOWER-BOUND START IS A SAMPLE. It is a finished run whose start Irrlicht
-// did not see, and dropping such runs is the under-count this whole change
-// exists to end — a restart re-discovers every live session as one of these.
+// A LOWER-BOUND START IS A SAMPLE. It is a finished run whose start Irrlicht did
+// not see, and dropping such runs is the under-count this whole change exists to
+// end — a restart re-discovers every live session as one of these.
 //
-// MUTATION CAUGHT: treating it like a running run (excluding it) takes the
-// count from 2 back to 1 and removes the longest run in the window.
-func TestAutonomyDuration_LowerBoundStartIsStillASample(t *testing.T) {
+// MUTATION CAUGHT: treating it like a run to drop removes the longest run in the
+// window and takes the run count from 2 to 1.
+func TestAutonomy_LowerBoundStartIsStillCounted(t *testing.T) {
 	const end = 1_700_000_000
 	bounded := spanEndingAt(end-100, 7200, "p", session.AutonomyReasonUnknown)
 	bounded.StartLowerBound = true
@@ -89,17 +102,14 @@ func TestAutonomyDuration_LowerBoundStartIsStillASample(t *testing.T) {
 		measurement: outbound.AutonomySpanMeasurement{LowerBoundStart: 1},
 	}
 
-	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
-	var got historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	panel := panelFor(t, got, "p")
+	if panel.Runs != 2 {
+		t.Fatalf("runs = %d, want 2 — a run whose start was not measured has still FINISHED, and "+
+			"dropping it is the under-count this fix is about", panel.Runs)
 	}
-	if got.Summary.Count != 2 {
-		t.Fatalf("summary count = %d, want 2 — a run whose start was not measured has still "+
-			"FINISHED, and dropping it is the under-count this fix is about", got.Summary.Count)
-	}
-	if got.Summary.Max != 7200 {
-		t.Errorf("max = %.0f, want 7200", got.Summary.Max)
+	if panel.Longest != 7200 {
+		t.Errorf("longest = %.0f, want 7200", panel.Longest)
 	}
 	if got.Measurement.LowerBoundStart != 1 {
 		t.Errorf("measurement.start_lower_bound = %d, want 1 — the panel cannot mark what the "+
@@ -107,63 +117,25 @@ func TestAutonomyDuration_LowerBoundStartIsStillASample(t *testing.T) {
 	}
 }
 
-// Every span row carries both marks, so a client can tell a run in progress
-// from a finished one without recomputing anything.
-//
-// MUTATION CAUGHT: dropping either flag from the row leaves the strip drawing a
-// still-running run exactly like a completed one.
-func TestAutonomySpanRows_CarryRunningAndLowerBound(t *testing.T) {
+// The panel-level marks are omitempty, so a project whose longest run finished
+// carries no `longest_running` key at all — a client testing for presence must
+// not see one on every panel.
+func TestAutonomyPanel_RunningMarkIsAbsentWhenNothingIsRunning(t *testing.T) {
 	const end = 1_700_000_000
-	bounded := spanEndingAt(end-500, 300, "p", session.StateReady)
-	bounded.Session = "bounded"
-	bounded.StartLowerBound = true
-	running := runningSpan(end-10, 900, "p")
-	running.Session = "running"
-
 	store := &fakeAutonomyStore{
-		spans: []outbound.AutonomySpan{
-			spanEndingAt(end-900, 60, "p", session.StateReady),
-			bounded,
-			running,
-		},
+		spans: []outbound.AutonomySpan{spanEndingAt(end-1000, 600, "p", session.StateReady)},
 	}
-	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
-	var got historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if len(got.Spans) != 3 {
-		t.Fatalf("got %d spans, want 3", len(got.Spans))
-	}
-	byID := map[string]historyAutonomySpanRow{}
-	for _, r := range got.Spans {
-		byID[r.Session] = r
-	}
-	if !byID["running"].Running {
-		t.Error("the in-progress row is not marked `running` on the wire")
-	}
-	if byID["running"].StartLowerBound {
-		t.Error("the in-progress row claims an unmeasured start it does not have")
-	}
-	if !byID["bounded"].StartLowerBound {
-		t.Error("the unmeasured-start row lost its mark on the wire")
-	}
-	if byID["bounded"].Running {
-		t.Error("a finished row is marked running")
-	}
-	// The two marks are omitempty, so an ordinary finished run carries neither
-	// key — a client testing for presence must not see one on every row.
+	rec := getAutonomy(t, store, "chart=autonomy_projects&window=30d")
 	var raw struct {
-		Spans []map[string]any `json:"spans"`
+		Panels []map[string]any `json:"panels"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
 		t.Fatalf("decode raw: %v", err)
 	}
-	plain := raw.Spans[0]
-	if _, present := plain["running"]; present {
-		t.Errorf("an ordinary finished run carries a `running` key: %v", plain)
+	if len(raw.Panels) != 1 {
+		t.Fatalf("got %d panels, want 1", len(raw.Panels))
 	}
-	if _, present := plain["start_lower_bound"]; present {
-		t.Errorf("an ordinary finished run carries a `start_lower_bound` key: %v", plain)
+	if _, present := raw.Panels[0]["longest_running"]; present {
+		t.Errorf("a finished project carries a `longest_running` key: %v", raw.Panels[0])
 	}
 }

--- a/core/cmd/irrlichd/history_autonomy_provenance_test.go
+++ b/core/cmd/irrlichd/history_autonomy_provenance_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
@@ -19,29 +18,10 @@ import (
 // is exactly the "wrong number with nothing on screen saying so" this feature
 // exists to avoid.
 
-func decodeAutonomyDuration(t *testing.T, rec *httptest.ResponseRecorder) historyAutonomyDurationResponse {
-	t.Helper()
-	var resp historyAutonomyDurationResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode duration payload: %v", err)
-	}
-	return resp
-}
-
-func decodeAutonomySpans(t *testing.T, rec *httptest.ResponseRecorder) historyAutonomySpansResponse {
-	t.Helper()
-	var resp historyAutonomySpansResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode spans payload: %v", err)
-	}
-	return resp
-}
-
-// Both Autonomy payloads must carry the provenance block, and the SAME one:
-// the section draws two elements over one data source, and a strip claiming
-// "9 reconstructed" under a chart claiming something else is worse than
-// neither claiming anything.
-func TestAutonomyProvenance_IsEchoedByBothElements(t *testing.T) {
+// The panels payload carries the provenance block verbatim: the section draws
+// five panels over one data source, and a figure whose provenance is stated
+// once for the whole stack cannot disagree with itself panel by panel.
+func TestAutonomyProvenance_IsEchoedOnTheWire(t *testing.T) {
 	now := time.Now().Unix()
 	store := &fakeAutonomyStore{
 		spans:    []outbound.AutonomySpan{spanEndingAt(now-3600, 300, "proj", session.StateReady)},
@@ -54,17 +34,12 @@ func TestAutonomyProvenance_IsEchoedByBothElements(t *testing.T) {
 		},
 	}
 
-	duration := decodeAutonomyDuration(t, getAutonomy(t, store, "chart=autonomy_duration&window=30d"))
-	spans := decodeAutonomySpans(t, getAutonomy(t, store, "chart=autonomy_spans&window=24h"))
-
-	if !reflect.DeepEqual(duration.Provenance, spans.Provenance) {
-		t.Fatalf("the two elements disagree about provenance: %+v vs %+v", duration.Provenance, spans.Provenance)
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	if got.Provenance.Reconstructed != 9 || got.Provenance.CostDerived != 4 {
+		t.Fatalf("provenance = %+v, want the store's counts echoed unchanged", got.Provenance)
 	}
-	if duration.Provenance.Reconstructed != 9 || duration.Provenance.CostDerived != 4 {
-		t.Fatalf("provenance = %+v, want the store's counts echoed unchanged", duration.Provenance)
-	}
-	if duration.Provenance.LiveSince != now-7200 {
-		t.Fatalf("LiveSince = %d, want %d", duration.Provenance.LiveSince, now-7200)
+	if got.Provenance.LiveSince != now-7200 {
+		t.Fatalf("LiveSince = %d, want %d", got.Provenance.LiveSince, now-7200)
 	}
 }
 
@@ -81,7 +56,7 @@ func TestAutonomyProvenance_AllLiveWindowReportsZeroAndSaysSo(t *testing.T) {
 		earliest: now - 86400,
 		total:    1,
 	}
-	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	rec := getAutonomy(t, store, "chart=autonomy_projects&window=30d")
 
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
@@ -90,30 +65,43 @@ func TestAutonomyProvenance_AllLiveWindowReportsZeroAndSaysSo(t *testing.T) {
 	if _, ok := raw["provenance"]; !ok {
 		t.Fatal("the payload omits `provenance` entirely — an absent block and a zero one must not look alike")
 	}
-	duration := decodeAutonomyDuration(t, rec)
-	if duration.Provenance.Reconstructed != 0 || duration.Provenance.CostDerived != 0 {
-		t.Fatalf("provenance = %+v, want zeroes on an all-live window", duration.Provenance)
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	if got.Provenance.Reconstructed != 0 || got.Provenance.CostDerived != 0 {
+		t.Fatalf("provenance = %+v, want zeroes on an all-live window", got.Provenance)
 	}
 }
 
-// A span reconstructed from the cost log reaches the strip carrying `unknown`,
-// and `unknown` must survive the trip unchanged — neither normalized into a
-// real end reason on the way out, nor blanked (which would make it
-// indistinguishable from an old row whose reason was never recorded).
-func TestAutonomySpans_UnknownReasonSurvivesTheWire(t *testing.T) {
+// `reason` STAYS A RECORDED FIELD even though nothing renders it any more
+// (#1905 redesign). It is the only fact about a run that cannot be recovered
+// after the event, so the section keeps recording it — and `unknown` in
+// particular must survive unchanged, neither normalized into a real end reason
+// nor blanked, which would make a cost-derived span indistinguishable from an
+// old row whose reason was never recorded at all.
+func TestAutonomyReason_IsStillCarriedByEveryStoredSpan(t *testing.T) {
 	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-3600, 300, "proj", session.AutonomyReasonUnknown),
+		spanEndingAt(now-1800, 300, "proj", session.StateWaiting),
+	}
 	store := &fakeAutonomyStore{
-		spans:      []outbound.AutonomySpan{spanEndingAt(now-3600, 300, "proj", session.AutonomyReasonUnknown)},
-		total:      1,
+		spans:      spans,
+		total:      2,
 		provenance: outbound.AutonomySpanProvenance{Reconstructed: 1, CostDerived: 1},
 	}
-	spans := decodeAutonomySpans(t, getAutonomy(t, store, "chart=autonomy_spans&window=24h"))
-
-	if len(spans.Spans) != 1 {
-		t.Fatalf("spans = %d, want 1", len(spans.Spans))
+	// The panels payload deliberately carries no per-run rows, so what is pinned
+	// here is that the field reaches the handler intact and is neither rewritten
+	// nor required by it.
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	if panelFor(t, got, "proj").Runs != 2 {
+		t.Fatalf("a span carrying %q was dropped — the section counts every run whatever ended it",
+			session.AutonomyReasonUnknown)
 	}
-	if spans.Spans[0].Reason != session.AutonomyReasonUnknown {
-		t.Fatalf("reason = %q, want %q", spans.Spans[0].Reason, session.AutonomyReasonUnknown)
+	if store.spans[0].Reason != session.AutonomyReasonUnknown {
+		t.Fatalf("reason = %q, want %q — the handler must not rewrite what the store holds",
+			store.spans[0].Reason, session.AutonomyReasonUnknown)
+	}
+	if session.IsAutonomyEndReason(session.AutonomyReasonUnknown) {
+		t.Fatal("`unknown` reads back as a real end reason")
 	}
 }
 
@@ -234,16 +222,16 @@ func TestAutonomyBoundaries_ReachTheWire(t *testing.T) {
 			},
 		},
 	}
-	duration := decodeAutonomyDuration(t, getAutonomy(t, store, "chart=autonomy_duration&window=30d"))
-	if len(duration.Provenance.Boundaries) != 2 {
-		t.Fatalf("boundaries = %+v, want 2", duration.Provenance.Boundaries)
+	got := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	if len(got.Provenance.Boundaries) != 2 {
+		t.Fatalf("boundaries = %+v, want 2", got.Provenance.Boundaries)
 	}
-	if duration.Provenance.Boundaries[1].To != autonomyEraLive {
+	if got.Provenance.Boundaries[1].To != autonomyEraLive {
 		t.Fatalf("the measured era is named %q on the wire, want %q",
-			duration.Provenance.Boundaries[1].To, autonomyEraLive)
+			got.Provenance.Boundaries[1].To, autonomyEraLive)
 	}
-	if duration.Provenance.LiveSince != now-100000 {
-		t.Fatalf("LiveSince = %d, want the measured era's start", duration.Provenance.LiveSince)
+	if got.Provenance.LiveSince != now-100000 {
+		t.Fatalf("LiveSince = %d, want the measured era's start", got.Provenance.LiveSince)
 	}
 	// `live` must never be a row's source, or a measured row would read back
 	// as reconstructed.
@@ -268,7 +256,7 @@ func TestAutonomyBoundaries_EmptyListIsPresentOnTheWire(t *testing.T) {
 		provenance: outbound.AutonomySpanProvenance{EraStarts: map[string]int64{"": now - 100000}},
 	}
 	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(getAutonomy(t, store, "chart=autonomy_spans&window=24h").Body.Bytes(), &raw); err != nil {
+	if err := json.Unmarshal(getAutonomy(t, store, "chart=autonomy_projects&window=30d").Body.Bytes(), &raw); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	var prov map[string]json.RawMessage
@@ -277,25 +265,5 @@ func TestAutonomyBoundaries_EmptyListIsPresentOnTheWire(t *testing.T) {
 	}
 	if _, ok := prov["boundaries"]; !ok {
 		t.Fatal("the payload omits `boundaries` entirely")
-	}
-}
-
-// `unknown` ranks below every MEASURED reason on the strip's collapse ladder,
-// so one reconstructed span can never grey out a column that also holds a real
-// error. It is deliberately not a session state, so this falls out of
-// AutonomyReasonPriority's unrecognized-reason branch rather than needing a
-// case of its own — and that is what is being pinned.
-func TestAutonomyUnknown_RanksBelowEveryMeasuredReason(t *testing.T) {
-	reasons := session.AutonomyEndReasons()
-	if len(reasons) == 0 {
-		t.Fatal("session.AutonomyEndReasons() is empty — cannot verify anything")
-	}
-	for _, r := range reasons {
-		if session.AutonomyReasonPriority(session.AutonomyReasonUnknown) >= session.AutonomyReasonPriority(r) {
-			t.Fatalf("`unknown` outranks or ties %q on the collapse ladder", r)
-		}
-	}
-	if session.IsAutonomyEndReason(session.AutonomyReasonUnknown) {
-		t.Fatal("`unknown` reads back as a real end reason")
 	}
 }

--- a/core/domain/session/autonomy.go
+++ b/core/domain/session/autonomy.go
@@ -70,10 +70,7 @@ const (
 // NOT A SESSION STATE, and that is the whole point: it is deliberately absent
 // from canonicalStates, so IsCanonicalState and IsAutonomyEndReason both
 // refuse it, AutonomyEndReasons() never yields it, and nothing derived from
-// the canonical vocabulary can start treating it as a fifth state. It ranks
-// at autonomyPriorityUnknown on the collapse ladder — below every measured
-// reason — and both clients draw it in the neutral colour they already use
-// for a reason they cannot name.
+// the canonical vocabulary can start treating it as a fifth state.
 const AutonomyReasonUnknown = "unknown"
 
 // AutonomySources returns the reconstruction sources, in the order the
@@ -178,38 +175,17 @@ func AutonomyKindForParent(parentSessionID string) string {
 	return AutonomyKindTopLevel
 }
 
-// Autonomy end-reason priorities for the run strip's pixel-collapse rule
-// (#1905, design decision 4). When one device-pixel column of the strip holds
-// several spans, the column paints the HIGHEST-priority reason in it.
+// The end-reason COLLAPSE LADDER used to live here (#1905, design decision 4):
+// a rank per reason, so that when one device-pixel column of the per-project run
+// strip held several spans, the column painted the highest-ranked reason in it.
 //
-// The order is the session-history strip's own (services.statePriority*,
-// #1805), where one error in a bucket paints the whole bucket red: the failure
-// state outranks the needs-a-human state, which outranks the finished-cleanly
-// state. `TestAutonomyReasonLadderMatchesHistoryBar` in the services package
-// pins the two ladders together so they cannot drift.
+// It went with the strip. The Autonomy section reports the LONGEST RUN and how
+// many ran at once — only `working` matters to it — so nothing renders an end
+// reason any more, and a ladder with no consumer is an ordering nobody applies.
 //
-// Declared one value per line rather than as an ordered slice: the ladder is
-// NOT the canonical order (canonical puts `ready` after `waiting`; the ladder
-// puts it below), so it cannot be derived from CanonicalStates and has to be
-// stated. One state per line keeps it out of the vocabulary linter's sights.
-const (
-	autonomyPriorityUnknown = 0
-	autonomyPriorityReady   = 1
-	autonomyPriorityWaiting = 2
-	autonomyPriorityError   = 3
-)
-
-// AutonomyReasonPriority returns a span end reason's rank on the collapse
-// ladder. An unrecognized reason ranks below every real one, so a build that
-// cannot name a reason never outranks activity it can.
-func AutonomyReasonPriority(reason string) int {
-	switch reason {
-	case StateError:
-		return autonomyPriorityError
-	case StateWaiting:
-		return autonomyPriorityWaiting
-	case StateReady:
-		return autonomyPriorityReady
-	}
-	return autonomyPriorityUnknown
-}
+// The `reason` FIELD stays, on every row and on the wire: it costs one string,
+// it is the only fact about a run that cannot be recovered after the event, and
+// the day something wants to draw it again the data will be there. Should that
+// day come, the order to restore is the session-history strip's own
+// (services.statePriority*, #1805) — error over waiting over ready — which is
+// where this ladder's order came from in the first place.

--- a/core/domain/session/autonomy_provenance_test.go
+++ b/core/domain/session/autonomy_provenance_test.go
@@ -31,27 +31,6 @@ func TestAutonomyReasonUnknownIsNotASessionState(t *testing.T) {
 	}
 }
 
-// It ranks below every measured reason on the strip's collapse ladder, so one
-// reconstructed span can never grey out a column that also holds a real error.
-func TestAutonomyReasonUnknownRanksLowest(t *testing.T) {
-	reasons := AutonomyEndReasons()
-	if len(reasons) == 0 {
-		t.Fatal("AutonomyEndReasons() is empty — cannot verify anything")
-	}
-	unknown := AutonomyReasonPriority(AutonomyReasonUnknown)
-	for _, r := range reasons {
-		if unknown >= AutonomyReasonPriority(r) {
-			t.Fatalf("`unknown` (%d) outranks or ties %q (%d)", unknown, r, AutonomyReasonPriority(r))
-		}
-	}
-	// And it ranks the same as any other reason this build cannot name: the
-	// neutral column both clients already draw.
-	if unknown != AutonomyReasonPriority("") {
-		t.Fatalf("`unknown` (%d) ranks differently from an unnamed reason (%d); the clients draw both "+
-			"in the same neutral colour and the ladder must agree", unknown, AutonomyReasonPriority(""))
-	}
-}
-
 func TestIsAutonomyReconstructed(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -1,18 +1,29 @@
 import Foundation
 
-// Codable mirrors of the daemon's Autonomy payloads (#1905) —
-// `chart=autonomy_duration` and `chart=autonomy_spans` in
-// core/cmd/irrlichd/history_autonomy.go — plus the two pickers' vocabularies
-// and the strip's pure collapse rule.
+// Codable mirrors of the daemon's Autonomy payload (#1905) —
+// `chart=autonomy_projects` in core/cmd/irrlichd/history_autonomy.go — plus the
+// Range picker's vocabulary and the pure layout rules the panels draw with.
 //
-// An autonomy span is one unbroken stretch of `working` before the session
-// left that state; the state it left FOR is the signal the section is about.
+// FIVE PER-PROJECT PANELS, one per project, stacked. Each carries a LINE (the
+// longest run in each time bucket) and, under it, a HISTOGRAM (how many runs
+// were working at the same time in that bucket, derived by the daemon from the
+// spans by overlap).
+//
+// WHAT THIS REPLACED. Two payloads and two elements: a p5–p95 band with a p50
+// line, and a per-project run strip coloured by end reason. Both are gone —
+// with the strip's legend, glyphs and collapse ladder, the Span picker that
+// governed its window, and the sample floor that marked buckets whose p95 was
+// really their maximum. A maximum over one run IS that run, so the floor has
+// nothing left to protect.
 
-/// Element 1's Range picker. Two ranges, and 30 days is the floor: anything
-/// shorter has too few spans per bucket for a percentile to mean anything.
+/// The section's Range picker. Two windows, and 30 days is the floor.
 ///
 /// The raw values are WINDOW LENGTHS sent as `?window=`, not the
 /// bucket-width-times-count that `HistoryGranularity`'s same-looking keys mean.
+///
+/// There is no second picker. `HistoryAutonomySpanWindow` governed the run
+/// strip's own window and went with the strip: one window, one control, and no
+/// pair of textually-overlapping vocabularies for a reader to keep apart.
 enum HistoryAutonomyRange: String, CaseIterable, Identifiable {
     case days30 = "30d"
     case year = "1y"
@@ -27,40 +38,19 @@ enum HistoryAutonomyRange: String, CaseIterable, Identifiable {
     }
 }
 
-/// Element 2's Span picker — window lengths again, and deliberately a
-/// different set from element 1's.
-enum HistoryAutonomySpanWindow: String, CaseIterable, Identifiable {
-    case hours8 = "8h"
-    case hours24 = "24h"
-    case days7 = "7d"
-    case days30 = "30d"
-    case months12 = "12mo"
-
-    var id: String { rawValue }
-
-    var label: String {
-        switch self {
-        case .hours8: return "8h"
-        case .hours24: return "24h"
-        case .days7: return "7d"
-        case .days30: return "30d"
-        case .months12: return "12mo"
-        }
-    }
-}
-
-/// There is NO run-scope control any more (#1905 recording). The section counts
-/// every run, subagent runs included, because Irrlicht recorded them — so there
-/// is nothing to pick, and no mode a reader has to remember before reading a
-/// figure. Each row still carries its `kind` and `parent`, which is what keeps
-/// a subagent's run identifiable; what went is the choice, not the
-/// classification.
+/// There is NO run-scope control (#1905 recording). The section counts every
+/// run, subagent runs included, because Irrlicht recorded them — so there is
+/// nothing to pick, and no mode a reader has to remember before reading a
+/// figure. What a run WAS still matters: the `kind` field is what splits a
+/// concurrency peak into sessions and subagents.
 
 /// What one Autonomy payload is made of, by run kind (#1905 subagents).
 ///
 /// The three counts describe the window, and — nothing being dropped for its
-/// kind — the returned rows with it. They are still worth carrying: "42 runs"
-/// reads differently once you know how many of them happened inside another.
+/// kind — the returned rows with it. They are load-bearing twice over: "42 runs"
+/// reads differently once you know how many of them happened inside another,
+/// and `unknown` is what tells a reader why a panel's `at once` figure
+/// sometimes carries no split.
 struct HistoryAutonomyKinds: Codable, Equatable {
     let topLevel: Int
     let subagent: Int
@@ -81,13 +71,14 @@ struct HistoryAutonomyKinds: Codable, Equatable {
 /// than a measurement (#1905 recording).
 ///
 /// Two kinds, kept apart because they are two different limits and a reader who
-/// merged them would misread the chart in opposite directions:
+/// merged them would misread the panels in opposite directions:
 ///
-///   - `running` — the run has not ended, so its length is unknowable. Shown on
-///     the strip, and deliberately absent from the percentiles.
+///   - `running` — the run has not ended, so its length is how long it has
+///     lasted SO FAR. It COUNTS towards the longest run (the section reports a
+///     maximum, and "already lasted 3h" is true) and is marked "still going".
 ///   - `lowerBoundStart` — the run has FINISHED, but Irrlicht met it already in
-///     progress, so its start is where the watching began. Those are samples;
-///     dropping them is what left 5 of a day's 35 runs on the record.
+///     progress, so its start is where the watching began. Dropping those is
+///     what left 5 of a day's 35 runs on the record.
 struct HistoryAutonomyMeasurement: Codable, Equatable {
     let running: Int
     let lowerBoundStart: Int
@@ -105,55 +96,8 @@ struct HistoryAutonomyMeasurement: Codable, Equatable {
     var any: Bool { running > 0 || lowerBoundStart > 0 }
 }
 
-/// How a span ended — the state the session left `working` for. Raw values
-/// mirror `session.AutonomyEndReasons()` on the daemon.
-///
-/// One case per line, and one state per line in `priority` below: a single
-/// line naming three of the four canonical states is exactly what
-/// tools/state-vocabulary-lint.sh refuses, because such a list is complete
-/// when written and silently stale one state later.
-enum AutonomyEndReason: String, CaseIterable, Identifiable {
-    case waiting
-    case ready
-    case error
-
-    var id: String { rawValue }
-
-    /// Glyph shown in the strip legend, matching the issue's sketch.
-    var glyph: String {
-        switch self {
-        case .waiting: return "?"
-        case .ready: return "✓"
-        case .error: return "✗"
-        }
-    }
-
-    var label: String {
-        switch self {
-        case .waiting: return "it asked"
-        case .ready: return "turn finished"
-        case .error: return "error"
-        }
-    }
-
-    /// Rank on the strip's pixel-collapse ladder: when one device-pixel column
-    /// holds several spans, the column paints the highest-ranked reason in it.
-    ///
-    /// Same order as the session-history strip's ladder (#1805) — one error in
-    /// a column paints the whole column. `HistoryAutonomyTests` pins this
-    /// against `SessionManager.historyPriorityForState`, which is the other
-    /// hand-written copy of the same ladder.
-    var priority: Int {
-        switch self {
-        case .error: return 3
-        case .waiting: return 2
-        case .ready: return 1
-        }
-    }
-}
-
 /// How much of one window was RECONSTRUCTED rather than measured (#1905
-/// back-fill), carried by both Autonomy payloads.
+/// back-fill).
 ///
 /// `tools/autonomy-backfill` rebuilds pre-feature runs from logs a machine
 /// already had, and marks every row it writes. The daemon never runs it — it
@@ -205,11 +149,11 @@ struct HistoryAutonomyProvenance: Codable, Equatable {
 /// of it came from `from`, one to the right from `to`.
 ///
 /// It exists because the provenance PARAGRAPH cannot fix what the eye reads off
-/// the CURVE (#1905 back-fill, QA-2). The cost log cannot see a run shorter
-/// than its 60 s write interval; the event log records one-second runs. Across
-/// that boundary the p5 line steps by two orders of magnitude, and a reader
-/// takes a change of instrument for a change of behaviour. The marker puts the
-/// explanation where the artefact is.
+/// the LINE (#1905 back-fill, QA-2). The cost log cannot see a run shorter than
+/// its 60 s write interval; the event log records one-second runs. The redesign
+/// makes the marker MORE necessary rather than less: five stacked panels share
+/// one x axis, so all five step at the same instant, and five simultaneous steps
+/// read as five findings when they are one change of instrument.
 struct HistoryAutonomyBoundary: Codable, Equatable, Identifiable {
     let ts: Int64
     let from: String
@@ -231,134 +175,346 @@ struct HistoryAutonomyBoundary: Codable, Equatable, Identifiable {
     ]
 }
 
-/// One entry of the run strip's legend.
+/// Where a source-boundary caption is written, once the stack has five panels.
 ///
-/// `reason` is optional because the neutral entry stands for every run whose
-/// end reason nothing can name — a cost-derived span carrying `unknown`, and
-/// an old row written before the reason was recorded. Both draw the same
-/// neutral column, so one entry has to cover both or one of them is a colour
-/// with no key.
-struct AutonomyLegendEntry: Identifiable, Equatable {
-    let reason: AutonomyEndReason?
-    let glyph: String
-    let label: String
+/// THE RULE READS ONCE ACROSS THE STACK. The dashed rule is drawn through EVERY
+/// panel — it has to be, or it annotates one project's line and leaves the four
+/// below it stepping for no stated reason — but the caption is drawn on the TOP
+/// panel only. Five stacked copies of "← cost log · 60s resolution" down one x
+/// position are five competing captions where the reader needs one, and at 9 pt
+/// in a 380 pt popover they would collide with four project names.
+enum AutonomyBoundaryCaption {
+    /// The panel index that carries the words.
+    static let panelIndex = 0
 
-    var id: String { reason?.rawValue ?? "unknown" }
-}
+    static func isShown(panelIndex: Int) -> Bool { panelIndex == Self.panelIndex }
 
-enum AutonomyLegend {
-    static let unknown = AutonomyLegendEntry(reason: nil, glyph: "·", label: "end reason unknown")
-
-    /// The legend for one window: the measured reasons, plus the neutral entry
-    /// ONLY when the window actually holds a run with no nameable reason.
+    /// Which side of its rule the caption hangs off.
     ///
-    /// Conditional on the data rather than always shown, because a legend
-    /// explains the colours in front of the reader. A permanent fourth swatch
-    /// for a colour the strip is not drawing invites the opposite mistake —
-    /// reading the absence of neutral columns as an absence of runs.
-    static func entries(for spans: [HistoryAutonomySpanRow]) -> [AutonomyLegendEntry] {
-        var out = AutonomyEndReason.allCases.map {
-            AutonomyLegendEntry(reason: $0, glyph: $0.glyph, label: $0.label)
-        }
-        if spans.contains(where: { $0.endReason == nil }) { out.append(unknown) }
-        return out
-    }
+    /// The caption is a fixed string that can be most of the plot wide at 9 pt,
+    /// and pinned to the rule's LEFT unconditionally it would be clamped to the
+    /// chart's leading edge for any rule in the left third — leaving the caption
+    /// detached from the rule with its arrow pointing off-chart at nothing,
+    /// which reads as a rendering fault rather than as an annotation.
+    ///
+    /// Putting it on whichever side of the rule has more room cannot be clamped
+    /// unless the caption is wider than HALF the plot, and the arrow keeps its
+    /// meaning either way: it points across the rule, at the era to its left.
+    enum Side: Equatable { case left, right }
+
+    static func side(fraction: Double) -> Side { fraction >= 0.5 ? .left : .right }
 }
 
-/// One bucket of element 1. The daemon OMITS empty buckets, so every bucket
-/// present here has `count >= 1` — a day with no runs is a gap in the line,
-/// never a point on the axis.
-struct HistoryAutonomyBucket: Codable, Identifiable {
+/// One time bucket of one project's panel.
+///
+/// A BUCKET WITH NOTHING IN IT IS OMITTED by the daemon, never sent with zeros —
+/// a day with no runs is a gap, not a run of length zero next to nobody working.
+/// So a bucket present here has `longest > 0` or `peak > 0`.
+struct HistoryAutonomyPanelBucket: Codable, Identifiable, Equatable {
     let ts: Int64
-    let p95: Double
-    let p50: Double
-    let p5: Double
-    let min: Double
-    let max: Double
-    let count: Int
-    /// True when the bucket holds fewer than `sampleFloor` spans, so its p95
-    /// IS its max and its p5 IS its min. Rendered visibly differently (dashed
-    /// + faded), never hidden and never smoothed.
-    let thin: Bool
+
+    /// The longest run that ENDED in this bucket, in seconds; 0 when no run
+    /// ended here.
+    ///
+    /// The consequence worth stating: a run that merely passed THROUGH a bucket
+    /// raises that bucket's concurrency without putting a point on its line, so
+    /// a bucket can carry a bar and no line point. That is the honest pair of
+    /// facts — something was working, nothing finished.
+    let longest: Double
+
+    /// Whether this bucket's longest run HAS NOT ENDED: its length is how long
+    /// it has lasted so far, a floor rather than a measurement. It is still the
+    /// longest, and it is marked so nobody reads a floor as final.
+    let running: Bool
+
+    /// The greatest number of runs working AT THE SAME INSTANT anywhere in this
+    /// bucket. PEAK, not average: peak answers "how wide did I go", where an
+    /// average over a day is dominated by the hours nothing ran.
+    let peak: Int
+
+    /// `peak` split at the instant it was reached. Meaningful only when
+    /// `peakSplit` is true.
+    let peakTop: Int
+    let peakSub: Int
+
+    /// Whether every run alive at the peak instant said which kind it was, so
+    /// the split is a derivation rather than a guess. False is the normal case
+    /// for rows written before the classification existed.
+    let peakSplit: Bool
 
     var id: Int64 { ts }
 
     enum CodingKeys: String, CodingKey {
-        case ts, p95, p50, p5, min, max, count, thin
+        case ts, longest, running, peak
+        case peakTop = "peak_top"
+        case peakSub = "peak_sub"
+        case peakSplit = "peak_split"
+    }
+
+    init(ts: Int64, longest: Double, running: Bool = false,
+         peak: Int = 0, peakTop: Int = 0, peakSub: Int = 0, peakSplit: Bool = false) {
+        self.ts = ts
+        self.longest = longest
+        self.running = running
+        self.peak = peak
+        self.peakTop = peakTop
+        self.peakSub = peakSub
+        self.peakSplit = peakSplit
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         ts = try c.decode(Int64.self, forKey: .ts)
-        p95 = try c.decode(Double.self, forKey: .p95)
-        p50 = try c.decode(Double.self, forKey: .p50)
-        p5 = try c.decode(Double.self, forKey: .p5)
-        min = try c.decode(Double.self, forKey: .min)
-        max = try c.decode(Double.self, forKey: .max)
-        count = try c.decode(Int.self, forKey: .count)
-        // `thin` is omitempty on the wire: absent means false.
-        thin = try c.decodeIfPresent(Bool.self, forKey: .thin) ?? false
+        longest = try c.decode(Double.self, forKey: .longest)
+        // The three marks are omitempty on the wire: absent means false/zero.
+        running = try c.decodeIfPresent(Bool.self, forKey: .running) ?? false
+        peak = try c.decodeIfPresent(Int.self, forKey: .peak) ?? 0
+        peakTop = try c.decodeIfPresent(Int.self, forKey: .peakTop) ?? 0
+        peakSub = try c.decodeIfPresent(Int.self, forKey: .peakSub) ?? 0
+        peakSplit = try c.decodeIfPresent(Bool.self, forKey: .peakSplit) ?? false
+    }
+
+    /// Whether this bucket puts a point on the line. A run of no length is not
+    /// a run, so 0 is a GAP rather than a point on the floor.
+    var hasLine: Bool { longest > 0 }
+
+    /// Whether this bucket draws a bar. A zero-height bar on the axis reads as
+    /// a measured zero, which is a different and false claim from "no runs".
+    var hasBar: Bool { peak > 0 }
+}
+
+/// One project's panel: its two window-wide figures and its per-bucket series.
+struct HistoryAutonomyPanel: Codable, Identifiable, Equatable {
+    let project: String
+
+    /// The longest run in the whole window, and whether it has ended.
+    ///
+    /// A STILL-RUNNING RUN COUNTS TOWARDS IT, unlike its old effect on a
+    /// percentile: "the longest run already lasted 3h" is true and useful, where
+    /// a p95 folding the same floor in would have claimed the top 5% of runs
+    /// were shorter than they were.
+    let longest: Double
+    let longestRunning: Bool
+
+    /// The sum of every run's length — the figure the panels are RANKED by. On
+    /// the wire so the ranking can be checked against the panels rather than
+    /// taken on trust.
+    let totalSeconds: Double
+
+    let runs: Int
+
+    /// The most runs this project had working at once anywhere in the window,
+    /// split the same way a bucket's is when the split is derivable.
+    let peak: Int
+    let peakTop: Int
+    let peakSub: Int
+    let peakSplit: Bool
+
+    let buckets: [HistoryAutonomyPanelBucket]
+
+    var id: String { project }
+
+    enum CodingKeys: String, CodingKey {
+        case project, longest, runs, peak, buckets
+        case longestRunning = "longest_running"
+        case totalSeconds = "total_seconds"
+        case peakTop = "peak_top"
+        case peakSub = "peak_sub"
+        case peakSplit = "peak_split"
+    }
+
+    init(project: String, longest: Double, longestRunning: Bool = false, totalSeconds: Double = 0,
+         runs: Int = 0, peak: Int = 0, peakTop: Int = 0, peakSub: Int = 0, peakSplit: Bool = false,
+         buckets: [HistoryAutonomyPanelBucket] = []) {
+        self.project = project
+        self.longest = longest
+        self.longestRunning = longestRunning
+        self.totalSeconds = totalSeconds
+        self.runs = runs
+        self.peak = peak
+        self.peakTop = peakTop
+        self.peakSub = peakSub
+        self.peakSplit = peakSplit
+        self.buckets = buckets
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        project = try c.decode(String.self, forKey: .project)
+        longest = try c.decode(Double.self, forKey: .longest)
+        longestRunning = try c.decodeIfPresent(Bool.self, forKey: .longestRunning) ?? false
+        totalSeconds = try c.decodeIfPresent(Double.self, forKey: .totalSeconds) ?? 0
+        runs = try c.decodeIfPresent(Int.self, forKey: .runs) ?? 0
+        peak = try c.decodeIfPresent(Int.self, forKey: .peak) ?? 0
+        peakTop = try c.decodeIfPresent(Int.self, forKey: .peakTop) ?? 0
+        peakSub = try c.decodeIfPresent(Int.self, forKey: .peakSub) ?? 0
+        peakSplit = try c.decodeIfPresent(Bool.self, forKey: .peakSplit) ?? false
+        buckets = try c.decodeIfPresent([HistoryAutonomyPanelBucket].self, forKey: .buckets) ?? []
+    }
+
+    /// The panel's figure line: its longest run and its widest moment, for the
+    /// whole window. A still-running longest run is MARKED rather than dropped.
+    var headline: String {
+        var out = "longest " + AutonomyFormat.duration(longest)
+        if longestRunning { out += " (still going)" }
+        let concurrency = AutonomyFormat.concurrency(peak: peak, top: peakTop, sub: peakSub, splitKnown: peakSplit)
+        return concurrency.isEmpty ? out : out + " · " + concurrency
+    }
+
+    /// The buckets aligned to the payload's `bucket_starts`, with `nil` for
+    /// every bucket the daemon OMITTED — the macOS twin of the web's
+    /// `autonomyPanelPoints`.
+    ///
+    /// The nil is the honesty rule, not a convenience. Reading `buckets`
+    /// directly hands a dense list to whatever draws it, and the gap is simply
+    /// not there any more.
+    func alignedBuckets(_ bucketStarts: [Int64]) -> [HistoryAutonomyPanelBucket?] {
+        var byTS: [Int64: HistoryAutonomyPanelBucket] = [:]
+        for b in buckets { byTS[b.ts] = b }
+        return bucketStarts.map { byTS[$0] }
     }
 }
 
-/// The window-wide figure row under the chart. The true extremes stay FIGURES
-/// and are deliberately not lines: one four-hour run left going overnight
-/// would otherwise redraw the whole Y scale and flatten every other bucket.
-struct HistoryAutonomySummary: Codable {
-    let p95: Double
-    let p50: Double
-    let p5: Double
-    let min: Double
-    let max: Double
-    let count: Int
+/// The window-wide figure row: the section's headline numbers across EVERY
+/// project, not just the five drawn.
+struct HistoryAutonomySummary: Codable, Equatable {
+    let longest: Double
+    let longestRunning: Bool
+    let longestProject: String
+
+    /// The highest per-project concurrency in the window — the widest any ONE
+    /// project went, never a sum across projects, which would be a different
+    /// and much larger number.
+    let peak: Int
+    let peakProject: String
+
+    let runs: Int
+    let projects: Int
+
+    enum CodingKeys: String, CodingKey {
+        case longest, peak, runs, projects
+        case longestRunning = "longest_running"
+        case longestProject = "longest_project"
+        case peakProject = "peak_project"
+    }
+
+    init(longest: Double, longestRunning: Bool = false, longestProject: String = "",
+         peak: Int = 0, peakProject: String = "", runs: Int = 0, projects: Int = 0) {
+        self.longest = longest
+        self.longestRunning = longestRunning
+        self.longestProject = longestProject
+        self.peak = peak
+        self.peakProject = peakProject
+        self.runs = runs
+        self.projects = projects
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        longest = try c.decodeIfPresent(Double.self, forKey: .longest) ?? 0
+        longestRunning = try c.decodeIfPresent(Bool.self, forKey: .longestRunning) ?? false
+        longestProject = try c.decodeIfPresent(String.self, forKey: .longestProject) ?? ""
+        peak = try c.decodeIfPresent(Int.self, forKey: .peak) ?? 0
+        peakProject = try c.decodeIfPresent(String.self, forKey: .peakProject) ?? ""
+        runs = try c.decodeIfPresent(Int.self, forKey: .runs) ?? 0
+        projects = try c.decodeIfPresent(Int.self, forKey: .projects) ?? 0
+    }
 }
 
-struct HistoryAutonomyDurationResponse: Codable {
+/// One entry of the panel stack, in draw order — the macOS twin of the web's
+/// `autonomyStackRows`.
+///
+/// The client never re-decides how many panels there are: the daemon computes
+/// five and says how many it left out, so the two surfaces cannot disagree the
+/// way the run strip's twelve-rows-on-web against six-on-macOS did.
+enum AutonomyStackRow: Identifiable, Equatable {
+    case panel(HistoryAutonomyPanel, index: Int)
+    case more(String)
+
+    var id: String {
+        switch self {
+        case let .panel(p, _): return "panel-" + p.project
+        case .more: return "more"
+        }
+    }
+}
+
+struct HistoryAutonomyProjectsResponse: Codable {
     let window: String
     let chart: String
     let start: Int64
     let end: Int64
     let bucketSeconds: Int64
     let bucketStarts: [Int64]
-    let buckets: [HistoryAutonomyBucket]
+
+    /// The five most important projects, most autonomous time first.
+    ///
+    /// "Most important" is GREATEST TOTAL AUTONOMOUS TIME in the window, never
+    /// longest single run: one lucky overnight run would otherwise promote a
+    /// project nobody has touched in a month. The daemon ranks them; each panel
+    /// carries `totalSeconds` so the ranking can be checked.
+    let panels: [HistoryAutonomyPanel]
+    let panelLimit: Int
+    /// How many projects the window holds beyond the panels, all of them with
+    /// less autonomous time than every panel above.
+    let moreProjects: Int
+
     let summary: HistoryAutonomySummary
-    let sampleFloor: Int
+
     /// Earliest span on record across the WHOLE log (0 = nothing ever
-    /// recorded). What lets an empty chart say "collecting since <date>"
+    /// recorded). What lets an empty section say "collecting since <date>"
     /// instead of being read as "you did nothing".
     let earliestSpan: Int64
     let totalRecorded: Int
+
     /// Optional so a payload from a daemon that predates the field decodes
     /// rather than failing outright — `provenanceOrNone` collapses the two
     /// "say nothing" cases into one.
     let provenance: HistoryAutonomyProvenance?
-    /// What this payload is made of, by run kind (#1905 subagents). Optional
-    /// for the same reason as `provenance`, and absent means SAY NOTHING —
-    /// which is not the same claim as "there were none".
+    /// What this payload is made of, by run kind. Optional for the same reason,
+    /// and absent means SAY NOTHING — which is not the same claim as "there
+    /// were none".
     let kinds: HistoryAutonomyKinds?
-    /// How many of the runs in view are floors rather than measurements
-    /// (#1905 recording). Optional for the same reason; absent means nothing
-    /// was marked.
+    /// How many of the runs in view are floors rather than measurements.
     let measurement: HistoryAutonomyMeasurement?
 
     enum CodingKeys: String, CodingKey {
-        case window, chart, start, end, buckets, summary, provenance, kinds, measurement
+        case window, chart, start, end, panels, summary, provenance, kinds, measurement
         case bucketSeconds = "bucket_seconds"
         case bucketStarts = "bucket_starts"
-        case sampleFloor = "sample_floor"
+        case panelLimit = "panel_limit"
+        case moreProjects = "more_projects"
         case earliestSpan = "earliest_span"
         case totalRecorded = "total_recorded"
     }
 
-    var hasData: Bool { !buckets.isEmpty }
+    var hasData: Bool { !panels.isEmpty }
     var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
     var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
 
-    /// The source boundaries that fall inside the DRAWN domain, so the chart
-    /// marks only what the reader can actually see.
+    /// What the stack renders, in order: one entry per panel the daemon sent
+    /// and, when the window holds more projects than those, a final entry
+    /// naming the rest. An omission nothing mentions is indistinguishable from
+    /// a project that never ran.
+    var stackRows: [AutonomyStackRow] {
+        var out: [AutonomyStackRow] = panels.enumerated().map { .panel($1, index: $0) }
+        if let label = overflowLabel { out.append(.more(label)) }
+        return out
+    }
+
+    /// What the five-panel view left out, and WHY those are the ones missing —
+    /// so the reader knows the section took the tail rather than an arbitrary
+    /// slice. `nil` when every project already has a panel.
+    var overflowLabel: String? {
+        guard moreProjects > 0 else { return nil }
+        return "+\(moreProjects) more project\(moreProjects == 1 ? "" : "s"), each with less autonomous time"
+    }
+
+    /// The source boundaries that fall inside the DRAWN domain, so the panels
+    /// mark only what the reader can actually see.
     ///
     /// STRICTLY inside: a boundary at the very first or very last bucket would
-    /// draw a rule on the axis itself, marking nothing and reading as a chart
+    /// draw a rule on the axis itself, marking nothing and reading as a panel
     /// border. A range that does not straddle a boundary gets none — which is
     /// every range on a machine that was never back-filled.
     var visibleBoundaries: [HistoryAutonomyBoundary] {
@@ -374,282 +530,62 @@ struct HistoryAutonomyDurationResponse: Codable {
         return Double(boundary.ts - first) / Double(last - first)
     }
 
-    /// The buckets aligned to `bucket_starts`, with `nil` for every bucket the
-    /// daemon OMITTED — the macOS twin of the web's `autonomyChartPoints`.
+    /// The log Y domain SHARED by all five panels, `nil` when nothing in the
+    /// window has a length to plot.
     ///
-    /// The null is the honesty rule, not a convenience: an empty bucket is a
-    /// GAP, and a day with no runs must not pull a line down to the axis or
-    /// let a filled band close over it. Reading `buckets` directly — which is
-    /// what this section did before the band existed — hands Swift Charts a
-    /// dense list in which the gap is simply not there, and it connects
-    /// straight across.
-    var alignedBuckets: [HistoryAutonomyBucket?] {
-        var byTS: [Int64: HistoryAutonomyBucket] = [:]
-        for b in buckets { byTS[b.ts] = b }
-        return bucketStarts.map { byTS[$0] }
+    /// Shared, so the projects are comparable — that is the point of picking
+    /// five. Log, because a project whose best is two minutes would otherwise be
+    /// a flat line under one whose best is eleven hours. Each panel states its
+    /// own longest as a NUMBER in its header, so the exact figure never depends
+    /// on reading the axis.
+    var sharedYDomain: ClosedRange<Double>? {
+        let values = panels.flatMap { $0.buckets.map(\.longest) }.filter { $0 > 0 }
+        guard let smallest = values.min(), let biggest = values.max() else { return nil }
+        // Floored at 1s: a log scale cannot plot 0, and a sub-second span is
+        // not a run.
+        let lo = Swift.max(1, smallest * 0.8)
+        let hi = Swift.max(lo * 2, biggest * 1.25)
+        return lo...hi
+    }
+
+    /// The histogram's SHARED full-height value: the highest peak any panel
+    /// reaches. 0 when nothing overlapped anywhere, in which case no bar is
+    /// drawn at all rather than every bar being drawn full height.
+    var sharedPeakScale: Int {
+        panels.flatMap { $0.buckets.map(\.peak) }.max() ?? 0
     }
 }
 
-/// Where a source-boundary caption sits relative to the rule it describes.
+/// The contiguous stretches a panel's line may be stroked over — as a pure
+/// function so the gap rule is testable without a view, and so this and the
+/// web's `autonomyLineSegments` break the line in the same places.
 ///
-/// The caption is a fixed string ("← cost log · 60s resolution") that can be
-/// most of the plot wide at 9 pt, and it used to be pinned to the rule's LEFT
-/// unconditionally. A rule in the left third of the chart therefore had less
-/// room than the caption needed, SwiftUI clamped the annotation to the chart's
-/// leading edge, and the caption ended up detached from the rule with its
-/// arrow pointing off-chart at nothing — which is worse than no caption, since
-/// it reads as a rendering fault rather than as an annotation.
-///
-/// Putting it on whichever side of the rule has more room cannot be clamped
-/// unless the caption is wider than HALF the plot, and the arrow keeps its
-/// meaning either way: it points across the rule, at the era to its left.
-enum AutonomyBoundaryCaption {
-    enum Side: Equatable { case left, right }
-
-    static func side(fraction: Double) -> Side { fraction >= 0.5 ? .left : .right }
-}
-
-/// The p5–p95 band's geometry (#1905 redesign), as a pure function so both the
-/// gap rule and the thin-bucket rule are testable without a chart — and so
-/// this and the web's `autonomyBandSegments` fill the same shape.
-///
-/// TWO RULES, both of them honesty rules a smooth fill would otherwise erase:
-///
-///   - **A filled area wants to close across a gap.** The daemon omits empty
-///     buckets; a polygon spanning one paints a plane over days that hold no
-///     runs at all, a stronger false claim than the interpolated line #1905
-///     already refuses. A segment never crosses a `nil`.
-///   - **A thin bucket is not a percentile.** Under `sample_floor`, p95 is
-///     that bucket's longest run and p5 its shortest. The stroke already
-///     dashes across such a bucket; the fill splits at the same place so the
-///     thin stretch can be painted in its own fainter plane.
-enum AutonomyBandLayout {
-    /// One fillable stretch: inclusive indices into the aligned point list,
-    /// and whether it is thin. Adjacent segments SHARE their boundary index,
-    /// so a thin→solid handover leaves no seam. `from == to` is an isolated
-    /// bucket — it has no neighbour to make an area with, and the chart draws
-    /// its spread as a whisker rather than leaving it the one bucket with no
-    /// visible range at all.
+/// TWO KINDS OF GAP, and they are not the same gap. A bucket can be absent
+/// entirely (nothing happened), or present with `longest == 0` — a run passed
+/// THROUGH it without finishing in it, so something was working and nothing
+/// finished. Both break the line; only the first also removes the bar. Drawing a
+/// point at zero in the second case would claim a run of no length.
+enum AutonomyLineLayout {
     struct Segment: Equatable, Identifiable {
         let from: Int
         let to: Int
-        let thin: Bool
 
-        var id: String { "\(from)-\(to)-\(thin)" }
+        var id: String { "\(from)-\(to)" }
         var isIsolated: Bool { from == to }
     }
 
-    static func segments(points: [HistoryAutonomyBucket?]) -> [Segment] {
+    static func segments(points: [HistoryAutonomyPanelBucket?]) -> [Segment] {
         var out: [Segment] = []
-        var i = 0
-        while i < points.count {
-            guard points[i] != nil else { i += 1; continue }
-            var last = i
-            while last + 1 < points.count, points[last + 1] != nil { last += 1 }
-            if last == i {
-                out.append(Segment(from: i, to: i, thin: points[i]?.thin ?? false))
-                i = last + 1
-                continue
-            }
-            // Thinness belongs to the INTERVAL, not the bucket — matching the
-            // stroke, which dashes a segment either of whose ends is thin.
-            var start = i
-            var thin = isThin(points, i) || isThin(points, i + 1)
-            var j = i + 1
-            while j < last {
-                let next = isThin(points, j) || isThin(points, j + 1)
-                if next != thin {
-                    out.append(Segment(from: start, to: j, thin: thin))
-                    start = j
-                    thin = next
-                }
-                j += 1
-            }
-            out.append(Segment(from: start, to: last, thin: thin))
-            i = last + 1
-        }
-        return out
-    }
-
-    private static func isThin(_ points: [HistoryAutonomyBucket?], _ i: Int) -> Bool {
-        points[i]?.thin ?? false
-    }
-}
-
-struct HistoryAutonomySpanRow: Codable, Identifiable {
-    let start: Int64
-    let end: Int64
-    let project: String
-    let session: String
-    let reason: String?
-    /// `"top"`, `"sub"` or `"unknown"` — the daemon resolves a blank row before
-    /// it ships, so this is absent only from a payload that predates the field.
-    let kind: String?
-    /// The parent session id of a subagent run; absent otherwise.
-    let parent: String?
-    /// Whether this run has NOT ended (#1905 recording): `end` is where it had
-    /// got to when the window was taken, so its length is a floor. Absent on
-    /// every finished row and on a payload that predates the field.
-    let running: Bool?
-    /// Whether Irrlicht met this run already in progress, so `start` is when it
-    /// began WATCHING rather than when the run began.
-    let startLowerBound: Bool?
-
-    enum CodingKeys: String, CodingKey {
-        case start, end, project, session, reason, kind, parent, running
-        case startLowerBound = "start_lower_bound"
-    }
-
-    /// Spelled out rather than left to the synthesized memberwise init, so the
-    /// trailing fields can default — the same reason
-    /// `HistoryAutonomyProvenance` spells its own out. A call site that says
-    /// nothing about the kind means exactly what a row that says nothing means:
-    /// nobody established it.
-    init(start: Int64, end: Int64, project: String, session: String,
-         reason: String?, kind: String? = nil, parent: String? = nil,
-         running: Bool? = nil, startLowerBound: Bool? = nil) {
-        self.start = start
-        self.end = end
-        self.project = project
-        self.session = session
-        self.reason = reason
-        self.kind = kind
-        self.parent = parent
-        self.running = running
-        self.startLowerBound = startLowerBound
-    }
-
-    /// Whether the run is still going. Absent reads as finished, which is the
-    /// only thing it can mean: a build that could not record a run in progress
-    /// never wrote one.
-    var isRunning: Bool { running == true }
-
-    /// Whether the run's start is an estimate. Absent reads as measured, for
-    /// the same reason.
-    var hasLowerBoundStart: Bool { startLowerBound == true }
-
-    var id: String { "\(project)|\(session)|\(start)|\(end)" }
-
-    var endReason: AutonomyEndReason? { reason.flatMap(AutonomyEndReason.init(rawValue:)) }
-    var duration: Int64 { Swift.max(0, end - start) }
-    /// Whether this run belonged to a subagent. FALSE for a row that never said
-    /// — which is "nothing established it", not "it was top-level". Every run
-    /// is drawn either way (#1905 recording); this is what makes a nested run
-    /// identifiable, not what excludes it.
-    var isSubagentRun: Bool { kind == "sub" }
-}
-
-struct HistoryAutonomySpansResponse: Codable {
-    let window: String
-    let chart: String
-    let start: Int64
-    let end: Int64
-    let spans: [HistoryAutonomySpanRow]
-    /// Strip row order, computed daemon-side (most autonomous seconds first)
-    /// so both clients draw the same rows in the same order.
-    let projects: [String]
-    let earliestSpan: Int64
-    let totalRecorded: Int
-    let truncated: Bool
-    let provenance: HistoryAutonomyProvenance?
-    let kinds: HistoryAutonomyKinds?
-    let measurement: HistoryAutonomyMeasurement?
-
-    enum CodingKeys: String, CodingKey {
-        case window, chart, start, end, spans, projects, truncated, provenance, kinds, measurement
-        case earliestSpan = "earliest_span"
-        case totalRecorded = "total_recorded"
-    }
-
-    var hasData: Bool { !spans.isEmpty }
-    var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
-    var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
-
-    func spans(for project: String) -> [HistoryAutonomySpanRow] {
-        spans.filter { $0.project == project }
-    }
-
-    /// How many project rows the run strip draws.
-    ///
-    /// The strip had no cap at all, which was invisible until there was
-    /// history to draw: a 12mo window over a back-filled log renders 95 rows
-    /// (#1905 back-fill, QA-1), and this surface is a 380 pt popover. Six is
-    /// what fits under a 190 pt chart and its summary without pushing the
-    /// legend and the provenance line — the two things that explain the strip
-    /// — off the bottom.
-    ///
-    /// Lower than the web's twelve ON PURPOSE, and that is not a disagreement:
-    /// the daemon ranks `projects` by TOTAL AUTONOMOUS SECONDS, so each surface
-    /// shows a PREFIX of one shared order. Neither invents an ordering, and one
-    /// four-hour run still outranks forty three-second ones on both.
-    static let maxStripRows = 6
-
-    /// The rows actually drawn — the busiest `maxStripRows` projects.
-    var visibleProjects: [String] { Array(projects.prefix(Self.maxStripRows)) }
-
-    /// How many projects the cap left out. 0 when it did not bite.
-    var hiddenProjectCount: Int { Swift.max(0, projects.count - Self.maxStripRows) }
-
-    /// What the cap left out, named as a count rather than dropped in silence
-    /// — an omission nothing mentions is indistinguishable from a project that
-    /// never ran. It says WHY those rows are the missing ones, so the reader
-    /// knows the cap took the tail rather than an arbitrary slice.
-    var overflowLabel: String? {
-        let hidden = hiddenProjectCount
-        guard hidden > 0 else { return nil }
-        return "+\(hidden) more project\(hidden == 1 ? "" : "s"), each with less autonomous time than the rows above"
-    }
-}
-
-/// The strip's pixel-collapse rule (#1905 design decision 4), as a pure
-/// function so it can be tested without a view.
-///
-/// TWO HALVES, both load-bearing:
-///
-///   - **Every span draws at a minimum of one column.** At `12mo` a 40-second
-///     run is far under one pixel wide; rounding it to nothing would erase
-///     exactly the short runs the p5 line is about.
-///   - **A column holding several spans takes the HIGHEST-priority end
-///     reason** — error over waiting over ready, `AutonomyEndReason.priority`.
-///     The same ladder the session-history strip uses: one error in a column
-///     paints the whole column, because the thing worth seeing at a glance is
-///     that something broke in there.
-enum AutonomyStripLayout {
-    /// One drawn column of the strip. `occupied` and `reason` are separate
-    /// because a span whose reason this build cannot name STILL HAPPENED: it
-    /// occupies its column (drawn neutral) rather than reading as idle.
-    struct Column: Equatable {
-        var occupied: Bool
-        var reason: AutonomyEndReason?
-    }
-
-    /// Collapse `spans` into `columns` columns covering [start, end).
-    static func collapse(spans: [HistoryAutonomySpanRow],
-                         start: Int64,
-                         end: Int64,
-                         columns: Int) -> [Column] {
-        guard columns > 0, end > start else { return [] }
-        var out = [Column](repeating: Column(occupied: false, reason: nil), count: columns)
-        let width = Double(end - start)
-        for row in spans {
-            var first = Int((Double(row.start - start) / width * Double(columns)).rounded(.down))
-            var last = Int((Double(row.end - start) / width * Double(columns)).rounded(.down))
-            // A span entirely outside the window contributes nothing; one that
-            // straddles an edge is clipped to the visible part.
-            if last < 0 || first > columns - 1 { continue }
-            first = Swift.max(0, first)
-            last = Swift.min(columns - 1, last)
-            // The minimum-one-column rule: a sub-pixel run still draws.
-            if last < first { last = first }
-            let rank = row.endReason?.priority ?? 0
-            for i in first...last {
-                // -1 for an untouched column, so even an unnamed reason (rank
-                // 0) claims it.
-                let existingRank = out[i].occupied ? (out[i].reason?.priority ?? 0) : -1
-                out[i].occupied = true
-                if rank > existingRank { out[i].reason = row.endReason }
+        var start: Int?
+        for (i, point) in points.enumerated() {
+            if point?.hasLine == true {
+                if start == nil { start = i }
+            } else if let from = start {
+                out.append(Segment(from: from, to: i - 1))
+                start = nil
             }
         }
+        if let from = start { out.append(Segment(from: from, to: points.count - 1)) }
         return out
     }
 }

--- a/platforms/macos/Irrlicht/Theme/Tokens.swift
+++ b/platforms/macos/Irrlicht/Theme/Tokens.swift
@@ -67,24 +67,23 @@ enum IrrColors {
     static let readyDim   = ready.opacity(0.12)
     static let errorDim   = error.opacity(0.12)
 
-    // Autonomy chart (#1905) — ONE hue, three weights. The p50 line is
-    // `working` at full strength; the p5–p95 band is the same hue as a
-    // translucent plane, and its two edges the same hue again, quiet enough to
-    // bound the plane without competing with the line inside it.
+    // Autonomy panels (#1905) — ONE hue, two weights. The longest-run line is
+    // `working` at full strength; the concurrency histogram under it is the
+    // same hue, quieter, because the bars are a second reading of the same
+    // activity and not a second subject.
     //
     // `adaptive` rather than `working.opacity(…)` because the alpha itself has
     // to differ per appearance, and a single opacity cannot have two values:
-    // on a dark window a violet wash has to LIGHTEN the surface to register at
+    // on a dark window a violet bar has to LIGHTEN the surface to register at
     // all, while on a light one the same alpha reads as a solid lavender slab
-    // louder than the line it sits behind. Hex is `#AARRGGBB`, so the alpha
-    // rides in the token. Web twin: --autonomy-band / --autonomy-band-thin /
-    // --autonomy-edge in platforms/web/irrlicht.css, same alphas.
-    static let autonomyBand     = Color.adaptive(light: "#1C8B5CF6", dark: "#338B5CF6")
-    // Buckets under `sample_floor` keep their own, fainter plane: there p95 IS
-    // the maximum and p5 IS the minimum, so the area is a range rather than a
-    // percentile spread and must not read as one.
-    static let autonomyBandThin = Color.adaptive(light: "#0D8B5CF6", dark: "#148B5CF6")
-    static let autonomyEdge     = Color.adaptive(light: "#618B5CF6", dark: "#738B5CF6")
+    // louder than the line above it. Hex is `#AARRGGBB`, so the alpha rides in
+    // the token. Web twin: --autonomy-bar in platforms/web/irrlicht.css, same
+    // alphas.
+    //
+    // The p5–p95 band's three tokens went with the band (#1905 redesign): the
+    // section reports the LONGEST run now, so there is no plane to fill and no
+    // thin-bucket variant to distinguish.
+    static let autonomyBar      = Color.adaptive(light: "#618B5CF6", dark: "#738B5CF6")
 
     // Glow halos (--working-glow 0.25, --waiting-glow / --ready-glow 0.20).
     static let workingGlow = working.opacity(0.25)

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -3,26 +3,24 @@ import SwiftUI
 
 // MARK: - Autonomy section (#1905)
 //
-// Two elements over the always-on span log, rendered together because they
-// answer two halves of one question: element 1 is "is this getting better?"
-// (p95/p50/p5 of autonomous run duration over time), element 2 is "who ran
-// long, who kept stopping, and were the stops questions or errors?".
+// FIVE PER-PROJECT PANELS, one per project, stacked. Each carries a LINE — the
+// longest run in each time bucket — and, under it, a low HISTOGRAM of how many
+// runs were working at the same time in that bucket.
 //
-// Pure inputs (the two decoded responses), so a snapshot test can host this
-// view directly with fixture data.
+// HOW FIVE PANELS FIT A 380 pt POPOVER. The tab's content is already inside a
+// ScrollView (HistoryView.content), so the stack scrolls rather than compresses:
+// a 58 pt panel (14 pt header + 44 pt plot) times five is 290 pt, and the
+// header, the "+N more" line, the axis, the key and the provenance paragraph
+// follow it. Compressing instead would leave a histogram two points tall — a
+// smear that cannot be read — and the paragraphs that explain the figures are
+// the last thing that may be clipped.
+//
+// Pure inputs (the decoded response), so a snapshot test can host this view
+// directly with fixture data.
 
 struct HistoryAutonomyContentView: View {
-    let duration: HistoryAutonomyDurationResponse
-    let spans: HistoryAutonomySpansResponse
+    let data: HistoryAutonomyProjectsResponse
     let range: HistoryAutonomyRange
-    /// A BINDING, unlike `range`: the Span picker lives in this view now,
-    /// in the strip's own section header. Range still belongs to the tab's
-    /// control row because the chart is the first thing under it; Span sat up
-    /// there too, one row of controls above two elements, with nothing saying
-    /// which control moved which — and the two vocabularies overlap textually
-    /// (`30d` is a Range value AND a Span value), so the row read as one zoom
-    /// control with an odd set of steps.
-    @Binding var spanWindow: HistoryAutonomySpanWindow
 
     /// #1659 — every date this view renders takes its zone as an INPUT rather
     /// than reading `NSTimeZone.default`.
@@ -30,9 +28,7 @@ struct HistoryAutonomyContentView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp4) {
-            durationSection
-            Divider()
-            stripSection
+            panelStack
             Divider()
             collectionProvenance
         }
@@ -40,139 +36,44 @@ struct HistoryAutonomyContentView: View {
         .padding(.vertical, IrrSpacing.sp3)
     }
 
-    // MARK: Element 1 — duration over time
+    // MARK: The stack
 
-    @ViewBuilder private var durationSection: some View {
+    @ViewBuilder private var panelStack: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
             HStack {
-                Text("Autonomous run duration · \(range.label)")
+                Text("Longest autonomous run · \(range.label)")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Text("log scale")
+                Text("log scale, shared")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
-            if duration.hasData {
-                AutonomyDurationChart(data: duration, timeZone: formatTimeZone)
-                    .frame(height: 190)
+            if data.hasData {
+                ForEach(data.stackRows) { row in
+                    switch row {
+                    case let .panel(panel, index):
+                        AutonomyPanelView(panel: panel,
+                                          data: data,
+                                          panelIndex: index,
+                                          timeZone: formatTimeZone)
+                    case let .more(label):
+                        overflow(label)
+                    }
+                }
+                stackAxis
                 AutonomyKeyView()
+                concurrencyCaveat
                 summaryRow
-                if thinCount > 0 { thinNote }
             } else {
-                emptyDurationText
+                emptyText
             }
         }
     }
 
-    /// "p95 1h58m · p50 11m · p5 41s · longest 2h14m · shortest 22s · 312 runs"
-    /// — the true extremes are figures here, deliberately not lines on the
-    /// chart (see HistoryAutonomySummary).
-    private var summaryRow: some View {
-        let s = duration.summary
-        return Text(
-            "p95 \(AutonomyFormat.duration(s.p95)) · p50 \(AutonomyFormat.duration(s.p50)) · "
-            + "p5 \(AutonomyFormat.duration(s.p5)) · longest \(AutonomyFormat.duration(s.max)) · "
-            + "shortest \(AutonomyFormat.duration(s.min)) · \(s.count) runs"
-        )
-        .font(.caption)
-        .monospacedDigit()
-        .foregroundColor(.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private var thinCount: Int { duration.buckets.filter(\.thin).count }
-
-    /// Thin buckets are MARKED, never hidden and never smoothed — and the
-    /// marking is explained in words, because a fainter plane means nothing on
-    /// its own. Three signals, since a distinction is easy to lose inside a
-    /// smooth band: the plane itself, the edges bounding it, and the points.
-    private var thinNote: some View {
-        Text("\(thinCount) of \(duration.buckets.count) buckets hold fewer than \(duration.sampleFloor) runs "
-             + "(fainter band, dashed edges, hollow points): there, p95 is that bucket's longest run and "
-             + "p5 its shortest — not percentiles.")
-            .font(.caption2)
-            .foregroundColor(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    /// An empty chart with axes drawn is not acceptable (#1905): the empty
-    /// state says, in words, that the feature collects from the day it ships.
-    private var emptyDurationText: some View {
-        Text(duration.totalRecorded == 0
-             ? "No autonomous runs recorded yet. Irrlicht starts measuring them the first time a session runs after this update — an empty chart here means \"nothing recorded\", not \"nothing happened\"."
-             : "No runs in this range. \(duration.totalRecorded) runs are on record outside it.")
-            .font(.callout)
-            .foregroundColor(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
-            .multilineTextAlignment(.center)
-    }
-
-    // MARK: Element 2 — the run strip
-
-    @ViewBuilder private var stripSection: some View {
-        VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
-            // The strip's own header: its title and the picker that changes
-            // it, together — the whole point of moving Span down here.
-            HStack(spacing: IrrSpacing.sp2) {
-                Text("Runs · last \(spanWindow.label)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                Spacer(minLength: IrrSpacing.sp2)
-                Picker("Span", selection: $spanWindow) {
-                    ForEach(HistoryAutonomySpanWindow.allCases) { Text($0.label).tag($0) }
-                }
-                .labelsHidden()
-                .fixedSize()
-                .pickerStyle(.menu)
-                .controlSize(.small)
-                .font(.caption)
-            }
-            if spans.hasData {
-                // A header over the value column: the figure at the end of
-                // each row was a bare duration with nothing saying what it
-                // measured.
-                stripHeader
-                // Capped at the busiest few: unbounded, a back-filled 12mo
-                // window draws 95 rows into a 380 pt popover and buries the
-                // projects worth looking at (#1905 back-fill, QA-1).
-                ForEach(spans.visibleProjects, id: \.self) { project in
-                    AutonomyStripRow(project: project,
-                                     spans: spans.spans(for: project),
-                                     start: spans.start,
-                                     end: spans.end)
-                }
-                if let overflow = spans.overflowLabel { stripOverflow(overflow) }
-                // …and the window's bounds under it, so a mark can be placed
-                // in time. Two labels, not a tick axis: at 12mo a full axis is
-                // more furniture than the strip is worth, but "from when to
-                // when" is the difference between a timeline and a texture.
-                stripAxis
-                stripLegend
-                if spans.truncated { truncationNote }
-            } else {
-                emptyStripText
-            }
-        }
-    }
-
-    /// Column header for the per-row "longest" figure. Right-aligned by the
-    /// same Spacer the rows use, so it sits over the values it names.
-    private var stripHeader: some View {
-        HStack(spacing: IrrSpacing.sp2) {
-            Text("project")
-            Spacer(minLength: IrrSpacing.sp2)
-            Text("longest")
-        }
-        .font(.caption2)
-        .foregroundColor(.secondary)
-        .accessibilityHidden(true) // each row's own label already says "longest"
-    }
-
-    /// "+N more projects" — quieter than a row and clearly not one: it is a
-    /// statement about the strip, not another line of it.
-    private func stripOverflow(_ text: String) -> some View {
+    /// "+N more projects" — quieter than a panel and clearly not one: it is a
+    /// statement about the stack, not another entry in it.
+    private func overflow(_ text: String) -> some View {
         Text(text)
             .font(.caption2)
             .foregroundColor(.secondary)
@@ -181,56 +82,55 @@ struct HistoryAutonomyContentView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// The strip's window bounds: where it starts on the left, `now` on the
-    /// right. The start label coarsens with the window (a time of day at 8h, a
-    /// month at 12mo) — see AutonomyFormat.axisBound.
-    private var stripAxis: some View {
+    /// The window's bounds, ONCE under the whole stack: the five panels share
+    /// one x domain, so five copies would be five statements of one fact. The
+    /// start label coarsens with the window — see AutonomyFormat.axisBound.
+    private var stackAxis: some View {
         HStack(spacing: IrrSpacing.sp2) {
-            Text(AutonomyFormat.axisBound(Date(timeIntervalSince1970: TimeInterval(spans.start)),
-                                          windowSeconds: spans.end - spans.start,
+            Text(AutonomyFormat.axisBound(Date(timeIntervalSince1970: TimeInterval(data.start)),
+                                          windowSeconds: data.end - data.start,
                                           timeZone: formatTimeZone))
             Spacer(minLength: IrrSpacing.sp2)
             Text("now")
         }
         .font(.caption2)
         .foregroundColor(.secondary)
+        .padding(.leading, AutonomyPanelMetrics.labelGutter)
     }
 
-    /// The measured reasons, plus a neutral `unknown` entry when — and only
-    /// when — this window actually holds a run whose end reason nothing can
-    /// name (#1905 back-fill).
-    private var stripLegend: some View {
-        HStack(spacing: IrrSpacing.sp3) {
-            ForEach(AutonomyLegend.entries(for: spans.spans)) { entry in
-                HStack(spacing: IrrSpacing.sp1) {
-                    RoundedRectangle(cornerRadius: 1)
-                        .fill(AutonomyPalette.color(for: entry.reason))
-                        .frame(width: 10, height: 8)
-                    Text("\(entry.glyph) \(entry.label)")
-                }
-            }
-            Spacer(minLength: 0)
-        }
-        .font(.caption2)
-        .foregroundColor(.secondary)
-    }
-
-    private var truncationNote: some View {
-        Text("This window holds more runs than one request returns; the strip shows the oldest part of it. "
-             + "Pick a shorter span for a complete picture.")
+    /// The sentence beside the `at once` figure, and it is not optional:
+    /// without it the number is read as "N independent agents" and it is not
+    /// that. A parent is held `working` while its subagents run.
+    private var concurrencyCaveat: some View {
+        Text(AutonomyFormat.concurrencyCaveat)
             .font(.caption2)
-            .foregroundColor(IrrColors.waiting)
+            .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
     }
 
-    private var emptyStripText: some View {
-        Text(spans.totalRecorded == 0
-             ? "No runs recorded yet — this strip fills in as sessions run."
-             : "No runs in the last \(spanWindow.label). \(spans.totalRecorded) runs are on record over a longer period.")
+    /// "longest 11h39m in irrlicht · most at once 5 · 312 runs across 12 projects"
+    private var summaryRow: some View {
+        let s = data.summary
+        var longest = "longest \(AutonomyFormat.duration(s.longest))"
+        if !s.longestProject.isEmpty { longest += " in \(s.longestProject)" }
+        if s.longestRunning { longest += " (still going)" }
+        return Text("\(longest) · most at once \(s.peak) · \(s.runs) runs across \(s.projects) projects")
+            .font(.caption)
+            .monospacedDigit()
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// An empty stack with axes drawn is not acceptable (#1905): the empty
+    /// state says, in words, that the feature collects from the day it ships.
+    private var emptyText: some View {
+        Text(data.totalRecorded == 0
+             ? "No autonomous runs recorded yet. Irrlicht starts measuring them the first time a session runs after this update — an empty section here means \"nothing recorded\", not \"nothing happened\"."
+             : "No runs in this range. \(data.totalRecorded) runs are on record outside it.")
             .font(.callout)
             .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
+            .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
             .multilineTextAlignment(.center)
     }
 
@@ -243,22 +143,24 @@ struct HistoryAutonomyContentView: View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp1) {
             // What these figures counted (#1905 subagents). Above the
             // provenance line because it qualifies every number in the section,
-            // where provenance qualifies where they came from.
-            if let counting = AutonomyFormat.countingLine(duration.kinds) {
+            // where provenance qualifies where they came from — and because its
+            // `unknown` clause is why a panel's `at once` figure sometimes
+            // carries no split.
+            if let counting = AutonomyFormat.countingLine(data.kinds) {
                 Text(counting)
             }
             // …and which of them are floors rather than measurements (#1905
             // recording). Same register, same reason: a lower bound rendered as
             // a measurement is a wrong number with nothing on screen saying it
             // is wrong. Silent when every run in view is finished and measured.
-            if let measurement = AutonomyFormat.measurementLine(duration.measurementOrNone) {
+            if let measurement = AutonomyFormat.measurementLine(data.measurementOrNone) {
                 Text(measurement)
             }
-            Text(AutonomyFormat.provenance(earliest: duration.earliestSpan,
-                                           total: duration.totalRecorded,
+            Text(AutonomyFormat.provenance(earliest: data.earliestSpan,
+                                           total: data.totalRecorded,
                                            timeZone: formatTimeZone))
-            if let note = AutonomyFormat.reconstructionNote(duration.provenanceOrNone,
-                                                            inView: duration.summary.count,
+            if let note = AutonomyFormat.reconstructionNote(data.provenanceOrNone,
+                                                            inView: data.summary.runs,
                                                             timeZone: formatTimeZone) {
                 Text(note)
             }
@@ -269,149 +171,74 @@ struct HistoryAutonomyContentView: View {
     }
 }
 
-// MARK: - The percentile chart
+// MARK: - Panel geometry
 
-private struct AutonomyDurationChart: View {
-    let data: HistoryAutonomyDurationResponse
+/// The panel's fixed geometry, in points. Named rather than spread across the
+/// views so the stack's total height is arithmetic a reader can do: five times
+/// (`headerHeight` + `plotHeight` + `barsHeight`) plus the spacing between them.
+enum AutonomyPanelMetrics {
+    static let plotHeight: CGFloat = 32
+    static let barsHeight: CGFloat = 10
+    /// The width reserved for the shared axis's duration labels. The stack's
+    /// own x axis is indented by the same amount so its two bounds sit under
+    /// the plot rather than under the labels.
+    static let labelGutter: CGFloat = 46
+}
+
+// MARK: - One project's panel
+
+private struct AutonomyPanelView: View {
+    let panel: HistoryAutonomyPanel
+    let data: HistoryAutonomyProjectsResponse
+    /// Which panel of the stack this is — the caption rule reads it, and
+    /// nothing else does.
+    let panelIndex: Int
     let timeZone: TimeZone
 
-    /// One drawn point.
-    ///
-    /// `series` names which of the three lines it belongs to and is what the
-    /// colour scale reads. `run` is a different key on purpose: it names the
-    /// CONTIGUOUS STRETCH the point belongs to, and Swift Charts connects
-    /// points that share it. Without that second key a line is drawn through
-    /// every bucket the daemon sent — which silently bridges the omitted ones,
-    /// exactly the interpolation `alignedBuckets` exists to refuse.
-    private struct Datum: Identifiable {
-        let id: String
-        let date: Date
-        let series: String
-        let run: String
-        let value: Double
-        let thin: Bool
-    }
-
-    /// One stretch of the band: the plane between p5 and p95 over a run of
-    /// consecutive buckets, or (when `isolated`) a single bucket's spread.
-    private struct BandDatum: Identifiable {
-        let id: String
-        let date: Date
-        let run: String
-        let low: Double
-        let high: Double
-        let thin: Bool
-    }
-
-    /// Log scales cannot plot 0, and a span shorter than a second is not a
-    /// run — clamp to one second so a degenerate value cannot blank the chart.
-    private func plottable(_ v: Double) -> Double { Swift.max(1, v) }
-
-    private func date(at index: Int) -> Date {
-        Date(timeIntervalSince1970: TimeInterval(data.bucketStarts[index]))
-    }
-
-    private var points: [HistoryAutonomyBucket?] { data.alignedBuckets }
-    private var segments: [AutonomyBandLayout.Segment] {
-        AutonomyBandLayout.segments(points: points)
-    }
-
-    /// The three lines, split into one series per contiguous stretch so the
-    /// stroke BREAKS at every omitted bucket instead of being drawn through it.
-    private func lineData(_ segments: [AutonomyBandLayout.Segment]) -> [Datum] {
-        var out: [Datum] = []
-        for segment in segments where !segment.isIsolated {
-            for i in segment.from...segment.to {
-                guard let b = points[i] else { continue }
-                for key in AutonomyPalette.seriesOrder {
-                    let v: Double
-                    switch key {
-                    case "p95": v = b.p95
-                    case "p5": v = b.p5
-                    default: v = b.p50
-                    }
-                    out.append(Datum(id: "\(key)-\(segment.id)-\(b.ts)",
-                                     date: date(at: i),
-                                     series: key,
-                                     run: "\(key)#\(segment.id)",
-                                     value: plottable(v),
-                                     thin: segment.thin))
-                }
-            }
-        }
-        return out
-    }
-
-    private func bandData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
-        var out: [BandDatum] = []
-        for segment in segments where !segment.isIsolated {
-            for i in segment.from...segment.to {
-                guard let b = points[i] else { continue }
-                out.append(BandDatum(id: "band-\(segment.id)-\(b.ts)",
-                                     date: date(at: i),
-                                     run: segment.id,
-                                     low: plottable(b.p5),
-                                     high: plottable(b.p95),
-                                     thin: segment.thin))
-            }
-        }
-        return out
-    }
-
-    /// Buckets with no neighbour to make an area with. Drawn as a whisker
-    /// rather than dropped: a lone bucket is exactly where a reader most needs
-    /// to see how wide the range was, and it would otherwise be the only one
-    /// whose spread is invisible.
-    private func whiskerData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
-        segments.filter(\.isIsolated).compactMap { segment in
-            guard let b = points[segment.from] else { return nil }
-            return BandDatum(id: "whisker-\(segment.id)", date: date(at: segment.from), run: segment.id,
-                             low: plottable(b.p5), high: plottable(b.p95), thin: segment.thin)
-        }
-    }
-
-    /// Y domain with a little headroom, floored so a single short run still
-    /// draws inside a readable range.
-    private var yDomain: ClosedRange<Double> {
-        let values = data.buckets.flatMap { [plottable($0.p5), plottable($0.p95)] }
-        let lo = Swift.max(1, (values.min() ?? 1) * 0.8)
-        let hi = Swift.max(lo * 2, (values.max() ?? 60) * 1.25)
-        return lo...hi
-    }
+    private var points: [HistoryAutonomyPanelBucket?] { panel.alignedBuckets(data.bucketStarts) }
 
     var body: some View {
-        let segments = self.segments
-        let lines = lineData(segments)
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: IrrSpacing.sp2) {
+                Text(panel.project)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: IrrSpacing.sp2)
+                // The panel's OWN figures, so the exact longest never depends
+                // on reading a shared axis, and the concurrency split is
+                // legible rather than buried.
+                Text(panel.headline)
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+            longestRunChart
+            concurrencyBars
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(panel.project): \(panel.headline), \(panel.runs) runs")
+    }
+
+    /// The longest-run line, on the SHARED log domain.
+    ///
+    /// `run` is the series key on purpose: it names the CONTIGUOUS STRETCH a
+    /// point belongs to, and Swift Charts connects points that share it. Without
+    /// that key the line is drawn through every bucket the daemon sent — which
+    /// silently bridges the omitted ones, exactly the interpolation
+    /// `alignedBuckets` exists to refuse.
+    @ViewBuilder private var longestRunChart: some View {
+        let domain = data.sharedYDomain ?? 1...60
         Chart {
-            // FIRST in the builder, so the plane and the rules sit UNDER the
-            // lines. The band is context; the p50 line is the headline, and it
-            // is the last ink down so nothing crosses over it.
-            ForEach(bandData(segments)) { d in
-                AreaMark(
-                    x: .value("Date", d.date),
-                    yStart: .value("p5", d.low),
-                    yEnd: .value("p95", d.high),
-                    series: .value("Band", d.run)
-                )
-                .foregroundStyle(d.thin ? AutonomyPalette.bandThin : AutonomyPalette.band)
-                .interpolationMethod(.monotone)
-            }
-            ForEach(whiskerData(segments)) { d in
-                RuleMark(
-                    x: .value("Date", d.date),
-                    yStart: .value("p5", d.low),
-                    yEnd: .value("p95", d.high)
-                )
-                .lineStyle(StrokeStyle(lineWidth: 1, dash: d.thin ? [3, 3] : []))
-                .foregroundStyle(AutonomyPalette.edge)
-            }
-            // The source-change markers: the marker explains the data, it is
-            // not part of it, so it sits under the curves too.
+            // The source-change markers first, so they sit UNDER the line: the
+            // marker explains the data, it is not part of it.
             //
-            // A LONG-DASHED 1.5 pt rule, deliberately unlike the axis
-            // gridlines below (solid hairlines): before, both were thin dashes
-            // in a muted colour and the one line on the chart that carries an
-            // explanation was indistinguishable from furniture.
+            // A LONG-DASHED 1.5 pt rule, deliberately unlike the axis gridlines
+            // (solid hairlines): before, both were thin dashes in a muted colour
+            // and the one line carrying an explanation was indistinguishable
+            // from furniture. It is drawn on EVERY panel; only the top one is
+            // captioned (AutonomyBoundaryCaption).
             ForEach(data.visibleBoundaries) { boundary in
                 RuleMark(x: .value("Source change", boundary.date))
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [6, 3]))
@@ -419,73 +246,140 @@ private struct AutonomyDurationChart: View {
                     .annotation(position: .top,
                                 alignment: captionAlignment(for: boundary),
                                 spacing: 2) {
-                        Text(boundary.label)
-                            .font(.system(size: 9))
-                            .foregroundColor(.secondary)
-                            .opacity(0.9)
-                            .fixedSize()
+                        if AutonomyBoundaryCaption.isShown(panelIndex: panelIndex) {
+                            Text(boundary.label)
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary)
+                                .opacity(0.9)
+                                .fixedSize()
+                        }
                     }
             }
-            ForEach(lines) { d in
+            ForEach(lineData()) { d in
                 LineMark(
                     x: .value("Date", d.date),
-                    y: .value("Duration", d.value),
+                    y: .value("Longest", d.value),
                     series: .value("Run", d.run)
                 )
-                .foregroundStyle(by: .value("Series", d.series))
+                .foregroundStyle(AutonomyPalette.lineColor)
+                .lineStyle(StrokeStyle(lineWidth: 1.6))
                 .interpolationMethod(.monotone)
-                .lineStyle(StrokeStyle(lineWidth: AutonomyPalette.lineWidth(AutonomyPalette.role(of: d.series)),
-                                       dash: d.thin ? [3, 3] : []))
-                .opacity(AutonomyPalette.opacity(AutonomyPalette.role(of: d.series), thin: d.thin))
             }
-            // Thin buckets are marked rather than hidden: a hollow point on
-            // every line at that bucket, so a low-sample day is visibly
-            // different from a well-sampled one without being dropped. Inside
-            // a smooth band this is the third signal, alongside the fainter
-            // plane and the dashed edges.
-            ForEach(lines.filter(\.thin)) { d in
-                PointMark(
-                    x: .value("Date", d.date),
-                    y: .value("Duration", d.value)
-                )
-                .symbol(.circle)
-                .symbolSize(28)
-                .foregroundStyle(by: .value("Series", d.series))
-                .opacity(0.45)
+            // An isolated bucket has no neighbour to draw a segment to, and
+            // would otherwise be the one bucket that vanishes.
+            ForEach(lineData().filter(\.isolated)) { d in
+                PointMark(x: .value("Date", d.date), y: .value("Longest", d.value))
+                    .symbolSize(14)
+                    .foregroundStyle(AutonomyPalette.lineColor)
+            }
+            // A bucket whose longest run has not ended is hollow: its length is
+            // a floor, and the header says "still going" beside it.
+            ForEach(lineData().filter(\.running)) { d in
+                PointMark(x: .value("Date", d.date), y: .value("Longest", d.value))
+                    .symbol(.circle)
+                    .symbolSize(30)
+                    .foregroundStyle(AutonomyPalette.lineColor.opacity(0.5))
             }
         }
-        // One table for the three lines, read by the scale AND by
-        // AutonomyPalette.keyEntries — the web's twin of this is
-        // AUTONOMY_SERIES, and both surfaces must name the lines the same way.
-        .chartForegroundStyleScale(domain: AutonomyPalette.seriesOrder,
-                                   range: AutonomyPalette.seriesRange)
-        // …and the legend Swift Charts derives from that scale is hidden,
-        // because with one hue it would be three identical swatches naming
-        // three percentiles. AutonomyKeyView draws the two entries that
-        // actually correspond to marks on the chart.
-        .chartLegend(.hidden)
-        .chartYScale(domain: yDomain, type: .log)
+        .chartYScale(domain: domain, type: .log)
+        .chartXScale(domain: xDomain)
         .chartYAxis {
-            AxisMarks { value in
+            AxisMarks(values: .automatic(desiredCount: 3)) { value in
                 AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
                 AxisValueLabel {
                     if let v = value.as(Double.self) {
-                        Text(AutonomyFormat.duration(v))
+                        Text(AutonomyFormat.duration(v)).font(.system(size: 9))
                     }
                 }
             }
         }
-        .chartXAxis {
-            AxisMarks(values: .automatic(desiredCount: 4)) { value in
-                // Solid hairlines. Dashed x gridlines read as several source
-                // markers and made the real one impossible to find.
-                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                AxisValueLabel {
-                    if let d = value.as(Date.self) {
-                        Text(AutonomyFormat.axisDate(d, timeZone: timeZone))
-                    }
-                }
+        .chartXAxis(.hidden)
+        .frame(height: AutonomyPanelMetrics.plotHeight)
+    }
+
+    /// The concurrency histogram: one low bar per bucket, scaled against the
+    /// stack's SHARED peak so the five panels are comparable.
+    ///
+    /// A BUCKET WITH NO ONE WORKING DRAWS NOTHING — not a zero-height bar, and
+    /// not a hairline on the baseline. A mark on the axis reads as a measured
+    /// zero, which is a different and false claim from "no runs here".
+    @ViewBuilder private var concurrencyBars: some View {
+        let scale = data.sharedPeakScale
+        Chart {
+            ForEach(barData()) { d in
+                BarMark(
+                    x: .value("Date", d.date),
+                    y: .value("At once", d.peak)
+                )
+                .foregroundStyle(AutonomyPalette.bars)
             }
+        }
+        .chartYScale(domain: 0...Double(Swift.max(1, scale)))
+        .chartXScale(domain: xDomain)
+        .chartXAxis(.hidden)
+        .chartYAxis {
+            // The gutter is kept — an empty label of the same width — so the
+            // bars line up under the plot above rather than starting further
+            // left, which would put the histogram out of register with the line
+            // it belongs to.
+            AxisMarks(values: [0]) { _ in AxisValueLabel { Text("     ").font(.system(size: 9)) } }
+        }
+        .frame(height: AutonomyPanelMetrics.barsHeight)
+    }
+
+    /// Both charts share one x domain, so the line, the bars and the boundary
+    /// rule stay in register down the whole stack.
+    private var xDomain: ClosedRange<Date> {
+        let first = data.bucketStarts.first ?? data.start
+        let last = data.bucketStarts.last ?? data.end
+        let lo = Date(timeIntervalSince1970: TimeInterval(first))
+        let hi = Date(timeIntervalSince1970: TimeInterval(Swift.max(last, first + 1)))
+        return lo...hi
+    }
+
+    private struct Datum: Identifiable {
+        let id: String
+        let date: Date
+        let run: String
+        let value: Double
+        let running: Bool
+        let isolated: Bool
+    }
+
+    private struct BarDatum: Identifiable {
+        let id: String
+        let date: Date
+        let peak: Int
+    }
+
+    private func date(at index: Int) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(data.bucketStarts[index]))
+    }
+
+    /// The line, split into one series per contiguous stretch so the stroke
+    /// BREAKS at every gap instead of being drawn through it.
+    private func lineData() -> [Datum] {
+        var out: [Datum] = []
+        for segment in AutonomyLineLayout.segments(points: points) {
+            for i in segment.from...segment.to {
+                guard let b = points[i], b.hasLine, i < data.bucketStarts.count else { continue }
+                out.append(Datum(id: "\(panel.project)-\(b.ts)",
+                                 date: date(at: i),
+                                 run: "\(panel.project)#\(segment.id)",
+                                 // A log scale cannot plot 0, and a span shorter
+                                 // than a second is not a run.
+                                 value: Swift.max(1, b.longest),
+                                 running: b.running,
+                                 isolated: segment.isIsolated))
+            }
+        }
+        return out
+    }
+
+    private func barData() -> [BarDatum] {
+        points.enumerated().compactMap { i, b in
+            guard let b, b.hasBar, i < data.bucketStarts.count else { return nil }
+            return BarDatum(id: "bar-\(panel.project)-\(b.ts)", date: date(at: i), peak: b.peak)
         }
     }
 
@@ -500,10 +394,10 @@ private struct AutonomyDurationChart: View {
     }
 }
 
-// MARK: - The chart's key
+// MARK: - The stack's key
 
-/// Two entries, because the chart draws two things: a line and a plane. Each
-/// swatch takes the SHAPE of what it stands for — a pair of identically
+/// Two entries, because a panel draws two things: a line and a row of bars.
+/// Each swatch takes the SHAPE of what it stands for — a pair of identically
 /// coloured dots would be a key that says the same thing twice.
 private struct AutonomyKeyView: View {
     var body: some View {
@@ -526,182 +420,56 @@ private struct AutonomyKeyView: View {
             Capsule()
                 .fill(entry.color)
                 .frame(width: 16, height: 2)
-        case .band:
-            (entry.fill ?? Color.clear)
-                .frame(width: 16, height: 9)
-                .overlay(alignment: .top) { entry.color.frame(height: 1) }
-                .overlay(alignment: .bottom) { entry.color.frame(height: 1) }
-                .clipShape(RoundedRectangle(cornerRadius: 1))
-        }
-    }
-}
-
-// MARK: - One strip row
-
-private struct AutonomyStripRow: View {
-    let project: String
-    let spans: [HistoryAutonomySpanRow]
-    let start: Int64
-    let end: Int64
-
-    private static let rowHeight: CGFloat = 14
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            HStack(spacing: IrrSpacing.sp2) {
-                Text(project)
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: IrrSpacing.sp2)
-                Text(AutonomyFormat.duration(Double(longest)))
-                    .font(.caption2)
-                    .monospacedDigit()
-                    .foregroundColor(.secondary)
+        case .bars:
+            HStack(alignment: .bottom, spacing: 2) {
+                entry.color.frame(width: 3, height: 4)
+                entry.color.frame(width: 3, height: 9)
+                entry.color.frame(width: 3, height: 6)
             }
-            Canvas { context, size in
-                // One column per point of width. The collapse rule (minimum
-                // one column per span, highest-priority reason wins a shared
-                // column) lives in AutonomyStripLayout so it is testable
-                // without a view — and so the web draws the same strip.
-                let columns = Swift.max(1, Int(size.width.rounded(.down)))
-                let cells = AutonomyStripLayout.collapse(spans: spans, start: start, end: end, columns: columns)
-                let colWidth = size.width / CGFloat(columns)
-                for (i, cell) in cells.enumerated() where cell.occupied {
-                    let rect = CGRect(x: CGFloat(i) * colWidth, y: 0,
-                                      width: Swift.max(colWidth, 1), height: size.height)
-                    context.fill(Path(rect), with: .color(AutonomyPalette.color(for: cell.reason)))
-                }
-            }
-            .frame(height: Self.rowHeight)
-            .background(Color.secondary.opacity(0.08))
-            .clipShape(RoundedRectangle(cornerRadius: 2))
-            .accessibilityLabel(accessibilityText)
+            .frame(width: 16, height: 9, alignment: .bottom)
         }
-    }
-
-    private var longest: Int64 { spans.map(\.duration).max() ?? 0 }
-
-    private var accessibilityText: String {
-        "\(project): \(spans.count) runs, longest \(AutonomyFormat.duration(Double(longest)))"
     }
 }
 
 // MARK: - Palette + formatting
 
-/// One entry of the chart's key. `from` names the `AutonomyPalette.seriesOrder`
-/// row the entry takes its colour from, so a key entry cannot be given a
-/// colour the chart does not draw.
+/// One entry of the stack's key. `kind` names the MARK it stands for, so a key
+/// entry cannot be given a colour for something the panels do not draw.
 struct AutonomyKeyEntry: Identifiable, Equatable {
-    enum Kind: String { case line, band }
+    enum Kind: String { case line, bars }
 
     let kind: Kind
-    let from: String
     let label: String
     let color: Color
-    /// The plane's fill. `nil` for the line entry — a line has no area, and a
-    /// swatch with a fill would claim one.
-    let fill: Color?
 
     var id: String { kind.rawValue }
 }
 
 enum AutonomyPalette {
-    /// The three drawn lines, in draw order, and their colours — ONE table,
-    /// read by the chart's style scale AND by the two key entries below, so
-    /// the key and the curves cannot disagree. Mirrors the web's
-    /// AUTONOMY_SERIES, which carries the same property.
+    /// ONE HUE, TWO WEIGHTS. The longest-run line is `working` at full
+    /// strength; the concurrency histogram under it is the same hue, quieter,
+    /// because the bars are a second reading of the same activity and not a
+    /// second subject. `barsAreTheLineHue` in the tests pins that.
     ///
-    /// ONE HUE, THREE WEIGHTS. The first round drew p95 green, p50 purple and
-    /// p5 orange — three equally loud curves and a legend that had to be
-    /// decoded before the chart said anything. It says one thing now: here is
-    /// the typical run (the solid `line`), and here is the spread around it
-    /// (the plane between the two quiet `edge`s). A hue per percentile made
-    /// p95 and p5 read as two independent measurements rather than as the
-    /// boundary of one range.
-    static let seriesOrder = ["p95", "p50", "p5"]
-    static let seriesColors: [String: Color] = [
-        "p95": IrrColors.working,
-        "p50": IrrColors.working,
-        "p5": IrrColors.working,
-    ]
+    /// What went: a colour per percentile. The first round drew p95 green, p50
+    /// purple and p5 orange — three equally loud curves and a legend that had to
+    /// be decoded before the chart said anything.
+    static var lineColor: Color { IrrColors.working }
+    static var bars: Color { IrrColors.autonomyBar }
 
-    /// What each line is FOR. The colours no longer separate them, so the
-    /// roles do — and the chart reads its stroke weights from here rather than
-    /// from a literal beside each mark.
-    enum Role { case line, edge }
-    static let seriesRoles: [String: Role] = [
-        "p95": .edge,
-        "p50": .line,
-        "p5": .edge,
-    ]
-
-    static func role(of key: String) -> Role { seriesRoles[key] ?? .line }
-
-    /// The headline line's colour: the one every reader is meant to follow.
-    static var lineColor: Color { seriesColors["p50"] ?? .gray }
-
-    /// The band's own three weights — the plane, the fainter plane a thin
-    /// stretch gets, and the weight its two edges are stroked at. A second
-    /// TABLE, not a second palette: every one of them is the `working` hue at
-    /// a lower alpha (`bandIsTheLineHue` in the tests pins that), and both the
-    /// chart and the key read these same entries.
-    static var band: Color { IrrColors.autonomyBand }
-    static var bandThin: Color { IrrColors.autonomyBandThin }
-    static var edge: Color { IrrColors.autonomyEdge }
-
-    /// Stroke weight per role. The line carries the chart; the edges are
-    /// present enough to bound the plane and quiet enough not to compete.
-    static func lineWidth(_ role: Role) -> CGFloat { role == .line ? 1.8 : 1 }
-    static func opacity(_ role: Role, thin: Bool) -> Double {
-        switch (role, thin) {
-        case (.line, false): return 1
-        case (.line, true): return 0.6
-        case (.edge, false): return 0.5
-        case (.edge, true): return 0.32
-        }
-    }
-
-    /// The chart's key: exactly two entries, because the chart draws exactly
-    /// two things. Three percentile swatches in one hue would promise a
-    /// distinction the chart stopped making — which is why the Swift Charts
-    /// legend derived from `seriesOrder` is hidden and this is drawn instead.
+    /// The stack's key: exactly two entries, because a panel draws exactly two
+    /// things.
     ///
-    /// Named for a reader who has never seen a percentile — the register the
-    /// section already used ("the typical run") — with the p-labels kept in
-    /// front for a reader who has. Two noun phrases that read as a pair: the
-    /// chart draws one line and one plane, and these name them as one thing
-    /// and its spread rather than as two measurements.
-    ///
-    /// SAME TWO STRINGS AS THE WEB's panel key (AUTONOMY_KEY in
-    /// platforms/web/historyTab.js), and pinned against it by `the two
-    /// surfaces name the key the same way` — two clients must not explain one
-    /// chart differently. This popover has room the web's 260 pt side panel
-    /// does not, so the length that fits THERE is the length both carry.
+    /// SAME TWO STRINGS AS THE WEB's side-panel key (AUTONOMY_KEY in
+    /// platforms/web/historyTab.js), and pinned against it by `the two surfaces
+    /// name the key the same way` — two clients must not explain one chart
+    /// differently. That panel is 260 pt where this popover is 380, so the
+    /// length that fits THERE is the length both carry.
     static var keyEntries: [AutonomyKeyEntry] {
         [
-            AutonomyKeyEntry(kind: .line, from: "p50", label: "p50 · the typical run",
-                             color: seriesColors["p50"] ?? .gray, fill: nil),
-            AutonomyKeyEntry(kind: .band, from: "p95", label: "p5–p95 · the usual spread",
-                             color: edge, fill: band),
+            AutonomyKeyEntry(kind: .line, label: "longest run in a bucket", color: lineColor),
+            AutonomyKeyEntry(kind: .bars, label: "working at once (peak)", color: bars),
         ]
-    }
-
-    /// The scale's range in `seriesOrder`. A key with no colour would be a
-    /// line drawn in the fallback grey rather than silently undrawn, which is
-    /// why this cannot crash on a bad key — but `seriesColorsCoverEveryLine`
-    /// in the tests refuses one.
-    static var seriesRange: [Color] { seriesOrder.map { seriesColors[$0] ?? .gray } }
-
-    /// A column's fill. An unnamed reason is drawn neutral rather than
-    /// skipped: the run happened, this build just cannot say how it ended.
-    static func color(for reason: AutonomyEndReason?) -> Color {
-        switch reason {
-        case .some(.error): return IrrColors.error
-        case .some(.waiting): return IrrColors.waiting
-        case .some(.ready): return IrrColors.ready
-        case .none: return Color.secondary.opacity(0.55)
-        }
     }
 }
 
@@ -725,10 +493,39 @@ enum AutonomyFormat {
         return h == 0 ? "\(d)d" : "\(d)d\(h)h"
     }
 
-    /// The run strip's left bound, coarsening with the window the way the
-    /// activity matrix's column headers do: an 8h strip needs a time of day, a
-    /// 12mo strip needs a month. In the caller's zone (#1659), never the
-    /// machine's.
+    /// One "at once" figure, with its split only when the daemon says the split
+    /// is derivable.
+    ///
+    /// NO SPLIT IS SHOWN OVER DATA THAT CANNOT SUPPORT ONE. Most rows written
+    /// before 18 Aug 2026 carry `kind: unknown` — they predate the
+    /// classification, or the back-fill rebuilt them from a source with no
+    /// parent information — and there is no way to recover which they were. The
+    /// total alone is the honest answer there; "5 (5 + 0 sub)" would be an
+    /// invented one.
+    static func concurrency(peak: Int, top: Int, sub: Int, splitKnown: Bool) -> String {
+        guard peak > 0 else { return "" }
+        guard splitKnown else { return "\(peak) at once" }
+        return "\(peak) at once (\(top) + \(sub) sub)"
+    }
+
+    /// The caveat beside the `at once` figure, and it is not optional: without
+    /// it the number is read as "N independent agents" and it is not that.
+    ///
+    /// The daemon deliberately holds a PARENT session in `working` while its
+    /// subagents run, so one agent with three subagents overlaps as four. Four
+    /// things really were working — the figure is not wrong — but a reader who
+    /// takes it for four independent agents has been misled by a true number,
+    /// which is the exact failure this section keeps writing sentences to avoid.
+    ///
+    /// SAME WORDING AS THE WEB's AUTONOMY_CONCURRENCY_CAVEAT.
+    static let concurrencyCaveat =
+        "A parent is held working while its subagents run, so one agent with three subagents counts as "
+        + "four at once. Four things really were working — but not four independent agents. That is what "
+        + "the “N + M sub” split separates, and it is shown wherever every run at the peak said which it was."
+
+    /// The stack's left bound, coarsening with the window the way the activity
+    /// matrix's column headers do: a 30-day stack needs a date, a year-long one
+    /// a month. In the caller's zone (#1659), never the machine's.
     static func axisBound(_ date: Date, windowSeconds: Int64, timeZone: TimeZone) -> String {
         if windowSeconds <= 36 * 3600 { return formatted(date, "HH:mm", timeZone) }
         if windowSeconds <= 60 * 86400 { return formatted(date, "MMM d", timeZone) }
@@ -757,7 +554,7 @@ enum AutonomyFormat {
     static func provenance(earliest: Int64, total: Int, timeZone: TimeZone) -> String {
         guard earliest > 0 else {
             return "No autonomous runs recorded yet. Irrlicht began measuring them with this update; "
-                + "the charts above fill in as sessions run."
+                + "the panels above fill in as sessions run."
         }
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
@@ -772,15 +569,16 @@ enum AutonomyFormat {
     /// census — absence there means "this response never said", which is not
     /// the same claim as "there were none".
     ///
-    /// THERE IS NO MODE ANY MORE. Every run counts, subagent runs included,
-    /// because Irrlicht recorded them — so no excluded count is reported and
-    /// there is no control whose position a reader has to remember. What the
-    /// sentence still does is describe the window's MAKEUP.
+    /// THERE IS NO MODE. Every run counts, subagent runs included, because
+    /// Irrlicht recorded them — so no excluded count is reported and there is no
+    /// control whose position a reader has to remember. What the sentence still
+    /// does is describe the window's MAKEUP.
     ///
-    /// THE UNKNOWN CLAUSE STAYS LOAD-BEARING. A row written before Irrlicht
-    /// told the two apart carries no classification, and it is counted like the
-    /// rest — but counting it in silence would let the panel imply a
-    /// classification nobody made. So it says how many.
+    /// THE UNKNOWN CLAUSE STAYS LOAD-BEARING, and now carries its consequence
+    /// for the concurrency figure: a row written before Irrlicht told the two
+    /// apart is counted like the rest, but a peak one of them was alive for
+    /// cannot be split, and the sentence says so rather than leaving a missing
+    /// split to read as a bug.
     static func countingLine(_ k: HistoryAutonomyKinds?) -> String? {
         guard let k else { return nil }
         var out = k.subagent > 0
@@ -790,7 +588,7 @@ enum AutonomyFormat {
         if k.unknown > 0 {
             out += " \(k.unknown) run\(k.unknown == 1 ? " was" : "s were") recorded before Irrlicht told "
                 + "top-level and subagent runs apart, so which they were is unknown — those are counted "
-                + "either way."
+                + "either way, and a peak one of them was alive for is shown as a total with no split."
         }
         return out
     }
@@ -801,17 +599,16 @@ enum AutonomyFormat {
     /// up all day.
     ///
     /// Two kinds, two sentences, because they are two different limits and a
-    /// reader who merged them would misread the chart in opposite directions:
+    /// reader who merged them would misread the panels in opposite directions:
     ///
-    ///   - STILL RUNNING. The run has not ended, so its length is unknowable.
-    ///     It is shown, and deliberately kept out of the percentiles — folding
-    ///     a floor into a p95 as though it were final always shortens, and
-    ///     shortens the longest runs hardest. Both halves are said, so a reader
-    ///     who can see a 3-hour run on the strip is not left wondering why the
-    ///     median did not move.
+    ///   - STILL RUNNING. The run has not ended, so its length is how long it
+    ///     has lasted SO FAR. It COUNTS towards the longest — the section
+    ///     reports a maximum, and "already lasted 3h" is true — and the panel
+    ///     that shows it says "still going" rather than presenting a floor as
+    ///     final.
     ///   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its
-    ///     start is where the watching began. Those ARE samples; dropping them
-    ///     is what left 5 of a day's 35 runs on the record.
+    ///     start is where the watching began. Dropping those is what left 5 of a
+    ///     day's 35 runs on the record.
     static func measurementLine(_ m: HistoryAutonomyMeasurement) -> String? {
         guard m.any else { return nil }
         var parts: [String] = []
@@ -819,7 +616,8 @@ enum AutonomyFormat {
             let one = m.running == 1
             parts.append("\(m.running) run\(one ? " is" : "s are") still going: "
                 + "\(one ? "its length is" : "their lengths are") how long \(one ? "it has" : "they have") "
-                + "lasted SO FAR, so \(one ? "it is" : "they are") shown but left out of the percentiles.")
+                + "lasted SO FAR. \(one ? "It counts" : "They count") towards the longest run, marked "
+                + "\"still going\".")
         }
         if m.lowerBoundStart > 0 {
             let one = m.lowerBoundStart == 1
@@ -839,8 +637,7 @@ enum AutonomyFormat {
     /// answers a question the reader would otherwise answer wrongly: HOW MANY
     /// of the runs in view are reconstructed, the date BEFORE WHICH everything
     /// is reconstructed, and whether any of it came from a source that cannot
-    /// say how a run ended — so an `unknown` column in the strip reads as a
-    /// limit of the source rather than as a bug.
+    /// say how a run ended.
     static func reconstructionNote(_ p: HistoryAutonomyProvenance,
                                    inView: Int,
                                    timeZone: TimeZone) -> String? {

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -92,12 +92,11 @@ struct HistoryView: View {
     // daemon's own chart=="state" special-case in resolveHistoryQuery).
     @State private var stateGranularity: HistoryGranularity = .hr24
 
-    // Autonomy (#1905) — TWO pickers, because the tab holds two elements with
-    // different windows: a Range for the percentile chart and a Span for the
-    // run strip. Both send ?window=, whose keys are window LENGTHS (unlike
-    // stateGranularity's same-looking keys, which are bucket widths).
+    // Autonomy (#1905) — ONE picker. The tab is a single element now (five
+    // per-project panels), so it has a single window: Range, sent as ?window=,
+    // whose keys are window LENGTHS (unlike stateGranularity's same-looking
+    // keys, which are bucket widths). The strip's Span went with the strip.
     @State private var autonomyRange: HistoryAutonomyRange = .days30
-    @State private var autonomySpanWindow: HistoryAutonomySpanWindow = .hours24
     // There is no section-wide run-scope state any more (#1905 recording): the
     // section counts every run, subagent runs included, so there is nothing to
     // hold and nothing for the query key below to vary on.
@@ -113,10 +112,9 @@ struct HistoryView: View {
     @State private var yieldResponse: HistoryYieldResponse?
     @State private var doraResponse: HistoryDoraResponse?
     @State private var stateResponse: HistoryStateResponse?
-    // Autonomy fetches BOTH elements for one tab render, so it keeps two
-    // responses rather than sharing the single-chart slot above.
-    @State private var autonomyDuration: HistoryAutonomyDurationResponse?
-    @State private var autonomySpans: HistoryAutonomySpansResponse?
+    // Autonomy has its own payload shape and its own window, so it keeps its
+    // own slot rather than sharing the single-chart one above.
+    @State private var autonomyProjects: HistoryAutonomyProjectsResponse?
     @State private var loadFailed = false
 
     init(onClose: @escaping () -> Void, initialTab: HistoryTab = .usage) {
@@ -128,7 +126,7 @@ struct HistoryView: View {
     /// This is the macOS equivalent of the web's manual `historyFetchSeq`
     /// dedup — `.task(id:)` cancels the in-flight request when the key changes.
     private var queryKey: String {
-        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)-\(autonomyRange.rawValue)-\(autonomySpanWindow.rawValue)"
+        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)-\(autonomyRange.rawValue)"
         if range == .custom {
             return "custom-\(appliedCustomStart ?? 0)-\(appliedCustomEnd ?? 0)-\(dims)"
         }
@@ -321,19 +319,16 @@ struct HistoryView: View {
         .font(.caption)
     }
 
-    /// Autonomy tab (#1905): Range, and only Range. It governs the duration
-    /// chart, which is the first thing under this row.
+    /// Autonomy tab (#1905): Range, and only Range. It governs all five
+    /// panels, which are the first thing under this row.
     ///
-    /// Span — the run strip's window — used to sit here beside it, one control
-    /// row above BOTH elements, with nothing on screen saying which control
-    /// moved which; the two vocabularies even overlap textually (`30d` is a
-    /// Range value AND a Span value), so the row read as a single zoom control
-    /// with an odd set of steps. Span now lives in the strip's own section
-    /// header, in HistoryAutonomyContentView.
+    /// Span — the run strip's window — used to sit here beside it, two controls
+    /// above two elements with nothing on screen saying which moved which, and
+    /// two vocabularies that overlap textually (`30d` was a Range value AND a
+    /// Span value). The strip is gone and Span went with it.
     ///
-    /// Neither is the shared `range`: the two elements answer different
-    /// questions over different windows, and the section uses no Group or
-    /// drilldown at all.
+    /// It is not the shared `range`: the section answers a different question
+    /// over a different window, and uses no Group or drilldown at all.
     @ViewBuilder private var autonomyControls: some View {
         HStack(spacing: IrrSpacing.sp3) {
             Text("Range").foregroundColor(.secondary)
@@ -482,12 +477,10 @@ struct HistoryView: View {
         }
     }
 
-    /// Autonomy tab (#1905): both elements, always together — the percentile
-    /// chart above, the run strip below.
+    /// Autonomy tab (#1905): the five per-project panels.
     @ViewBuilder private var autonomyContent: some View {
-        if let d = autonomyDuration, let s = autonomySpans {
-            HistoryAutonomyContentView(duration: d, spans: s,
-                                       range: autonomyRange, spanWindow: $autonomySpanWindow)
+        if let d = autonomyProjects {
+            HistoryAutonomyContentView(data: d, range: autonomyRange)
         } else if loadFailed {
             loadFailedText
         } else {
@@ -625,28 +618,22 @@ struct HistoryView: View {
         }
     }
 
-    /// Autonomy (#1905) fetches BOTH elements — the tab shows them together,
-    /// and each has its own window, so neither can be folded into the shared
-    /// single-chart fetch above. A failure in either marks the tab failed
-    /// rather than showing one element beside a spinner that never resolves.
+    /// Autonomy (#1905) has its own window and its own payload shape, so it
+    /// cannot be folded into the shared single-chart fetch above.
     private func fetchAutonomy() async {
         loadFailed = false
-        async let duration: HistoryAutonomyDurationResponse? =
-            fetchAutonomyPart(chart: "autonomy_duration", window: autonomyRange.rawValue)
-        async let spans: HistoryAutonomySpansResponse? =
-            fetchAutonomyPart(chart: "autonomy_spans", window: autonomySpanWindow.rawValue)
-        let (d, s) = await (duration, spans)
+        let d: HistoryAutonomyProjectsResponse? =
+            await fetchAutonomyPart(chart: "autonomy_projects", window: autonomyRange.rawValue)
         if Task.isCancelled { return }
-        guard let d, let s else {
+        guard let d else {
             loadFailed = true
             return
         }
-        autonomyDuration = d
-        autonomySpans = s
+        autonomyProjects = d
     }
 
-    /// One Autonomy request. Returns nil on any failure — the caller decides
-    /// what an incomplete pair means, rather than each half guessing.
+    /// The Autonomy request. Returns nil on any failure — the caller decides
+    /// what that means rather than the fetch guessing.
     private func fetchAutonomyPart<T: Decodable>(chart: String, window: String) async -> T? {
         var comps = URLComponents(string: "\(DaemonEndpoint.httpBase)/api/v1/history")
         // The chart and its window, and nothing else (#1905 recording). Every

--- a/platforms/macos/Tests/HistoryAutonomyBackfillTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyBackfillTests.swift
@@ -12,28 +12,18 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
 
     // MARK: Decoding the provenance block
 
-    func testProvenanceDecodesFromBothPayloads() throws {
-        let durationJSON = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[1],"buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":100,"count":30}],
-         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
-         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33,
+    func testProvenanceDecodes() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0,"runs":33,"projects":2},
+         "earliest_span":1700000000,"total_recorded":33,
          "provenance":{"reconstructed":9,"cost_derived":4,"live_since":1755000000}}
         """
-        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(durationJSON.utf8))
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
         XCTAssertEqual(d.provenanceOrNone.reconstructed, 9)
         XCTAssertEqual(d.provenanceOrNone.costDerived, 4)
         XCTAssertEqual(d.provenanceOrNone.liveSince, 1_755_000_000)
-
-        let spansJSON = """
-        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[{"start":1,"end":9,"project":"a","session":"s1","reason":"unknown"}],
-         "projects":["a"],"earliest_span":1,"total_recorded":1,"truncated":false,
-         "provenance":{"reconstructed":1,"cost_derived":1,"live_since":0}}
-        """
-        let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(spansJSON.utf8))
-        XCTAssertEqual(s.provenanceOrNone.reconstructed, 1)
-        XCTAssertEqual(s.provenanceOrNone.liveSince, 0)
     }
 
     /// A payload from a daemon that predates the field must still decode. The
@@ -41,27 +31,14 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
     /// is a worse failure than saying nothing about provenance.
     func testAnAbsentProvenanceBlockDecodesAsSayingNothing() throws {
         let json = """
-        {"window":"1y","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":604800,
-         "bucket_starts":[1],"buckets":[],
-         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
-         "sample_floor":20,"earliest_span":0,"total_recorded":0}
+        {"window":"1y","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":604800,
+         "bucket_starts":[1],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0},"earliest_span":0,"total_recorded":0}
         """
-        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
         XCTAssertEqual(d.provenanceOrNone, .none)
         XCTAssertFalse(d.provenanceOrNone.isReconstructed)
         XCTAssertNil(AutonomyFormat.reconstructionNote(d.provenanceOrNone, inView: 0, timeZone: utc))
-    }
-
-    /// `unknown` is not one of the three measured reasons, so it decodes to a
-    /// nil `endReason` and draws in the neutral colour both surfaces already
-    /// use for a reason they cannot name.
-    func testUnknownReasonDecodesAsUnnamedAndDrawsNeutral() throws {
-        let json = """
-        {"start":1,"end":9,"project":"a","session":"s1","reason":"unknown"}
-        """
-        let row = try JSONDecoder().decode(HistoryAutonomySpanRow.self, from: Data(json.utf8))
-        XCTAssertNil(row.endReason, "`unknown` must not decode into a measured end reason")
-        XCTAssertEqual(AutonomyPalette.color(for: row.endReason), AutonomyPalette.color(for: nil))
     }
 
     // MARK: The note
@@ -133,99 +110,7 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
         XCTAssertNotNil(AutonomyFormat.reconstructionNote(backfilled, inView: 100, timeZone: utc))
     }
 
-    // MARK: The legend
-
-    func testLegendIsTheMeasuredReasonsWhenEveryReasonIsNamed() {
-        let spans = [
-            row(reason: "ready"),
-            row(reason: "waiting"),
-            row(reason: "error"),
-        ]
-        let entries = AutonomyLegend.entries(for: spans)
-        XCTAssertEqual(entries.count, AutonomyEndReason.allCases.count)
-        XCTAssertFalse(entries.contains(AutonomyLegend.unknown))
-    }
-
-    func testLegendGainsTheNeutralEntryForAnUnknownRun() {
-        let entries = AutonomyLegend.entries(for: [row(reason: "ready"), row(reason: "unknown")])
-        XCTAssertEqual(entries.count, AutonomyEndReason.allCases.count + 1)
-        XCTAssertEqual(entries.last, AutonomyLegend.unknown)
-        XCTAssertNil(entries.last?.reason, "the neutral entry stands for every unnameable reason, not one of them")
-    }
-
-    /// Two different rows draw the same neutral column — a cost-derived span
-    /// carrying `unknown`, and an old row written before the reason was
-    /// recorded. One entry covers both, or one of them is a colour with no key.
-    func testLegendGainsTheNeutralEntryForARowWithNoReasonAtAll() {
-        let entries = AutonomyLegend.entries(for: [row(reason: "ready"), row(reason: nil)])
-        XCTAssertEqual(entries.count, AutonomyEndReason.allCases.count + 1)
-    }
-
-    func testLegendDoesNotInventAnEntryForAnEmptyWindow() {
-        XCTAssertEqual(AutonomyLegend.entries(for: []).count, AutonomyEndReason.allCases.count)
-    }
-
-    /// An `unknown` span still OCCUPIES its column — the run happened, nothing
-    /// can say how it ended — but never outranks a measured reason sharing it.
-    func testUnknownOccupiesItsColumnButNeverOutranksAMeasuredReason() {
-        let unknownOnly = AutonomyStripLayout.collapse(
-            spans: [row(start: 1_000, end: 1_100, reason: "unknown")], start: 0, end: 100_000, columns: 10)
-        XCTAssertTrue(unknownOnly[0].occupied, "an unknown run must not read as idle")
-        XCTAssertNil(unknownOnly[0].reason)
-
-        let shared = AutonomyStripLayout.collapse(
-            spans: [row(start: 1_000, end: 1_100, reason: "unknown"),
-                    row(start: 1_200, end: 1_300, reason: "error")],
-            start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(shared[0].reason, .error, "one unknown run must not grey out a column holding a real error")
-    }
-
-    // MARK: The strip's row cap (QA-1)
-
-    /// The strip had no row cap at all, which nobody could see until the
-    /// back-fill gave it history to draw: a 12mo window over a back-filled log
-    /// renders 95 project rows into a 380 pt popover. The daemon ranks
-    /// `projects` by TOTAL AUTONOMOUS SECONDS, so the cap keeps the rows that
-    /// matter and the omission is stated rather than silent.
-    func testStripDrawsExactlyTheCapAndAccountsForTheRest() throws {
-        let spans = try spansResponse(projectCount: 95)
-        XCTAssertEqual(spans.visibleProjects.count, HistoryAutonomySpansResponse.maxStripRows)
-        // A PREFIX of the daemon's ranking — the cap must never reorder, or the
-        // two clients would disagree about which projects are the busiest.
-        XCTAssertEqual(spans.visibleProjects,
-                       Array(spans.projects.prefix(HistoryAutonomySpansResponse.maxStripRows)))
-        XCTAssertEqual(spans.hiddenProjectCount, 95 - HistoryAutonomySpansResponse.maxStripRows)
-        let overflow = try XCTUnwrap(spans.overflowLabel)
-        XCTAssertTrue(overflow.contains("+\(95 - HistoryAutonomySpansResponse.maxStripRows) more projects"),
-                      "got: \(overflow)")
-        // …and WHY they are the missing ones, so the cap does not read as an
-        // arbitrary slice of an unknown ordering.
-        XCTAssertTrue(overflow.contains("less autonomous time"), "got: \(overflow)")
-    }
-
-    func testStripSaysNothingWhenEveryProjectFits() throws {
-        let spans = try spansResponse(projectCount: HistoryAutonomySpansResponse.maxStripRows)
-        XCTAssertEqual(spans.visibleProjects.count, HistoryAutonomySpansResponse.maxStripRows)
-        XCTAssertEqual(spans.hiddenProjectCount, 0)
-        XCTAssertNil(spans.overflowLabel)
-    }
-
-    func testStripOverflowIsSingularForOneHiddenProject() throws {
-        let spans = try spansResponse(projectCount: HistoryAutonomySpansResponse.maxStripRows + 1)
-        let overflow = try XCTUnwrap(spans.overflowLabel)
-        XCTAssertTrue(overflow.contains("+1 more project,"), "got: \(overflow)")
-    }
-
-    /// This surface caps lower than the web's twelve, and that is not a
-    /// disagreement: both show a prefix of one shared ranking. What must hold
-    /// is that the popover's cap is the smaller one — it has 380 pt to work in.
-    func testStripCapFitsThisSurface() {
-        XCTAssertGreaterThan(HistoryAutonomySpansResponse.maxStripRows, 0)
-        XCTAssertLessThanOrEqual(HistoryAutonomySpansResponse.maxStripRows, 8,
-                                 "more rows than a 380 pt popover can show under a 190 pt chart")
-    }
-
-    // MARK: Source boundaries on the chart (QA-2)
+    // MARK: Source boundaries across the panel stack (QA-2)
 
     func testARangeStraddlingABoundaryMarksIt() throws {
         let d = try durationResponse(bucketStarts: [0, 100, 200, 300, 400],
@@ -263,12 +148,11 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
         XCTAssertTrue(empty.visibleBoundaries.isEmpty)
         // …and a payload from a daemon that predates the field.
         let json = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[0,100,200],"buckets":[],
-         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
-         "sample_floor":20,"earliest_span":0,"total_recorded":0}
+        {"window":"30d","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[0,100,200],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0},"earliest_span":0,"total_recorded":0}
         """
-        let old = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        let old = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
         XCTAssertTrue(old.visibleBoundaries.isEmpty)
     }
 
@@ -314,11 +198,11 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
     /// QA-1/QA-2) and one that speaks unconditionally both answer identically
     /// for the two fixtures of each pair; production must not, or each
     /// direction could pass against a build that never looked at the data.
-    func testProductionTellsTheCappedAndStraddlingFixturesApart() throws {
-        let fits = try spansResponse(projectCount: HistoryAutonomySpansResponse.maxStripRows)
-        let overflows = try spansResponse(projectCount: HistoryAutonomySpansResponse.maxStripRows + 1)
-        let neverSpeaks: (HistoryAutonomySpansResponse) -> String? = { _ in nil }
-        let alwaysSpeaks: (HistoryAutonomySpansResponse) -> String? = { _ in "+N more projects" }
+    func testProductionTellsTheOverflowAndStraddlingFixturesApart() throws {
+        let fits = try projectsResponse(panelCount: 5, moreProjects: 0)
+        let overflows = try projectsResponse(panelCount: 5, moreProjects: 7)
+        let neverSpeaks: (HistoryAutonomyProjectsResponse) -> String? = { _ in nil }
+        let alwaysSpeaks: (HistoryAutonomyProjectsResponse) -> String? = { _ in "+N more projects" }
         XCTAssertEqual(neverSpeaks(fits), neverSpeaks(overflows))
         XCTAssertEqual(alwaysSpeaks(fits), alwaysSpeaks(overflows))
         XCTAssertNil(fits.overflowLabel)
@@ -328,8 +212,8 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
                                              boundaries: [(150, "cost", "log")])
         let misses = try durationResponse(bucketStarts: [0, 100, 200, 300],
                                           boundaries: [(9999, "cost", "log")])
-        let neverMarks: (HistoryAutonomyDurationResponse) -> Int = { _ in 0 }
-        let alwaysMarks: (HistoryAutonomyDurationResponse) -> Int = { _ in 1 }
+        let neverMarks: (HistoryAutonomyProjectsResponse) -> Int = { _ in 0 }
+        let alwaysMarks: (HistoryAutonomyProjectsResponse) -> Int = { _ in 1 }
         XCTAssertEqual(neverMarks(straddles), neverMarks(misses))
         XCTAssertEqual(alwaysMarks(straddles), alwaysMarks(misses))
         XCTAssertEqual(straddles.visibleBoundaries.count, 1)
@@ -338,38 +222,33 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
 
     // MARK: Fixtures
 
-    private func row(start: Int64 = 1, end: Int64 = 9, reason: String?) -> HistoryAutonomySpanRow {
-        HistoryAutonomySpanRow(start: start, end: end, project: "p", session: "s", reason: reason)
-    }
-
-    /// Decodes a spans payload carrying `projectCount` projects, so the cap is
-    /// exercised through the real decode path rather than a hand-built struct.
-    private func spansResponse(projectCount: Int) throws -> HistoryAutonomySpansResponse {
-        let projects = (0..<projectCount).map { "\"p\($0)\"" }.joined(separator: ",")
-        let spans = (0..<projectCount)
-            .map { "{\"start\":1,\"end\":9,\"project\":\"p\($0)\",\"session\":\"s\($0)\",\"reason\":\"ready\"}" }
+    /// A payload carrying `panelCount` panels and `moreProjects` beyond them,
+    /// decoded through the real path rather than hand-built.
+    private func projectsResponse(panelCount: Int, moreProjects: Int) throws -> HistoryAutonomyProjectsResponse {
+        let panels = (0..<panelCount)
+            .map { "{\"project\":\"p\($0)\",\"longest\":60,\"total_seconds\":60,\"runs\":1,\"buckets\":[]}" }
             .joined(separator: ",")
         let json = """
-        {"window":"12mo","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[\(spans)],"projects":[\(projects)],
-         "earliest_span":1,"total_recorded":\(projectCount),"truncated":false}
+        {"window":"1y","chart":"autonomy_projects","start":0,"end":100,"bucket_seconds":604800,
+         "bucket_starts":[0],"panels":[\(panels)],"panel_limit":5,"more_projects":\(moreProjects),
+         "summary":{"longest":60,"runs":\(panelCount),"projects":\(panelCount + moreProjects)},
+         "earliest_span":1,"total_recorded":\(panelCount)}
         """
-        return try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
+        return try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
     }
 
     private func durationResponse(bucketStarts: [Int64],
-                                  boundaries: [(Int64, String, String)]) throws -> HistoryAutonomyDurationResponse {
+                                  boundaries: [(Int64, String, String)]) throws -> HistoryAutonomyProjectsResponse {
         let starts = bucketStarts.map(String.init).joined(separator: ",")
         let bounds = boundaries
             .map { "{\"ts\":\($0.0),\"from\":\"\($0.1)\",\"to\":\"\($0.2)\"}" }
             .joined(separator: ",")
         let json = """
-        {"window":"1y","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":604800,
-         "bucket_starts":[\(starts)],"buckets":[],
-         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
-         "sample_floor":20,"earliest_span":0,"total_recorded":0,
+        {"window":"1y","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":604800,
+         "bucket_starts":[\(starts)],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0},"earliest_span":0,"total_recorded":0,
          "provenance":{"reconstructed":0,"cost_derived":0,"live_since":0,"boundaries":[\(bounds)]}}
         """
-        return try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        return try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
     }
 }

--- a/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
@@ -6,8 +6,10 @@ import XCTest
 ///
 /// Two kinds, and they are two different limits:
 ///
-///   - STILL RUNNING — the run has not ended, so its length is unknowable.
-///     Shown on the strip, deliberately absent from the percentiles.
+///   - STILL RUNNING — the run has not ended, so its length is how long it has
+///     lasted SO FAR. It COUNTS towards the longest run (the section reports a
+///     maximum, and "already lasted 3h" is true) and is marked "still going"
+///     rather than presented as final.
 ///   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
 ///     start is where Irrlicht began watching. Those ARE samples; dropping them
 ///     is what left 5 of a day's 35 runs on the record.
@@ -18,29 +20,27 @@ final class HistoryAutonomyMeasurementTests: XCTestCase {
 
     // MARK: Decoding
 
-    func testMeasurementAndRowMarksDecode() throws {
+    func testMeasurementAndPanelMarksDecode() throws {
         let json = """
-        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[{"start":1,"end":9,"project":"a","session":"done","reason":"ready","kind":"top"},
-                  {"start":20,"end":100,"project":"a","session":"live","kind":"top","running":true},
-                  {"start":30,"end":60,"project":"a","session":"partial","reason":"unknown",
-                   "kind":"top","start_lower_bound":true}],
-         "projects":["a"],"earliest_span":1,"total_recorded":3,"truncated":false,
+        {"window":"30d","chart":"autonomy_projects","start":0,"end":100,"bucket_seconds":86400,
+         "bucket_starts":[0],
+         "panels":[{"project":"a","longest":10800,"longest_running":true,"total_seconds":10860,
+                    "runs":2,"peak":1,
+                    "buckets":[{"ts":0,"longest":10800,"running":true,"peak":1}]}],
+         "panel_limit":5,"more_projects":0,
+         "summary":{"longest":10800,"longest_running":true,"longest_project":"a","runs":2,"projects":1},
+         "earliest_span":1,"total_recorded":3,
          "measurement":{"running":1,"start_lower_bound":1}}
         """
-        let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(s.measurementOrNone.running, 1)
-        XCTAssertEqual(s.measurementOrNone.lowerBoundStart, 1)
-
-        // A finished, fully measured row claims neither.
-        XCTAssertFalse(s.spans[0].isRunning)
-        XCTAssertFalse(s.spans[0].hasLowerBoundStart)
-        // The in-progress row is marked, and only as running.
-        XCTAssertTrue(s.spans[1].isRunning)
-        XCTAssertFalse(s.spans[1].hasLowerBoundStart)
-        // The unmeasured-start row is marked, and only as that.
-        XCTAssertTrue(s.spans[2].hasLowerBoundStart)
-        XCTAssertFalse(s.spans[2].isRunning)
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(d.measurementOrNone.running, 1)
+        XCTAssertEqual(d.measurementOrNone.lowerBoundStart, 1)
+        // A run in progress IS the longest run, and it is marked — on the panel
+        // and on the bucket the line draws it at.
+        XCTAssertTrue(d.panels[0].longestRunning)
+        XCTAssertTrue(d.panels[0].buckets[0].running)
+        XCTAssertTrue(d.summary.longestRunning)
+        XCTAssertTrue(d.panels[0].headline.contains("still going"), d.panels[0].headline)
     }
 
     /// A payload from a daemon that predates the field decodes, and reads as
@@ -48,12 +48,12 @@ final class HistoryAutonomyMeasurementTests: XCTestCase {
     /// could not record a run in progress never wrote one.
     func testAnAbsentMeasurementBlockReadsAsNothingMarked() throws {
         let json = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[1],"buckets":[],
-         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
-         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33}
+        {"window":"30d","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0,"runs":33,"projects":2},
+         "earliest_span":1700000000,"total_recorded":33}
         """
-        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
         XCTAssertNil(d.measurement)
         XCTAssertEqual(d.measurementOrNone, .none)
         XCTAssertFalse(d.measurementOrNone.any)
@@ -72,14 +72,18 @@ final class HistoryAutonomyMeasurementTests: XCTestCase {
         XCTAssertNil(AutonomyFormat.measurementLine(measurement()))
     }
 
-    /// A running run is SHOWN and left OUT of the percentiles, and the sentence
-    /// has to say both — otherwise a reader who can see a 3-hour run on the
-    /// strip is left wondering why the median did not move.
-    func testARunningRunIsNamedAsGoingAndAsAbsentFromThePercentiles() throws {
+    /// A running run COUNTS towards the longest and is MARKED, and the
+    /// sentence has to say both — otherwise a reader who can see "longest 3h"
+    /// beside a project is left unsure whether that figure is finished.
+    func testARunningRunIsNamedAsGoingAndAsCounted() throws {
         let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 1)))
         XCTAssertTrue(line.contains("1 run is still going"), line)
         XCTAssertTrue(line.contains("SO FAR"), line)
-        XCTAssertTrue(line.contains("left out of the percentiles"), line)
+        XCTAssertTrue(line.contains("counts towards the longest run"), line)
+        // The percentile-era wording must be gone with the percentiles: a
+        // sentence claiming an exclusion that no longer happens is an alibi for
+        // a wrong number.
+        XCTAssertFalse(line.contains("percentile"), line)
     }
 
     func testAnUnmeasuredStartSaysWhichEndIsTheEstimate() throws {

--- a/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
@@ -13,55 +13,42 @@ final class HistoryAutonomySubagentTests: XCTestCase {
 
     // MARK: Decoding
 
-    func testKindsDecodeFromBothPayloads() throws {
-        let durationJSON = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[1],"buckets":[],
-         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
-         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33,
-         "kinds":{"top_level":20,"subagent":9,"unknown":4}}
+    func testKindsDecode() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0,"runs":15,"projects":1},
+         "earliest_span":1700000000,"total_recorded":15,
+         "kinds":{"top_level":7,"subagent":5,"unknown":3}}
         """
-        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(durationJSON.utf8))
-        let dk = try XCTUnwrap(d.kinds)
-        XCTAssertEqual(dk.topLevel, 20)
-        XCTAssertEqual(dk.subagent, 9)
-        XCTAssertEqual(dk.unknown, 4)
-
-        let spansJSON = """
-        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[{"start":1,"end":9,"project":"a","session":"kid","reason":"ready",
-                   "kind":"sub","parent":"boss"},
-                  {"start":20,"end":30,"project":"a","session":"boss","reason":"ready","kind":"top"},
-                  {"start":40,"end":50,"project":"a","session":"old","reason":"ready","kind":"unknown"}],
-         "projects":["a"],"earliest_span":1,"total_recorded":3,"truncated":false,
-         "kinds":{"top_level":1,"subagent":1,"unknown":1}}
-        """
-        let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(spansJSON.utf8))
-        // The subagent's run is RETURNED, and it says so about itself.
-        XCTAssertEqual(s.spans.count, 3)
-        XCTAssertTrue(s.spans[0].isSubagentRun)
-        XCTAssertEqual(s.spans[0].parent, "boss")
-        XCTAssertFalse(s.spans[1].isSubagentRun)
-        // An `unknown` row is not a subagent run: nothing established it was.
-        XCTAssertFalse(s.spans[2].isSubagentRun)
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(d.kinds?.topLevel, 7)
+        XCTAssertEqual(d.kinds?.subagent, 5)
+        XCTAssertEqual(d.kinds?.unknown, 3)
     }
 
-    /// A payload from a daemon that predates the field must still decode, and
-    /// a row with no `kind` at all must NOT read as a subagent run — absence is
-    /// "nothing established it", never one of the two answers.
-    func testAnAbsentKindsBlockDecodesAsSayingNothing() throws {
+    /// The classification's one visible consequence now that the run strip is
+    /// gone: a concurrency peak splits only when every run alive at it said
+    /// which kind it was. Rows written before the classification carry
+    /// `unknown`, and there is no way to recover which they were.
+    func testTheSplitIsShownOnlyWhereTheDaemonSaysItIsDerivable() throws {
         let json = """
-        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[{"start":1,"end":9,"project":"a","session":"legacy","reason":"ready"}],
-         "projects":["a"],"earliest_span":1,"total_recorded":1,"truncated":false}
+        {"window":"30d","chart":"autonomy_projects","start":0,"end":100,"bucket_seconds":86400,
+         "bucket_starts":[0,86400],
+         "panels":[{"project":"known","longest":60,"runs":5,"peak":5,"peak_top":3,"peak_sub":2,
+                    "peak_split":true,"buckets":[]},
+                   {"project":"legacy","longest":60,"runs":5,"peak":5,"peak_top":0,"peak_sub":0,
+                    "buckets":[]}],
+         "panel_limit":5,"more_projects":0,
+         "summary":{"longest":60,"runs":10,"projects":2},
+         "earliest_span":1,"total_recorded":10,
+         "kinds":{"top_level":3,"subagent":2,"unknown":5}}
         """
-        let s = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
-        XCTAssertNil(s.kinds)
-        XCTAssertNil(s.spans[0].kind)
-        XCTAssertFalse(s.spans[0].isSubagentRun)
-        // …and the panel says nothing rather than asserting a census this
-        // response never carried.
-        XCTAssertNil(AutonomyFormat.countingLine(s.kinds))
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertTrue(d.panels[0].headline.contains("5 at once (3 + 2 sub)"), d.panels[0].headline)
+        XCTAssertTrue(d.panels[1].headline.contains("5 at once"), d.panels[1].headline)
+        XCTAssertFalse(d.panels[1].headline.contains("sub"),
+                       "a peak an unclassified run was alive for must show the total alone, never a guess")
     }
 
     // MARK: The sentence
@@ -102,6 +89,9 @@ final class HistoryAutonomySubagentTests: XCTestCase {
         let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 3, unknown: 8148)))
         XCTAssertTrue(line.contains("8148 runs were recorded before Irrlicht told"), line)
         XCTAssertTrue(line.contains("counted either way"), line)
+        // …and the clause now carries its consequence for the concurrency
+        // figure: a peak one of those runs was alive for cannot be split.
+        XCTAssertTrue(line.contains("no split"), line)
     }
 
     func testAWindowWithNoUnknownRunsSaysNothingAboutThem() throws {

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -3,464 +3,309 @@ import SwiftUI
 import XCTest
 @testable import Irrlicht
 
-/// Autonomy section (#1905): the decode contract, the strip's pixel-collapse
-/// rule, and the two ladders that must not drift apart.
+/// Autonomy section (#1905), redesigned: five per-project panels, each a
+/// longest-run line over a concurrency histogram.
+///
+/// What these pin is the set of claims the panels make about data they cannot
+/// show in full — the gap rule on BOTH marks, the shared axis that makes five
+/// panels comparable, the split that is only ever shown where the data supports
+/// one, and the decode contract that keeps an older daemon's payload readable.
 final class HistoryAutonomyTests: XCTestCase {
 
-    // MARK: The collapse ladder
-
-    /// The strip's ladder and the session-history bar's ladder are two
-    /// hand-written copies of one ORDER — not of one numbering: the bar also
-    /// ranks `working`, which is never a span's end reason, so the absolute
-    /// values differ by construction and only the order can be compared. This
-    /// is what stops the two drifting, the same job
-    /// `TestAutonomyReasonLadderMatchesHistoryBar` does on the daemon side.
-    @MainActor
-    func testCollapseLadderMatchesTheHistoryBar() {
-        let manager = SessionManager()
-        let ordered = AutonomyEndReason.allCases.sorted { $0.priority > $1.priority }
-        for i in 1..<ordered.count {
-            let higher = ordered[i - 1]
-            let lower = ordered[i]
-            XCTAssertGreaterThan(
-                manager.historyPriorityForState(higher.rawValue),
-                manager.historyPriorityForState(lower.rawValue),
-                "the autonomy strip ranks \(higher.rawValue) above \(lower.rawValue), but the " +
-                "session-history bar does not — the two ladders have drifted")
-        }
-        // Asserted one rung per line: a single line naming three of the four
-        // canonical states is what tools/state-vocabulary-lint.sh refuses.
-        XCTAssertEqual(ordered[0].rawValue, "error")
-        XCTAssertEqual(ordered[1].rawValue, "waiting")
-        XCTAssertEqual(ordered[2].rawValue, "ready")
-    }
-
-    // MARK: The pixel-collapse rule
-
-    private func row(_ start: Int64, _ end: Int64, _ reason: String, project: String = "p") -> HistoryAutonomySpanRow {
-        decodeRow("""
-        {"start":\(start),"end":\(end),"project":"\(project)","session":"s\(start)","reason":"\(reason)"}
-        """)
-    }
-
-    /// Decoding a literal fixture cannot fail; a malformed one is a bug in the
-    /// test, so it reports as a test failure with the offending JSON rather
-    /// than as a crash (`try!`) with no context.
-    private func decodeRow(_ json: String, file: StaticString = #filePath, line: UInt = #line) -> HistoryAutonomySpanRow {
-        do {
-            return try JSONDecoder().decode(HistoryAutonomySpanRow.self, from: Data(json.utf8))
-        } catch {
-            XCTFail("fixture is not a decodable span row: \(error)\n\(json)", file: file, line: line)
-            return HistoryAutonomySpanRow(start: 0, end: 0, project: "", session: "", reason: nil)
-        }
-    }
-
-    /// Every span draws at a minimum of one column. At 12 months a 40-second
-    /// run is far under one pixel; rounding it away would erase exactly the
-    /// short runs the p5 line is about.
-    func testSubPixelSpanStillDrawsOneColumn() {
-        // A 1-second run inside a 100,000-second window drawn 10 columns wide:
-        // its true width is 0.0001 columns.
-        let cells = AutonomyStripLayout.collapse(
-            spans: [row(50_000, 50_001, "ready")],
-            start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(cells.count, 10)
-        let occupied = cells.filter(\.occupied)
-        XCTAssertEqual(occupied.count, 1, "a sub-pixel run must still occupy exactly one column, never zero")
-        XCTAssertEqual(occupied.first?.reason, .ready)
-    }
-
-    /// When one column holds several spans, the column takes the
-    /// highest-priority end reason — error over waiting over ready.
-    func testSharedColumnTakesTheHighestPriorityReason() {
-        // Three runs inside the same 1/10th of the window.
-        let spans = [
-            row(1_000, 1_100, "ready"),
-            row(1_200, 1_300, "error"),
-            row(1_400, 1_500, "waiting"),
-        ]
-        let cells = AutonomyStripLayout.collapse(spans: spans, start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(cells[0].reason, .error,
-                       "a column holding several runs must paint the highest-priority reason — one error " +
-                       "in a column paints the whole column")
-
-        // Order must not matter: the ladder decides, not arrival.
-        let reversed = AutonomyStripLayout.collapse(spans: spans.reversed(), start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(reversed[0].reason, .error)
-
-        // And without the error, waiting beats ready.
-        let noError = AutonomyStripLayout.collapse(
-            spans: [row(1_000, 1_100, "ready"), row(1_400, 1_500, "waiting")],
-            start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(noError[0].reason, .waiting)
-    }
-
-    /// A long run spans every column it covers, so the strip still reads as a
-    /// length and not just a marker.
-    func testLongSpanCoversItsColumns() {
-        let cells = AutonomyStripLayout.collapse(
-            spans: [row(0, 50_000, "waiting")],
-            start: 0, end: 100_000, columns: 10)
-        XCTAssertEqual(cells.filter(\.occupied).count, 6,
-                       "half the window plus the column its end falls in")
-    }
-
-    func testSpansOutsideTheWindowAreClippedNotDrawn() {
-        let before = AutonomyStripLayout.collapse(
-            spans: [row(-5_000, -1_000, "ready")], start: 0, end: 100_000, columns: 10)
-        XCTAssertTrue(before.allSatisfy { !$0.occupied })
-
-        let straddling = AutonomyStripLayout.collapse(
-            spans: [row(-5_000, 10_000, "ready")], start: 0, end: 100_000, columns: 10)
-        XCTAssertTrue(straddling[0].occupied, "the visible part of a straddling run must still draw")
-        XCTAssertFalse(straddling[5].occupied)
-    }
-
-    /// A run whose reason this build cannot name still HAPPENED: it occupies
-    /// its column (drawn neutral) rather than reading as idle.
-    func testUnnamedReasonStillOccupiesItsColumn() {
-        let unknown = decodeRow(#"{"start":10,"end":20,"project":"p","session":"s","reason":"martian"}"#)
-        let cells = AutonomyStripLayout.collapse(spans: [unknown], start: 0, end: 100, columns: 10)
-        XCTAssertTrue(cells[1].occupied, "an unrecognized reason must not erase the run")
-        XCTAssertNil(cells[1].reason)
-
-        // …and it must never outrank a real reason in a shared column.
-        let mixed = AutonomyStripLayout.collapse(
-            spans: [unknown, row(11, 19, "error")], start: 0, end: 100, columns: 10)
-        XCTAssertEqual(mixed[1].reason, .error)
-    }
-
-    func testDegenerateInputsProduceNoColumns() {
-        XCTAssertTrue(AutonomyStripLayout.collapse(spans: [], start: 0, end: 0, columns: 10).isEmpty)
-        XCTAssertTrue(AutonomyStripLayout.collapse(spans: [], start: 0, end: 100, columns: 0).isEmpty)
-    }
+    private let utc = TimeZone(identifier: "UTC")!
 
     // MARK: Decoding
 
-    func testDurationResponseDecodesIncludingOmittedThin() throws {
+    func testProjectsResponseDecodes() throws {
         let json = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[1,2],
-         "buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":100,"count":30},
-                    {"ts":2,"p95":9,"p50":5,"p5":1,"min":1,"max":9,"count":3,"thin":true}],
-         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
-         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33}
+        {"window":"30d","chart":"autonomy_projects","start":0,"end":259200,"bucket_seconds":86400,
+         "bucket_starts":[0,86400,172800],
+         "panels":[{"project":"irrlicht","longest":41940,"longest_running":true,"total_seconds":90000,
+                    "runs":12,"peak":5,"peak_top":3,"peak_sub":2,"peak_split":true,
+                    "buckets":[{"ts":0,"longest":41940,"running":true,"peak":5,"peak_top":3,"peak_sub":2,
+                                "peak_split":true},
+                               {"ts":172800,"longest":120,"peak":1,"peak_top":1,"peak_sub":0,
+                                "peak_split":true}]}],
+         "panel_limit":5,"more_projects":7,
+         "summary":{"longest":41940,"longest_running":true,"longest_project":"irrlicht","peak":5,
+                    "peak_project":"irrlicht","runs":12,"projects":8},
+         "earliest_span":1700000000,"total_recorded":33}
         """
-        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(r.buckets.count, 2)
-        XCTAssertFalse(r.buckets[0].thin, "`thin` is omitempty on the wire — absent must decode as false")
-        XCTAssertTrue(r.buckets[1].thin)
-        XCTAssertEqual(r.sampleFloor, 20)
-        XCTAssertEqual(r.earliestSpan, 1_700_000_000)
-        XCTAssertEqual(r.totalRecorded, 33)
-        XCTAssertTrue(r.hasData)
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertTrue(d.hasData)
+        XCTAssertEqual(d.panels.count, 1)
+        XCTAssertEqual(d.panels[0].peakSub, 2)
+        XCTAssertTrue(d.panels[0].longestRunning)
+        XCTAssertEqual(d.moreProjects, 7)
+        XCTAssertEqual(d.summary.longestProject, "irrlicht")
+        XCTAssertEqual(d.summary.projects, 8)
     }
 
-    func testEmptyBucketListIsNoData() throws {
+    /// A payload from a daemon that predates a field must still decode: a
+    /// client that goes blank against an older daemon is a worse failure than
+    /// one that says nothing about the field.
+    func testOptionalFieldsDecodeAsSayingNothing() throws {
         let json = """
-        {"window":"1y","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":604800,
-         "bucket_starts":[1,2,3],"buckets":[],
-         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
-         "sample_floor":20,"earliest_span":0,"total_recorded":0}
+        {"window":"1y","chart":"autonomy_projects","start":0,"end":1,"bucket_seconds":604800,
+         "bucket_starts":[0],"panels":[{"project":"p","longest":60,"buckets":[{"ts":0,"longest":60}]}],
+         "panel_limit":5,"more_projects":0,
+         "summary":{"longest":60},"earliest_span":0,"total_recorded":0}
         """
-        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
-        XCTAssertFalse(r.hasData, "a fully-drawn axis with no buckets is still \"no data\"")
-        XCTAssertFalse(r.bucketStarts.isEmpty, "the axis is still sent, so the chart can say what window it is")
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(d.provenanceOrNone, .none)
+        XCTAssertEqual(d.measurementOrNone, .none)
+        XCTAssertNil(d.kinds)
+        XCTAssertFalse(d.panels[0].longestRunning)
+        XCTAssertEqual(d.panels[0].buckets[0].peak, 0)
+        XCTAssertFalse(d.panels[0].buckets[0].peakSplit)
     }
 
-    func testSpansResponseDecodesAndGroups() throws {
+    func testEmptyPanelListIsNoData() throws {
         let json = """
-        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
-         "spans":[{"start":1,"end":9,"project":"a","session":"s1","reason":"ready"},
-                  {"start":2,"end":8,"project":"b","session":"s2","reason":"error"}],
-         "projects":["b","a"],"earliest_span":1,"total_recorded":2,"truncated":false}
+        {"window":"30d","chart":"autonomy_projects","start":0,"end":1,"bucket_seconds":86400,
+         "bucket_starts":[0],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0},"earliest_span":1700000000,"total_recorded":42}
         """
-        let r = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
-        XCTAssertEqual(r.projects, ["b", "a"], "row order is the daemon's, not re-derived here")
-        XCTAssertEqual(r.spans(for: "a").count, 1)
-        XCTAssertEqual(r.spans(for: "a").first?.endReason, .ready)
-        XCTAssertEqual(r.spans(for: "a").first?.duration, 8)
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertFalse(d.hasData, "no panels means no data, even with a non-zero total on record")
+        XCTAssertEqual(d.totalRecorded, 42, "…and the total is what keeps that from reading as \"you did nothing\"")
     }
 
-    // MARK: The two window vocabularies stay distinct
+    // MARK: A bucket with no runs is a gap, not a zero
 
-    /// The macOS twin of the daemon's window-vocabulary tripwire: the Autonomy
-    /// pickers send window LENGTHS, while `HistoryGranularity`'s same-looking
-    /// keys are bucket widths. Nothing may quietly reuse one for the other.
-    func testAutonomyWindowsAreNotGranularities() {
-        let autonomyKeys = Set(HistoryAutonomySpanWindow.allCases.map(\.rawValue))
-        XCTAssertTrue(autonomyKeys.contains("12mo"),
-                      "12mo is the strip's own key and has no granularity twin — if it is gone, the two " +
-                      "vocabularies may have been merged")
-        XCTAssertFalse(Set(HistoryGranularity.allCases.map(\.rawValue)).contains("12mo"))
-        // The overlapping keys must not be sourced from the granularity enum.
-        for key in ["8h", "24h", "7d"] {
-            XCTAssertNotNil(HistoryAutonomySpanWindow(rawValue: key))
-            XCTAssertNotNil(HistoryGranularity(rawValue: key),
-                            "the overlap this check guards is gone; re-check whether it still covers the trap")
-        }
-        XCTAssertEqual(Set(HistoryAutonomyRange.allCases.map(\.rawValue)), ["30d", "1y"])
-    }
-
-    // MARK: The chart's key, and the strip's bounds
-
-    /// The chart's colour scale still has to cover every drawn line: a line
-    /// with no colour is a line drawn in fallback grey.
-    func testSeriesColorsCoverEveryLine() {
-        XCTAssertEqual(AutonomyPalette.seriesOrder, ["p95", "p50", "p5"])
-        for key in AutonomyPalette.seriesOrder {
-            XCTAssertNotNil(AutonomyPalette.seriesColors[key],
-                            "\(key) is drawn but has no colour, so the key cannot name it")
-            XCTAssertNotNil(AutonomyPalette.seriesRoles[key],
-                            "\(key) is drawn but has no role, so nothing decides its weight")
-        }
-        XCTAssertEqual(AutonomyPalette.seriesRange.count, AutonomyPalette.seriesOrder.count)
-    }
-
-    /// The INVERSION of the old `…AndAreDistinct`. Distinct hues are what the
-    /// redesign removed: p95 and p5 are the two EDGES of one range, and a hue
-    /// each made them read as two independent measurements. The web twin is
-    /// `the three lines share one colour, and roles carry the difference`.
-    func testTheThreeLinesShareOneColourAndRolesCarryTheDifference() {
-        let colours = Set(AutonomyPalette.seriesRange.map { String(describing: $0) })
-        XCTAssertEqual(colours.count, 1, "the three lines must be one hue — weight is what separates them")
-        XCTAssertEqual(AutonomyPalette.seriesOrder.map { AutonomyPalette.role(of: $0) },
-                       [.edge, .line, .edge])
-        XCTAssertEqual(AutonomyPalette.seriesRoles.values.filter { $0 == .line }.count, 1,
-                       "more than one headline line makes \"the typical run\" ambiguous")
-        // The line carries the weight; the edges stay out of its way.
-        XCTAssertGreaterThan(AutonomyPalette.lineWidth(.line), AutonomyPalette.lineWidth(.edge))
-        XCTAssertGreaterThan(AutonomyPalette.opacity(.line, thin: false),
-                             AutonomyPalette.opacity(.edge, thin: false))
-        // …and a thin bucket is quieter than a measured one on both roles.
-        XCTAssertLessThan(AutonomyPalette.opacity(.line, thin: true),
-                          AutonomyPalette.opacity(.line, thin: false))
-        XCTAssertLessThan(AutonomyPalette.opacity(.edge, thin: true),
-                          AutonomyPalette.opacity(.edge, thin: false))
-    }
-
-    /// The key is two entries, because the chart draws two things — a line and
-    /// a plane. Three percentile swatches in one hue would promise a
-    /// distinction the chart stopped making, which is why the Swift Charts
-    /// legend derived from `seriesOrder` is hidden and this is drawn instead.
-    func testTheKeyHasTwoEntriesBothFromTheOneTable() {
-        let entries = AutonomyPalette.keyEntries
-        XCTAssertEqual(entries.count, 2)
-        XCTAssertEqual(entries.map(\.kind), [.line, .band])
-        for entry in entries {
-            // `from` names a row of the one table, not a label someone invented.
-            XCTAssertTrue(AutonomyPalette.seriesOrder.contains(entry.from),
-                          "\(entry.from) is not a line the chart draws")
-        }
-        XCTAssertEqual(String(describing: entries[0].color),
-                       String(describing: AutonomyPalette.seriesColors["p50"]!),
-                       "the line swatch must be the very colour the p50 line is stroked in")
-        XCTAssertEqual(String(describing: entries[1].fill), String(describing: Optional(AutonomyPalette.band)))
-        XCTAssertEqual(String(describing: entries[1].color), String(describing: AutonomyPalette.edge))
-        XCTAssertNil(entries[0].fill, "a line has no area; a fill would claim one")
-    }
-
-    /// Both labels name their percentiles AND say what they mean in words:
-    /// "p5–p95" is not something a reader who has never seen a percentile can
-    /// read. Same two strings as the web panel's key.
-    func testTheKeyExplainsItselfInWords() {
-        let entries = AutonomyPalette.keyEntries
-        XCTAssertEqual(entries[0].label, "p50 · the typical run")
-        XCTAssertEqual(entries[1].label, "p5–p95 · the usual spread")
-    }
-
-    /// The band is a WEIGHT of the line's hue, not a fourth colour. Were it an
-    /// independent value, "one hue" would hold for the three strokes and
-    /// quietly fail for the largest area of ink on the chart. Checked in BOTH
-    /// appearances, because the band's alpha differs per appearance and a
-    /// hand-typed hex is exactly where a wrong triple would hide.
-    @MainActor
-    func testBandIsTheLineHueInBothAppearances() {
-        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
-            let line = srgb(AutonomyPalette.lineColor, in: appearance)
-            for (name, colour) in [("band", AutonomyPalette.band),
-                                   ("bandThin", AutonomyPalette.bandThin),
-                                   ("edge", AutonomyPalette.edge)] {
-                let got = srgb(colour, in: appearance)
-                XCTAssertEqual(got.r, line.r, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
-                XCTAssertEqual(got.g, line.g, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
-                XCTAssertEqual(got.b, line.b, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
-            }
-        }
-    }
-
-    /// …and the band is genuinely translucent, in both appearances and with a
-    /// fainter plane for thin buckets. An opaque plane would bury the line it
-    /// is supposed to sit behind.
-    @MainActor
-    func testBandIsTranslucentAndThinIsFainter() {
-        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
-            let band = alpha(AutonomyPalette.band, in: appearance)
-            let thin = alpha(AutonomyPalette.bandThin, in: appearance)
-            let edge = alpha(AutonomyPalette.edge, in: appearance)
-            XCTAssertGreaterThan(band, 0, "an invisible band draws nothing at all")
-            XCTAssertLessThan(band, 0.5, "a plane this solid competes with the line inside it")
-            XCTAssertLessThan(thin, band, "a thin bucket's plane must be fainter than a measured one's")
-            XCTAssertGreaterThan(edge, band, "the edges must read as the band's boundary")
-            XCTAssertLessThan(edge, 1, "a full-strength edge is a fourth curve, not a boundary")
-        }
-    }
-
-    /// Resolved sRGB of a possibly-appearance-dependent colour. Same technique
-    /// `TokenContrastTests.srgb` uses; force-unwraps on purpose, since a colour
-    /// this cannot resolve must fail the test rather than compare as equal.
-    @MainActor
-    private func srgb(_ color: Color, in appearance: NSAppearance.Name) -> (r: Double, g: Double, b: Double) {
-        var out = (r: 0.0, g: 0.0, b: 0.0)
-        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
-            let ns = NSColor(color).usingColorSpace(.sRGB)!
-            out = (Double(ns.redComponent), Double(ns.greenComponent), Double(ns.blueComponent))
-        }
-        return out
-    }
-
-    @MainActor
-    private func alpha(_ color: Color, in appearance: NSAppearance.Name) -> Double {
-        var out = 0.0
-        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
-            out = Double(NSColor(color).usingColorSpace(.sRGB)!.alphaComponent)
-        }
-        return out
-    }
-
-    // MARK: The band's geometry
-
-    private func bucket(_ ts: Int64, thin: Bool = false) -> HistoryAutonomyBucket {
-        decodeBucket("""
-        {"ts":\(ts),"p95":90,"p50":50,"p5":10,"min":10,"max":90,"count":\(thin ? 3 : 30),"thin":\(thin)}
-        """)
-    }
-
-    private func decodeBucket(_ json: String, file: StaticString = #filePath, line: UInt = #line) -> HistoryAutonomyBucket {
-        do {
-            return try JSONDecoder().decode(HistoryAutonomyBucket.self, from: Data(json.utf8))
-        } catch {
-            XCTFail("fixture is not a decodable bucket: \(error)\n\(json)", file: file, line: line)
-            return decodeBucket("""
-            {"ts":0,"p95":1,"p50":1,"p5":1,"min":1,"max":1,"count":1}
-            """)
-        }
-    }
-
-    /// The daemon OMITS empty buckets, and reading `buckets` directly hands
-    /// Swift Charts a dense list in which the gap simply is not there — so it
-    /// connects straight across. `alignedBuckets` is what puts the hole back.
+    /// The honesty rule, and it now binds TWO marks rather than one: the line
+    /// has to break, and the histogram has to draw nothing. A zero-height bar
+    /// sitting on the axis looks measured; a zero point pulls the line down.
     func testAlignedBucketsPutTheGapBack() throws {
-        let d = try durationWithBuckets(starts: [100, 200, 300, 400], present: [100, 400])
-        let aligned = d.alignedBuckets
-        XCTAssertEqual(aligned.count, 4)
-        XCTAssertNotNil(aligned[0])
-        XCTAssertNil(aligned[1], "an omitted bucket is a GAP, not a zero")
-        XCTAssertNil(aligned[2])
-        XCTAssertNotNil(aligned[3])
+        let d = try response(bucketStarts: [100, 200, 300, 400, 500],
+                             panels: [("p", [(100, 60.0, 1), (400, 90.0, 2)])])
+        let points = d.panels[0].alignedBuckets(d.bucketStarts)
+        XCTAssertEqual(points.count, 5)
+        XCTAssertEqual(points[0]?.longest, 60)
+        XCTAssertNil(points[1])
+        XCTAssertNil(points[2])
+        XCTAssertEqual(points[3]?.longest, 90)
+        XCTAssertNil(points[4])
     }
 
-    /// A LINE drawn across a gap interpolates; a FILLED AREA drawn across one
-    /// paints a whole plane over days that hold no runs at all.
-    func testABandSegmentNeverSpansAnEmptyBucket() throws {
-        let d = try durationWithBuckets(starts: [100, 200, 300, 400, 500], present: [100, 200, 400, 500])
-        let points = d.alignedBuckets
-        let segments = AutonomyBandLayout.segments(points: points)
-        XCTAssertEqual(segments.map { [$0.from, $0.to] }, [[0, 1], [3, 4]])
-        // Stated as the property, not just the shape.
-        for segment in segments {
-            for i in segment.from...segment.to {
-                XCTAssertNotNil(points[i], "segment \(segment.id) covers an omitted bucket")
-            }
-        }
-    }
-
-    /// THE COMMITTED MUTATION: the "one polygon over everything present"
-    /// build — the shape a fill takes by default, and the shape that silently
-    /// claims the gap. It answers identically for a gapped range and an
-    /// unbroken one; production must not.
+    /// The committed mutation: `buckets` read straight off the payload — a
+    /// dense list in which the gap is simply not there, and whatever draws it
+    /// runs the stroke straight across.
     func testProductionTellsAGappedRangeFromAnUnbrokenOne() throws {
-        let gapped = try durationWithBuckets(starts: [1, 2, 3], present: [1, 3]).alignedBuckets
-        let whole = try durationWithBuckets(starts: [1, 2, 3], present: [1, 2, 3]).alignedBuckets
-
-        let bridging: ([HistoryAutonomyBucket?]) -> [AutonomyBandLayout.Segment] = {
-            [AutonomyBandLayout.Segment(from: 0, to: $0.count - 1, thin: false)]
-        }
-        XCTAssertEqual(bridging(gapped), bridging(whole))
-
-        XCTAssertEqual(AutonomyBandLayout.segments(points: whole),
-                       [AutonomyBandLayout.Segment(from: 0, to: 2, thin: false)])
-        XCTAssertNotEqual(AutonomyBandLayout.segments(points: gapped),
-                          AutonomyBandLayout.segments(points: whole))
-        // Two isolated buckets — a bridging build would have drawn one plane
-        // straight over the empty day between them.
-        XCTAssertEqual(AutonomyBandLayout.segments(points: gapped),
-                       [AutonomyBandLayout.Segment(from: 0, to: 0, thin: false),
-                        AutonomyBandLayout.Segment(from: 2, to: 2, thin: false)])
+        let d = try response(bucketStarts: [100, 200, 300, 400, 500],
+                             panels: [("p", [(100, 60.0, 1), (400, 90.0, 2)])])
+        let dense = d.panels[0].buckets.map { Optional($0) }
+        XCTAssertEqual(AutonomyLineLayout.segments(points: dense),
+                       [AutonomyLineLayout.Segment(from: 0, to: 1)],
+                       "the dense mutation draws one unbroken stretch")
+        XCTAssertEqual(AutonomyLineLayout.segments(points: d.panels[0].alignedBuckets(d.bucketStarts)),
+                       [AutonomyLineLayout.Segment(from: 0, to: 0),
+                        AutonomyLineLayout.Segment(from: 3, to: 3)],
+                       "production breaks at the gap")
     }
 
-    /// A thin bucket's p95 IS its maximum and its p5 IS its minimum. Inside
-    /// one smooth plane that distinction disappears, so the plane splits there
-    /// and the thin stretch is filled from its own fainter token.
-    func testAThinStretchIsItsOwnSegmentAndTheSeamIsShared() {
-        let points: [HistoryAutonomyBucket?] = [
-            bucket(1), bucket(2), bucket(3, thin: true), bucket(4), bucket(5),
-        ]
-        let segments = AutonomyBandLayout.segments(points: points)
-        XCTAssertEqual(segments, [
-            AutonomyBandLayout.Segment(from: 0, to: 1, thin: false),
-            AutonomyBandLayout.Segment(from: 1, to: 3, thin: true),
-            AutonomyBandLayout.Segment(from: 3, to: 4, thin: false),
-        ])
-        // Adjacent segments SHARE their boundary index — a seam would show as
-        // a hairline crack down the band.
-        for i in 1..<segments.count {
-            XCTAssertEqual(segments[i].from, segments[i - 1].to)
-        }
+    func testABarIsDrawnOnlyWhereSomebodyWasWorking() throws {
+        let d = try response(bucketStarts: [100, 200],
+                             panels: [("p", [(100, 60.0, 2), (200, 90.0, 0)])])
+        let points = d.panels[0].alignedBuckets(d.bucketStarts)
+        XCTAssertTrue(points[0]?.hasBar == true)
+        XCTAssertFalse(points[1]?.hasBar == true,
+                       "a zero-height bar on the axis reads as a measured zero, which is a different " +
+                       "and false claim from \"nobody was working\"")
     }
 
-    /// The stroke dashes a segment either of whose ends is thin; the fill has
-    /// to split on the same rule, or the dashes and the plane disagree about
-    /// where the thin stretch is.
-    func testThinnessBelongsToTheIntervalNotTheBucket() {
-        let segments = AutonomyBandLayout.segments(points: [bucket(1), bucket(2, thin: true), bucket(3)])
-        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 0, to: 2, thin: true)])
-    }
-
-    /// A lone bucket has no neighbour to make an area with. Reported as a
-    /// zero-width segment so the chart can draw its spread as a whisker rather
-    /// than leaving the one bucket that most needs a range with none.
-    func testAnIsolatedBucketIsAZeroWidthSegment() throws {
-        let points = try durationWithBuckets(starts: [1, 2, 3], present: [2]).alignedBuckets
-        let segments = AutonomyBandLayout.segments(points: points)
-        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 1, to: 1, thin: false)])
-        XCTAssertTrue(segments[0].isIsolated)
+    /// A bucket a long run merely crossed: something WAS working, nothing
+    /// finished. Two true facts, and neither may be borrowed for the other.
+    func testARunThatPassedThroughBreaksTheLineButKeepsItsBar() throws {
+        let d = try response(bucketStarts: [100, 200, 300],
+                             panels: [("p", [(100, 60.0, 1), (200, 0.0, 3), (300, 90.0, 1)])])
+        let points = d.panels[0].alignedBuckets(d.bucketStarts)
+        XCTAssertEqual(AutonomyLineLayout.segments(points: points),
+                       [AutonomyLineLayout.Segment(from: 0, to: 0),
+                        AutonomyLineLayout.Segment(from: 2, to: 2)])
+        XCTAssertEqual(points[1]?.peak, 3)
+        XCTAssertFalse(points[1]?.hasLine == true)
     }
 
     func testAnEmptyAxisProducesNoSegments() {
-        XCTAssertTrue(AutonomyBandLayout.segments(points: []).isEmpty)
-        XCTAssertTrue(AutonomyBandLayout.segments(points: [nil, nil]).isEmpty)
+        XCTAssertTrue(AutonomyLineLayout.segments(points: []).isEmpty)
+        XCTAssertTrue(AutonomyLineLayout.segments(points: [nil, nil]).isEmpty)
     }
 
-    // MARK: The boundary caption
+    func testAnIsolatedBucketIsAZeroWidthSegment() throws {
+        let d = try response(bucketStarts: [0, 100, 200], panels: [("p", [(100, 60.0, 1)])])
+        let segments = AutonomyLineLayout.segments(points: d.panels[0].alignedBuckets(d.bucketStarts))
+        XCTAssertEqual(segments, [AutonomyLineLayout.Segment(from: 1, to: 1)])
+        XCTAssertTrue(segments[0].isIsolated, "it has no neighbour to draw a segment to, so it is drawn as a point")
+    }
 
-    /// The caption used to hang off its rule's LEFT unconditionally. It is a
-    /// fixed string most of the plot wide at 9 pt, so a rule in the left third
-    /// had less room than the caption needed, SwiftUI clamped the annotation
-    /// to the chart's leading edge, and the caption ended up detached from the
-    /// rule it describes with its arrow pointing off-chart at nothing.
+    // MARK: The shared log axis
+
+    /// Shared, so the projects are comparable — that is the point of picking
+    /// five. Log, because a project whose best is two minutes would otherwise
+    /// be a flat line under one whose best is eleven hours.
+    func testTheYDomainSpansEveryPanel() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: [("big", [(0, 41_940.0, 5)]), ("small", [(0, 120.0, 1)])])
+        let domain = try XCTUnwrap(d.sharedYDomain)
+        XCTAssertLessThanOrEqual(domain.lowerBound, 120)
+        XCTAssertGreaterThanOrEqual(domain.upperBound, 41_940)
+    }
+
+    /// The committed mutation: a per-panel domain. Under it `small`'s own 120s
+    /// would sit at the top of its plot while `big`'s 120s sat near the bottom,
+    /// and the five panels would not be comparable at all.
+    func testProductionTellsASharedDomainFromAPerPanelOne() throws {
+        // `small` FIRST on purpose: a mutation that reads only the first panel
+        // would then produce the per-panel domain here, and this goes red too
+        // rather than leaving one assertion to carry the whole rule.
+        let d = try response(bucketStarts: [0],
+                             panels: [("small", [(0, 120.0, 1)]), ("big", [(0, 41_940.0, 5)])])
+        let shared = try XCTUnwrap(d.sharedYDomain)
+        let onlySmall = try response(bucketStarts: [0], panels: [("small", [(0, 120.0, 1)])])
+        let perPanel = try XCTUnwrap(onlySmall.sharedYDomain)
+        XCTAssertNotEqual(shared.upperBound, perPanel.upperBound,
+                          "a per-panel domain would put the small project's own maximum at the top of " +
+                          "its plot, and the five panels would not be comparable")
+        XCTAssertGreaterThan(shared.upperBound, perPanel.upperBound)
+    }
+
+    func testAnEmptyWindowHasNoDomainRatherThanAFabricatedOne() throws {
+        let none = try response(bucketStarts: [0], panels: [])
+        XCTAssertNil(none.sharedYDomain)
+        // …and a window whose only bucket has a bar but no finished run.
+        let barsOnly = try response(bucketStarts: [0], panels: [("p", [(0, 0.0, 2)])])
+        XCTAssertNil(barsOnly.sharedYDomain)
+        XCTAssertEqual(barsOnly.sharedPeakScale, 2)
+    }
+
+    func testThePeakScaleIsSharedToo() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: [("a", [(0, 60.0, 5)]), ("b", [(0, 60.0, 2)])])
+        XCTAssertEqual(d.sharedPeakScale, 5)
+        let flat = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 0)])])
+        XCTAssertEqual(flat.sharedPeakScale, 0,
+                       "nothing overlapped anywhere, so no bar is drawn rather than every bar full height")
+    }
+
+    // MARK: The concurrency figure, and the split it may not invent
+
+    func testADerivableSplitIsSpelledOutBesideTheTotal() {
+        XCTAssertEqual(AutonomyFormat.concurrency(peak: 5, top: 3, sub: 2, splitKnown: true),
+                       "5 at once (3 + 2 sub)")
+    }
+
+    /// Most rows before 18 Aug 2026 carry `kind: unknown`; there is no way to
+    /// recover which they were, and "5 (5 + 0 sub)" would be an invented answer.
+    func testAnUnderivableSplitShowsTheTotalAlone() {
+        let label = AutonomyFormat.concurrency(peak: 5, top: 0, sub: 0, splitKnown: false)
+        XCTAssertEqual(label, "5 at once")
+        XCTAssertFalse(label.contains("sub"))
+    }
+
+    func testAWindowNobodyOverlappedInSaysNothingAtAll() {
+        XCTAssertEqual(AutonomyFormat.concurrency(peak: 0, top: 0, sub: 0, splitKnown: true), "")
+    }
+
+    /// The number is otherwise misread: a parent is held `working` while its
+    /// subagents run, so one agent with three subagents reads as four at once.
+    func testTheCaveatSaysWhatTheNumberIsNot() {
+        let caveat = AutonomyFormat.concurrencyCaveat
+        XCTAssertTrue(caveat.contains("parent"), "got: \(caveat)")
+        XCTAssertTrue(caveat.contains("subagents"), "got: \(caveat)")
+        XCTAssertTrue(caveat.contains("not four independent agents"), "got: \(caveat)")
+    }
+
+    // MARK: A panel states its own two figures
+
+    func testPanelHeadlineCarriesLongestAndAtOnce() {
+        let panel = HistoryAutonomyPanel(project: "irrlicht", longest: 41_940,
+                                         peak: 5, peakTop: 3, peakSub: 2, peakSplit: true)
+        XCTAssertEqual(panel.headline, "longest 11h39m · 5 at once (3 + 2 sub)")
+    }
+
+    func testAStillRunningLongestRunIsMarkedNotDropped() {
+        let panel = HistoryAutonomyPanel(project: "p", longest: 10_800, longestRunning: true,
+                                         peak: 1, peakSplit: false)
+        XCTAssertTrue(panel.headline.contains("longest 3h"), "got: \(panel.headline)")
+        XCTAssertTrue(panel.headline.contains("still going"), "got: \(panel.headline)")
+    }
+
+    func testAProjectNobodyOverlappedInStillStatesItsLongest() {
+        XCTAssertEqual(HistoryAutonomyPanel(project: "p", longest: 600).headline, "longest 10m")
+    }
+
+    // MARK: The stack, and what it left out
+
+    func testTheStackDrawsThePanelsItWasSentAndNamesTheRest() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: (0..<5).map { ("p\($0)", [(Int64(0), 60.0, 1)]) },
+                             moreProjects: 7)
+        let rows = d.stackRows
+        XCTAssertEqual(rows.count, 6)
+        guard case let .more(label) = rows[5] else {
+            return XCTFail("the last stack row must be the overflow line, got \(rows[5])")
+        }
+        XCTAssertEqual(label, "+7 more projects, each with less autonomous time")
+    }
+
+    func testTheStackSaysNothingWhenEveryProjectHasAPanel() throws {
+        let d = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 1)])], moreProjects: 0)
+        XCTAssertNil(d.overflowLabel)
+        XCTAssertEqual(d.stackRows.count, 1)
+    }
+
+    func testOneHiddenProjectIsSingular() throws {
+        let d = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 1)])], moreProjects: 1)
+        XCTAssertEqual(try XCTUnwrap(d.overflowLabel),
+                       "+1 more project, each with less autonomous time")
+    }
+
+    /// The committed mutation: a client that re-decides the panel count itself.
+    /// Two surfaces doing that is exactly how the run strip ended up drawing
+    /// twelve rows on the web against six here, from one ranked list.
+    func testTheClientRendersWhatItWasSentNeverItsOwnCount() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: (0..<5).map { ("p\($0)", [(Int64(0), 60.0, 1)]) },
+                             moreProjects: 7)
+        let clientCap = Array(d.panels.prefix(3))
+        XCTAssertEqual(clientCap.count, 3)
+        let drawn = d.stackRows.filter { if case .panel = $0 { return true } else { return false } }
+        XCTAssertEqual(drawn.count, d.panels.count)
+        XCTAssertEqual(drawn.count, 5)
+    }
+
+    // MARK: The boundary caption reads once across the stack
+
+    /// The rule runs through all five panels — it has to, or it annotates one
+    /// project's line and leaves the four below it stepping for no stated
+    /// reason — but the caption is drawn on exactly one.
+    func testTheCaptionIsWrittenOnceNotOncePerPanel() {
+        let carrying = (0..<5).filter { AutonomyBoundaryCaption.isShown(panelIndex: $0) }
+        XCTAssertEqual(carrying.count, 1)
+        XCTAssertEqual(carrying, [AutonomyBoundaryCaption.panelIndex])
+        XCTAssertTrue(AutonomyBoundaryCaption.isShown(panelIndex: 0))
+        XCTAssertFalse(AutonomyBoundaryCaption.isShown(panelIndex: 4))
+    }
+
+    /// The committed mutation: captioning every panel. It passes "a caption is
+    /// drawn" and fails the thing that matters, which is that there is one.
+    func testProductionTellsOneCaptionFromFive() {
+        let captionEverywhere: (Int) -> Bool = { _ in true }
+        XCTAssertEqual((0..<5).filter(captionEverywhere).count, 5)
+        XCTAssertEqual((0..<5).filter { AutonomyBoundaryCaption.isShown(panelIndex: $0) }.count, 1)
+    }
+
+    /// The caption hangs off whichever side of its rule has room. Pinned to the
+    /// left unconditionally it would be clamped to the plot's leading edge for
+    /// any rule in the left third, leaving the caption detached with its arrow
+    /// pointing off-chart at nothing.
     func testTheCaptionHangsOffWhicheverSideOfTheRuleHasRoom() {
-        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.0), .right)
-        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.36), .right,
-                       "the measured case: a rule at 36% has more room to its right")
-        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.5), .left)
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.1), .right)
         XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.9), .left)
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.5), .left)
     }
 
-    /// THE COMMITTED MUTATION for it: the always-left build. It answers
-    /// identically for a rule near the left edge and one near the right;
-    /// production must not, or "it is placed where there is room" could pass
-    /// against a build that never looked at where the rule is.
     func testProductionTellsALeftRuleFromARightOne() {
         let alwaysLeft: (Double) -> AutonomyBoundaryCaption.Side = { _ in .left }
         XCTAssertEqual(alwaysLeft(0.1), alwaysLeft(0.9))
@@ -468,72 +313,138 @@ final class HistoryAutonomyTests: XCTestCase {
                           AutonomyBoundaryCaption.side(fraction: 0.9))
     }
 
-    /// The fraction the side is chosen from is the rule's real position in the
-    /// drawn domain — the macOS twin of the web's `fraction`.
-    func testBoundaryFractionIsItsPositionInTheDrawnDomain() throws {
-        let d = try durationWithBuckets(starts: [0, 100, 200, 300, 400], present: [0])
-        let boundary = HistoryAutonomyBoundary(ts: 100, from: "cost", to: "log")
-        XCTAssertEqual(d.domainFraction(of: boundary), 0.25, accuracy: 0.0001)
+    // MARK: The window vocabulary
+
+    /// The trap #1905 calls out by name: chart=state's granularity keys and the
+    /// Autonomy windows OVERLAP textually and mean different things.
+    func testAutonomyWindowsAreNotGranularities() {
+        let autonomy = Set(HistoryAutonomyRange.allCases.map(\.rawValue))
+        XCTAssertEqual(autonomy, ["30d", "1y"])
+        // The run strip's own vocabulary went with the strip. If any of its
+        // keys reappears here, two textually-overlapping sets are back on one
+        // screen — which is the confusion the redesign removed.
+        for stripKey in ["8h", "24h", "7d", "12mo"] {
+            XCTAssertFalse(autonomy.contains(stripKey),
+                           "\(stripKey) is a granularity key and must not be an Autonomy window")
+        }
     }
 
-    /// Decodes a duration payload whose `bucket_starts` is `starts` and whose
-    /// `buckets` holds only `present` — the omission the daemon really makes,
-    /// exercised through the real decode path rather than a hand-built struct.
-    private func durationWithBuckets(starts: [Int64], present: [Int64]) throws -> HistoryAutonomyDurationResponse {
-        let startList = starts.map(String.init).joined(separator: ",")
-        let bucketList = present
-            .map { "{\"ts\":\($0),\"p95\":90,\"p50\":50,\"p5\":10,\"min\":10,\"max\":90,\"count\":30}" }
-            .joined(separator: ",")
-        let json = """
-        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[\(startList)],"buckets":[\(bucketList)],
-         "summary":{"p95":90,"p50":50,"p5":10,"min":10,"max":90,"count":\(present.count)},
-         "sample_floor":20,"earliest_span":1,"total_recorded":\(present.count)}
-        """
-        return try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+    // MARK: The palette and the key
+
+    /// ONE HUE, TWO WEIGHTS: the bars are the line's hue, quieter. What went is
+    /// a colour per percentile — three equally loud curves and a legend that
+    /// had to be decoded before the chart said anything.
+    @MainActor
+    func testBarsAreTheLineHue() {
+        for appearance in [NSAppearance(named: .aqua)!, NSAppearance(named: .darkAqua)!] {
+            let line = rgb(AutonomyPalette.lineColor, appearance)
+            let bars = rgb(AutonomyPalette.bars, appearance)
+            XCTAssertEqual(line.r, bars.r, accuracy: 0.02, "\(appearance.name.rawValue): red")
+            XCTAssertEqual(line.g, bars.g, accuracy: 0.02, "\(appearance.name.rawValue): green")
+            XCTAssertEqual(line.b, bars.b, accuracy: 0.02, "\(appearance.name.rawValue): blue")
+            XCTAssertLessThan(bars.a, line.a,
+                              "\(appearance.name.rawValue): a histogram at the line's full strength " +
+                              "competes with the line above it")
+        }
     }
 
-    /// The strip's bounds coarsen with the window, so an 8h strip reads as a
-    /// time of day and a 12mo strip as a month.
-    func testAxisBoundCoarsensWithTheWindow() {
-        let utc = TimeZone(identifier: "UTC")!
-        // 2026-01-02T15:30:00Z
-        let d = Date(timeIntervalSince1970: 1_767_367_800)
-        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600, timeZone: utc), "15:30")
-        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 7 * 86400, timeZone: utc), "Jan 2")
-        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 365 * 86400, timeZone: utc), "Jan 2026")
+    func testTheKeyHasTwoEntriesOnePerMark() {
+        let entries = AutonomyPalette.keyEntries
+        XCTAssertEqual(entries.map(\.kind), [.line, .bars])
+        XCTAssertEqual(entries.map(\.id), ["line", "bars"])
     }
 
-    /// #1659: every date this section renders takes its zone as an input.
-    func testAxisBoundHonorsTheCallersZone() {
-        let d = Date(timeIntervalSince1970: 1_767_367_800)
-        let utc = AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600, timeZone: TimeZone(identifier: "UTC")!)
-        let tokyo = AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600,
-                                             timeZone: TimeZone(identifier: "Asia/Tokyo")!)
-        XCTAssertNotEqual(utc, tokyo, "the bound must follow the zone it is given, never the machine's")
+    /// The p50/band key went with the percentiles: a key naming something the
+    /// panels do not draw would promise a distinction that no longer exists.
+    func testTheKeyExplainsItselfInWordsAndNamesNoPercentile() {
+        let labels = AutonomyPalette.keyEntries.map(\.label).joined(separator: " ")
+        XCTAssertTrue(labels.contains("longest run"), "got: \(labels)")
+        XCTAssertTrue(labels.contains("at once"), "got: \(labels)")
+        for gone in ["p50", "p95", "spread", "typical"] {
+            XCTAssertFalse(labels.contains(gone), "\(gone) survives in the key: \(labels)")
+        }
     }
 
-    // MARK: Formatting + provenance
+    // MARK: Formatting
 
     func testDurationFormatting() {
         XCTAssertEqual(AutonomyFormat.duration(41), "41s")
         XCTAssertEqual(AutonomyFormat.duration(660), "11m")
         XCTAssertEqual(AutonomyFormat.duration(7080), "1h58m")
+        XCTAssertEqual(AutonomyFormat.duration(41_940), "11h39m")
         XCTAssertEqual(AutonomyFormat.duration(86_400), "1d")
+        XCTAssertEqual(AutonomyFormat.duration(0), "0s")
     }
 
-    /// "No data" must never read as "you did nothing": with nothing recorded
-    /// the line says so in words, and with something recorded it names the
-    /// date collection started.
-    func testProvenanceLineSaysWhenCollectionStarted() {
-        let utc = TimeZone(identifier: "UTC")!
-        let empty = AutonomyFormat.provenance(earliest: 0, total: 0, timeZone: utc)
-        XCTAssertTrue(empty.contains("began measuring"),
-                      "an empty section must explain that collection starts with this update, not imply idleness")
+    func testAxisBoundCoarsensWithTheWindow() {
+        let d = Date(timeIntervalSince1970: 1_767_000_000) // 2025-12-29T09:20:00Z
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600, timeZone: utc), "09:20")
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 30 * 86400, timeZone: utc), "Dec 29")
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 365 * 86400, timeZone: utc), "Dec 2025")
+    }
 
-        // 1700000000 = 2023-11-14T22:13:20Z
-        let seeded = AutonomyFormat.provenance(earliest: 1_700_000_000, total: 312, timeZone: utc)
-        XCTAssertTrue(seeded.contains("Nov 14, 2023"), "got: \(seeded)")
-        XCTAssertTrue(seeded.contains("312 runs"), "got: \(seeded)")
+    /// Every date this surface renders takes its zone as an INPUT (#1659).
+    func testAxisBoundHonorsTheCallersZone() {
+        // 2025-12-29T23:30:00Z — still Dec 29 in UTC, already Dec 30 in Tokyo
+        // (UTC+9). A date that read the same in both zones would let this pass
+        // against a formatter that ignored the parameter entirely.
+        let d = Date(timeIntervalSince1970: 1_767_051_000)
+        let tokyo = TimeZone(identifier: "Asia/Tokyo")!
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 30 * 86400, timeZone: utc), "Dec 29")
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 30 * 86400, timeZone: tokyo), "Dec 30")
+    }
+
+    func testProvenanceLineSaysWhenCollectionStarted() {
+        let empty = AutonomyFormat.provenance(earliest: 0, total: 0, timeZone: utc)
+        XCTAssertTrue(empty.contains("began measuring"), "got: \(empty)")
+        let seeded = AutonomyFormat.provenance(earliest: 1_755_000_000, total: 312, timeZone: utc)
+        XCTAssertTrue(seeded.contains("Collecting since Aug 12, 2025"), "got: \(seeded)")
+        XCTAssertTrue(seeded.contains("312 runs recorded"), "got: \(seeded)")
+    }
+
+    // MARK: Fixtures
+
+    /// Builds a payload through the real decode path rather than a hand-built
+    /// struct, so a wire-name slip fails here rather than in production.
+    private func response(bucketStarts: [Int64],
+                          panels: [(String, [(Int64, Double, Int)])],
+                          moreProjects: Int = 0) throws -> HistoryAutonomyProjectsResponse {
+        let starts = bucketStarts.map(String.init).joined(separator: ",")
+        let panelJSON = panels.map { project, buckets -> String in
+            let bs = buckets.map { ts, longest, peak in
+                "{\"ts\":\(ts),\"longest\":\(longest),\"peak\":\(peak),\"peak_top\":\(peak)," +
+                "\"peak_sub\":0,\"peak_split\":true}"
+            }.joined(separator: ",")
+            let longest = buckets.map(\.1).max() ?? 0
+            return "{\"project\":\"\(project)\",\"longest\":\(longest),\"total_seconds\":\(longest)," +
+                "\"runs\":\(buckets.count),\"peak\":\(buckets.map(\.2).max() ?? 0),\"buckets\":[\(bs)]}"
+        }.joined(separator: ",")
+        let json = """
+        {"window":"30d","chart":"autonomy_projects","start":0,"end":1,"bucket_seconds":86400,
+         "bucket_starts":[\(starts)],"panels":[\(panelJSON)],
+         "panel_limit":5,"more_projects":\(moreProjects),
+         "summary":{"longest":0},"earliest_span":0,"total_recorded":0}
+        """
+        return try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+    }
+
+    /// The resolved sRGB components of a token under one appearance — the same
+    /// technique the theme suites use, so a token that is a literal in one
+    /// appearance and adaptive in the other is still compared honestly.
+    @MainActor
+    private func rgb(_ color: Color,
+                     _ appearance: NSAppearance,
+                     file: StaticString = #filePath,
+                     line: UInt = #line) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        var out: (CGFloat, CGFloat, CGFloat, CGFloat) = (0, 0, 0, 0)
+        appearance.performAsCurrentDrawingAppearance {
+            guard let srgb = NSColor(color).usingColorSpace(.sRGB) else {
+                XCTFail("token does not resolve to an sRGB colour under \(appearance.name.rawValue)",
+                        file: file, line: line)
+                return
+            }
+            out = (srgb.redComponent, srgb.greenComponent, srgb.blueComponent, srgb.alphaComponent)
+        }
+        return out
     }
 }

--- a/platforms/web/autonomyLayout.test.js
+++ b/platforms/web/autonomyLayout.test.js
@@ -30,7 +30,18 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { JSDOM } from 'jsdom';
 import { WEB_DIR } from './shippedFiles.testutil.js';
-import { autonomyPanelRows, autonomyDuration } from './historyTab.js';
+import {
+  autonomyPanelRows,
+  autonomyDuration,
+  autonomyYDomain,
+  autonomyTickValues,
+  autonomyTickPlacement,
+  autonomyBarRect,
+  autonomyBaselineY,
+  AUTONOMY_PANEL,
+  AUTONOMY_PANEL_CANVAS_H,
+  AUTONOMY_BAR_MIN_H,
+} from './historyTab.js';
 
 function read(name) {
   const body = readFileSync(join(WEB_DIR, name), 'utf8');
@@ -107,15 +118,6 @@ describe('the Autonomy section offers exactly one window control', () => {
     expect(wrap, 'index.html must hold the chart card').not.toBeNull();
     expect(wrap.contains(panels)).toBe(true);
     expect(d.querySelector('.history-panel'), 'the side panel keeps its place').not.toBeNull();
-  });
-
-  test('the stack scrolls rather than clipping its explanation', () => {
-    // Five panels plus the "+N more" line and the axis run a little past a
-    // 360px card. Clipping is the one option that silently removes the row
-    // that says what was left out.
-    const body = ruleBody('.history-autonomy-panels');
-    expect(body).toMatch(/overflow:\s*auto/);
-    expect(body).toMatch(/position:\s*absolute/);
   });
 
   // The markup and the code that shows/hides it are two files, and a rename in
@@ -314,5 +316,233 @@ describe('the two surfaces name the key the same way', () => {
       .filter((r) => r.kind)
       .map((r) => r.label);
     expect(labels).toEqual(web);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QA of the shipped web build against the maintainer's real data found three
+// layout defects the macOS build does not have. These pin the fixes, and each
+// carries the shipped-before geometry as a committed mutation — a check that
+// could not tell the two apart would pass against the very layout it replaced.
+// ---------------------------------------------------------------------------
+
+describe('QA-1: a panel header and the topmost y tick never share a line', () => {
+  // THE DEFECT: tick labels sat in a gutter on the LEFT, drawn centred on their
+  // gridline. The top gridline is the plot's own top edge, so half of "14h34m"
+  // fell outside the canvas — sliced by the panel above, and landing on that
+  // panel's header line, where it overprinted "longest 11h39m · 15 at once".
+  //
+  // TWO INDEPENDENT HALVES OF THE FIX, and both are needed: the labels moved to
+  // the RIGHT gutter (which frees the header row's column), and the canvas
+  // gained a top inset (which keeps the topmost label inside the canvas).
+  const width = 420;
+  const domain = autonomyYDomain([
+    { buckets: [{ ts: 0, longest: 52_440, peak: 3 }, { ts: 1, longest: 120, peak: 1 }] },
+  ]);
+
+  test('every tick label is drawn in a gutter to the right of the plot', () => {
+    // Two claims, and the second is the one that distinguishes a real gutter
+    // from a nominal one: the label starts right of the plot AND fits in the
+    // room left for it. The widest figure autonomyDuration can emit is a
+    // six-character `NNdNNh`, at MONO_ADVANCE_EM per character.
+    const widest = autonomyDuration(12 * 86400 + 23 * 3600).length
+      * AUTONOMY_PANEL.tickFont * MONO_ADVANCE_EM;
+    expect(autonomyTickValues(domain)).toHaveLength(3);
+    for (const v of autonomyTickValues(domain)) {
+      const at = autonomyTickPlacement(v, domain, width);
+      expect(at.x, `${autonomyDuration(v)} is drawn at x=${at.x}, inside the plot`)
+        .toBeGreaterThanOrEqual(at.plotRight);
+      expect(at.x + widest, `the right gutter is only ${AUTONOMY_PANEL.padR}px — a tick label `
+        + `needs ${Math.ceil(widest + AUTONOMY_PANEL.tickGap)}px and would be clipped`)
+        .toBeLessThanOrEqual(width);
+    }
+  });
+
+  test('the topmost label is wholly inside the canvas, not sliced by the panel above', () => {
+    const highest = autonomyTickValues(domain).at(-1);
+    const at = autonomyTickPlacement(highest, domain, width);
+    expect(at.top, 'the top tick label spills above the canvas and lands on the header row')
+      .toBeGreaterThanOrEqual(0);
+  });
+
+  test('the lowest label is wholly inside the canvas too', () => {
+    const lowest = autonomyTickValues(domain)[0];
+    const at = autonomyTickPlacement(lowest, domain, width);
+    expect(at.bottom).toBeLessThanOrEqual(AUTONOMY_PANEL_CANVAS_H);
+  });
+
+  test('the header is a block of its own, above the canvas, not laid over it', () => {
+    // A header positioned over the plot would put the two back on one line
+    // whatever the tick geometry says.
+    const head = ruleBody('.history-autonomy-panel-head');
+    expect(head).not.toMatch(/position:\s*absolute/);
+    expect(head).toMatch(/line-height:\s*\d/);
+    expect(ruleBody('.history-autonomy-panel-canvas')).toMatch(/display:\s*block/);
+  });
+
+  // THE COMMITTED MUTATION: the shipped-before geometry — labels on the left,
+  // no top inset. Both assertions above have to reject it, or neither is
+  // measuring the defect.
+  test('the checks go red against the geometry that shipped', () => {
+    const before = { ...AUTONOMY_PANEL, padL: 46, padR: 6, padT: 0, lineH: 32 };
+    const highest = autonomyTickValues(domain).at(-1);
+    const mutated = autonomyTickPlacement(highest, domain, width, before);
+    expect(mutated.top, 'the shipped geometry drew the top label half outside the canvas')
+      .toBeLessThan(0);
+    // …and its label column was the LEFT one, under the header's project name.
+    expect(before.padL).toBeGreaterThan(before.padR);
+    expect(AUTONOMY_PANEL.padR).toBeGreaterThan(AUTONOMY_PANEL.padL);
+  });
+
+  test('the inset is derived from the tick font, not a lucky constant', () => {
+    // Half a glyph is what has to clear the edge; a smaller inset re-creates
+    // the defect for any larger tick font.
+    expect(AUTONOMY_PANEL.padT * 2).toBeGreaterThanOrEqual(AUTONOMY_PANEL.tickFont);
+  });
+});
+
+describe('QA-2: the axis and the “+N more” line are inside the rendered card', () => {
+  // THE DEFECT: the stack sat in a fixed-height card with its own scrollbar, so
+  // five panels were compressed AND clipped at once — the x axis was cut off at
+  // the bottom edge — while ~250px of page sat empty below the card.
+  const PANELS = 5;
+
+  // The stack's intrinsic height, from the same stylesheet and constants the
+  // renderer uses. Throws rather than defaulting: a rule this cannot read is
+  // one whose value nothing below can be trusted to have computed.
+  function stackHeight() {
+    const panel = ruleBody('.history-autonomy-panel');
+    const head = ruleBody('.history-autonomy-panel-head');
+    const perPanel = AUTONOMY_PANEL_CANVAS_H
+      + px(head, 'line-height', '.history-autonomy-panel-head')
+      + px(panel, 'margin-bottom', '.history-autonomy-panel');
+    const axis = px(ruleBody('.history-autonomy-axis'), 'font-size', '.history-autonomy-axis');
+    const more = px(ruleBody('.history-autonomy-more'), 'font-size', '.history-autonomy-more');
+    return PANELS * perPanel + axis + more;
+  }
+
+  test('the card releases its fixed height for this chart', () => {
+    const body = ruleBody('.history-chart-wrap.autonomy');
+    expect(body).toMatch(/height:\s*auto/);
+    // A min-height is a FLOOR (it keeps the empty state's overlay a sensible
+    // size). A max-height would be a ceiling, and a ceiling is what clipped the
+    // axis in the first place.
+    expect(body).not.toMatch(/max-height/);
+  });
+
+  test('the stack does not scroll inside the card', () => {
+    const body = ruleBody('.history-autonomy-panels');
+    expect(body).not.toMatch(/overflow:\s*auto/);
+    expect(body).not.toMatch(/overflow:\s*scroll/);
+    // …and it is in the flow rather than pinned to the card's box, which is
+    // what made the card's height a clip rectangle.
+    expect(body).toMatch(/position:\s*static/);
+    expect(body).not.toMatch(/inset:/);
+  });
+
+  test('the toggle that grows the card is actually wired', () => {
+    // A stylesheet rule nothing applies is a fix that never ships.
+    expect(js).toMatch(/classList\.toggle\('autonomy', isAutonomy\)/);
+  });
+
+  // THE COMMITTED MUTATION: the fixed-height card. The stack is taller than it,
+  // which is the whole reason the height had to go — and the two rows a
+  // scrollbar cut off first are the last two in the stack.
+  test('the stack is taller than the fixed card it used to be clipped by', () => {
+    const fixedCard = px(ruleBody('.history-chart-wrap'), 'height', '.history-chart-wrap')
+      - 2 * px(ruleBody('.history-chart-wrap'), 'padding', '.history-chart-wrap');
+    expect(stackHeight(), `five panels need ${stackHeight()}px; the fixed card offered ${fixedCard}px`)
+      .toBeGreaterThan(fixedCard);
+  });
+
+  test('the min-height floor cannot clip the stack', () => {
+    const floor = px(ruleBody('.history-chart-wrap.autonomy'), 'min-height', '.history-chart-wrap.autonomy');
+    expect(floor).toBeLessThan(stackHeight());
+  });
+
+  test('the axis is the last thing in the stack, so nothing can hide behind it', () => {
+    // Order matters for the clipping claim: the axis and the "+N more" line are
+    // appended after every panel, so a ceiling takes them first.
+    const render = /function renderAutonomyPanels\(\)[\s\S]*?\n}/.exec(js);
+    expect(render, 'fail-loud: renderAutonomyPanels not found in historyTab.js').not.toBeNull();
+    expect(render[0].indexOf('history-autonomy-more'))
+      .toBeLessThan(render[0].indexOf('buildAutonomyAxis(data)'));
+  });
+});
+
+describe('QA-3: the concurrency bars share a baseline', () => {
+  // THE DEFECT: two- or three-pixel bars with nothing to stand on scanned as
+  // dashes scattered under the line rather than as a distribution, and the
+  // tallest and the shortest looked nearly identical.
+  test('every bar stands on the same baseline', () => {
+    const heights = [1, 2, 7, 15];
+    const bottoms = new Set(heights.map((n) => autonomyBarRect(n, 15).bottom));
+    expect(bottoms.size, 'the bars do not share a foot').toBe(1);
+    expect([...bottoms][0]).toBe(autonomyBaselineY());
+  });
+
+  test('the baseline sits directly beneath the plot, at the foot of the panel', () => {
+    expect(autonomyBaselineY()).toBe(AUTONOMY_PANEL_CANVAS_H);
+    // …and immediately under the line plot, not floating below it.
+    expect(autonomyBaselineY() - AUTONOMY_PANEL.barsH)
+      .toBe(AUTONOMY_PANEL.padT + AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap);
+  });
+
+  test('a bar of 1 and a bar of 15 are visibly different heights', () => {
+    const smallest = autonomyBarRect(1, 15).height;
+    const biggest = autonomyBarRect(15, 15).height;
+    expect(biggest - smallest,
+      `1 draws ${smallest}px and 15 draws ${biggest}px — indistinguishable at a glance`)
+      .toBeGreaterThanOrEqual(12);
+    expect(biggest).toBe(AUTONOMY_PANEL.barsH);
+  });
+
+  test('the smallest real reading is still visible', () => {
+    expect(autonomyBarRect(1, 15).height).toBeGreaterThanOrEqual(AUTONOMY_BAR_MIN_H);
+    expect(AUTONOMY_BAR_MIN_H).toBeGreaterThan(1);
+  });
+
+  // The honesty rule survives the fix: a bucket where nobody worked draws
+  // NOTHING. The floor applies only to a bar that is drawn at all.
+  test('a bucket with nobody working still draws no bar', () => {
+    expect(autonomyBarRect(0, 15)).toBeNull();
+    expect(autonomyBarRect(undefined, 15)).toBeNull();
+    expect(autonomyBarRect(3, 0)).toBeNull();
+  });
+
+  test('the drawn baseline is furniture, not a measurement', () => {
+    // It is stroked in the gridline colour across the whole plot, exactly like
+    // the y gridlines — never in the bar colour, which would make it read as a
+    // row of zero-height bars.
+    const draw = /function drawAutonomyBars\([\s\S]*?\n}/.exec(js);
+    expect(draw, 'fail-loud: drawAutonomyBars not found in historyTab.js').not.toBeNull();
+    expect(draw[0]).toMatch(/strokeStyle = gridColor/);
+    expect(draw[0]).not.toMatch(/strokeStyle = color/);
+  });
+
+  // THE COMMITTED MUTATION: the shipped-before band height. At 10px a bar of 1
+  // and a bar of 15 differed by under 10px and both read as grit.
+  test('the check goes red against the band height that shipped', () => {
+    const before = { ...AUTONOMY_PANEL, barsH: 10 };
+    const spread = autonomyBarRect(15, 15, before).height - autonomyBarRect(1, 15, before).height;
+    expect(spread, 'the shipped band spread 1..15 over only ' + spread + 'px').toBeLessThan(12);
+    const now = autonomyBarRect(15, 15).height - autonomyBarRect(1, 15).height;
+    expect(now).toBeGreaterThanOrEqual(12);
+  });
+});
+
+describe('the stylesheet and the painter agree on the canvas height', () => {
+  // The painter sizes its backing store from AUTONOMY_PANEL_CANVAS_H and lays
+  // out against it; a stylesheet that disagreed would scale every panel and put
+  // the baseline somewhere other than the foot of the box.
+  test('.history-autonomy-panel-canvas is exactly AUTONOMY_PANEL_CANVAS_H tall', () => {
+    const css = px(ruleBody('.history-autonomy-panel-canvas'), 'height', '.history-autonomy-panel-canvas');
+    expect(css).toBe(AUTONOMY_PANEL_CANVAS_H);
+  });
+
+  test('the x-axis bounds sit under the plot, not under the tick gutter', () => {
+    const axis = ruleBody('.history-autonomy-axis');
+    expect(px(axis, 'padding-left', '.history-autonomy-axis')).toBe(AUTONOMY_PANEL.padL);
+    expect(px(axis, 'padding-right', '.history-autonomy-axis')).toBe(AUTONOMY_PANEL.padR);
   });
 });

--- a/platforms/web/autonomyLayout.test.js
+++ b/platforms/web/autonomyLayout.test.js
@@ -1,23 +1,29 @@
-// Autonomy control-placement contract (#1905 redesign).
+// Autonomy control-placement and key-width contract (#1905 redesign).
 //
-// The defect this pins: Range (which changes the duration chart) and Span
-// (which changes the run strip) shipped on ONE control row above BOTH
-// elements. Nothing on screen said which control moved which, and the two
-// vocabularies overlap textually — `30d` is a Range value AND a Span value —
-// so the row read as one zoom control with an odd set of steps. Each control
-// now sits directly above the element it changes: Range in its own row above
-// the chart card, Span in the strip's own header.
+// TWO DEFECTS, one retired and one still live.
+//
+// The retired one: Range (which changed the duration chart) and Span (which
+// changed the run strip) shipped on ONE control row above BOTH elements, with
+// nothing on screen saying which control moved which, and the two vocabularies
+// overlapping textually — `30d` was a Range value AND a Span value. The strip
+// is gone and Span went with it, so the section has ONE control now. What this
+// file keeps checking is that it stays one: a second picker reintroduces the
+// same confusion, and a Span leftover in either the markup or the wiring is a
+// control that does nothing or a listener on a key no request reads.
+//
+// The live one: a key label that does not fit the 260px side panel ellipsises
+// the very row whose job is to explain a mark.
 //
 // jsdom has no layout engine, so this cannot assert geometry — every
-// getBoundingClientRect here would be zeroes. It asserts the two things that
-// CAUSE the geometry instead: the DOM puts each picker inside the block it
-// governs, and the picker precedes the element it labels in document order.
-// The same technique headerLayout.test.js uses, for the same reason.
+// getBoundingClientRect here would be zeroes. It asserts the things that CAUSE
+// the geometry instead: where the DOM puts each control, and the width budget
+// the stylesheet gives a label. The same technique headerLayout.test.js uses,
+// for the same reason.
 //
-// Fail-loud (house rule: a verifier that cannot run must never read as a
-// pass): an unreadable or empty file, an index.html with no Autonomy section,
-// and a stylesheet with no matching rule each THROW rather than vacuously
-// satisfying the assertions below.
+// Fail-loud (house rule: a verifier that cannot run must never read as a pass):
+// an unreadable or empty file, an index.html with no Autonomy section, and a
+// stylesheet with no matching rule each THROW rather than vacuously satisfying
+// the assertions below.
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -40,8 +46,8 @@ const js = read('historyTab.js');
 
 function doc() {
   const d = new JSDOM(html).window.document;
-  if (!d.querySelector('#history-autonomy-strip')) {
-    throw new Error('fail-loud: index.html has no #history-autonomy-strip — the parse found no Autonomy section');
+  if (!d.querySelector('#history-autonomy-panels')) {
+    throw new Error('fail-loud: index.html has no #history-autonomy-panels — the parse found no Autonomy section');
   }
   return d;
 }
@@ -62,95 +68,90 @@ function ruleBody(selector) {
 const follows = (a, b) => Boolean(a.compareDocumentPosition(b) & 4);
 
 // The property under test, as a predicate over any document, so it can be run
-// against the mutation fixture below as well as against the shipped markup.
-function pickersAreSeparated(d) {
-  const range = d.querySelector('#history-autonomy-range-sel');
-  const span = d.querySelector('#history-autonomy-span-sel');
-  if (!range || !span) {
-    throw new Error('fail-loud: a document under test is missing one of the two Autonomy pickers');
+// against the mutation fixture below as well as against the shipped markup:
+// the Autonomy section offers EXACTLY ONE window control.
+function autonomyPickers(d) {
+  const rows = d.querySelectorAll('.history-ctl-row');
+  if (!rows.length) {
+    throw new Error('fail-loud: a document under test has no .history-ctl-row at all');
   }
-  const sharedRow = range.closest('.history-ctl-row');
-  return Boolean(sharedRow) && sharedRow !== span.closest('.history-ctl-row');
+  return [...d.querySelectorAll('fieldset[id^="history-autonomy-"]')].map((f) => f.id);
 }
 
-describe('each Autonomy control sits with the element it changes', () => {
-  test('Range has a control row of its own, and Span is not on it', () => {
-    const d = doc();
-    const range = d.querySelector('#history-autonomy-range-sel');
-    expect(range, 'the Range picker must exist').not.toBeNull();
-    const row = range.closest('.history-ctl-row');
-    expect(row, 'Range belongs in a .history-ctl-row above the chart').not.toBeNull();
-    expect(row.querySelector('#history-autonomy-span-sel'),
-      'Span must not share Range’s row — that is the confusion this fixes').toBeNull();
-    expect(pickersAreSeparated(d)).toBe(true);
+describe('the Autonomy section offers exactly one window control', () => {
+  test('Range is the only Autonomy picker in the tab', () => {
+    // `#history-autonomy-sel` is the chart CHOOSER (the segmented button that
+    // selects the section), not a window control — so two ids here is one
+    // picker plus the chooser, and a third would be a second window.
+    const pickers = autonomyPickers(doc());
+    expect(pickers).toContain('history-autonomy-range-sel');
+    expect(pickers).not.toContain('history-autonomy-span-sel');
+    expect(pickers.filter((id) => id.endsWith('-range-sel') || id.endsWith('-span-sel'))).toHaveLength(1);
   });
 
-  test('Range’s row comes before the chart it changes', () => {
+  test('Range’s row comes before the panels it changes', () => {
     const d = doc();
     const row = d.querySelector('#history-autonomy-range-row');
     expect(row, 'index.html must hold #history-autonomy-range-row').not.toBeNull();
-    const chart = d.querySelector('.history-layout');
-    expect(chart, 'index.html must hold the chart layout').not.toBeNull();
-    expect(follows(row, chart), 'the chart must follow its Range picker').toBe(true);
+    const layout = d.querySelector('.history-layout');
+    expect(layout, 'index.html must hold the chart layout').not.toBeNull();
+    expect(follows(row, layout), 'the panels must follow their Range picker').toBe(true);
   });
 
-  test('Span lives inside the run strip, above the rows it changes', () => {
+  test('the panels live inside the chart card, beside the side panel', () => {
+    // Not a full-width block below it, which is where the run strip lived when
+    // it was a SECOND element. There is one element now.
     const d = doc();
-    const span = d.querySelector('#history-autonomy-span-sel');
-    const strip = d.querySelector('#history-autonomy-strip');
-    expect(strip.contains(span), 'Span must live inside the strip section it governs').toBe(true);
-    // …and not in the control block at the top of the tab, which is what
-    // "above both elements" meant.
-    expect(span.closest('.history-ctl-row'), 'Span must not be in a top-of-tab control row').toBeNull();
-    const rows = d.querySelector('#history-autonomy-rows');
-    expect(rows, 'the strip must hold its rows container').not.toBeNull();
-    expect(follows(span, rows), 'the strip’s rows must follow the Span picker').toBe(true);
+    const panels = d.querySelector('#history-autonomy-panels');
+    const wrap = d.querySelector('#history-chart-wrap');
+    expect(wrap, 'index.html must hold the chart card').not.toBeNull();
+    expect(wrap.contains(panels)).toBe(true);
+    expect(d.querySelector('.history-panel'), 'the side panel keeps its place').not.toBeNull();
   });
 
-  test('the strip’s header keeps the title and the picker on one row', () => {
-    const d = doc();
-    const header = d.querySelector('.history-autonomy-header');
-    expect(header, 'the strip needs a header row for its title + picker').not.toBeNull();
-    expect(header.querySelector('#history-autonomy-strip-title')).not.toBeNull();
-    expect(header.querySelector('#history-autonomy-span-sel')).not.toBeNull();
-    expect(ruleBody('.history-autonomy-header')).toMatch(/display:\s*flex/);
-    // It wraps rather than compressing: five segmented buttons plus a title
-    // do not fit a narrow window on one line, and squeezing them is worse
-    // than stacking them.
-    expect(ruleBody('.history-autonomy-header')).toMatch(/flex-wrap:\s*wrap/);
+  test('the stack scrolls rather than clipping its explanation', () => {
+    // Five panels plus the "+N more" line and the axis run a little past a
+    // 360px card. Clipping is the one option that silently removes the row
+    // that says what was left out.
+    const body = ruleBody('.history-autonomy-panels');
+    expect(body).toMatch(/overflow:\s*auto/);
+    expect(body).toMatch(/position:\s*absolute/);
   });
 
   // The markup and the code that shows/hides it are two files, and a rename in
-  // one is invisible to the other until the row silently stops toggling. The
-  // shared row's old id is gone from BOTH, and the new one is in both.
+  // one is invisible to the other until the row silently stops toggling.
   test('the row toggle and the markup name the same row', () => {
     expect(html).toContain('id="history-autonomy-range-row"');
     expect(js).toContain("getElementById('history-autonomy-range-row')");
-    expect(html).not.toContain('id="history-autonomy-row"');
-    expect(js).not.toContain("getElementById('history-autonomy-row')");
+    expect(html).toContain('id="history-autonomy-panels"');
+    expect(js).toContain("getElementById('history-autonomy-panels')");
   });
 
-  // THE COMMITTED MUTATION: the shipped-before layout, both pickers on one
-  // row. A check that could not tell it from the split layout would pass
-  // against the very arrangement this change exists to remove.
-  test('the check goes red against the one-row layout it replaced', () => {
-    const merged = new JSDOM(`
-      <div class="history-ctl-row" id="history-autonomy-row">
+  // THE COMMITTED MUTATION: the shipped-before layout, two pickers with two
+  // textually-overlapping vocabularies. A check that could not tell it from
+  // the one-control layout would pass against the very arrangement this change
+  // removes.
+  test('the check goes red against the two-picker layout it replaced', () => {
+    const twoPickers = new JSDOM(`
+      <div class="history-ctl-row" id="history-autonomy-range-row">
         <span class="history-ctl-label">Range</span>
         <fieldset id="history-autonomy-range-sel"></fieldset>
         <span class="history-ctl-label">Span</span>
         <fieldset id="history-autonomy-span-sel"></fieldset>
       </div>
     `).window.document;
-    expect(pickersAreSeparated(merged)).toBe(false);
-    expect(pickersAreSeparated(doc())).toBe(true);
+    const mutated = autonomyPickers(twoPickers)
+      .filter((id) => id.endsWith('-range-sel') || id.endsWith('-span-sel'));
+    expect(mutated).toHaveLength(2);
+    expect(autonomyPickers(doc())
+      .filter((id) => id.endsWith('-range-sel') || id.endsWith('-span-sel'))).toHaveLength(1);
   });
 
-  // …and the fail-loud half: a document with no pickers at all must throw,
-  // never quietly report "separated".
-  test('a document missing a picker fails loudly instead of passing', () => {
+  // …and the fail-loud half: a document with no control rows at all must
+  // throw, never quietly report "one picker".
+  test('a document with no control rows fails loudly instead of passing', () => {
     const empty = new JSDOM('<div></div>').window.document;
-    expect(() => pickersAreSeparated(empty)).toThrow(/fail-loud/);
+    expect(() => autonomyPickers(empty)).toThrow(/fail-loud/);
   });
 });
 
@@ -188,7 +189,7 @@ function panelGeometry() {
   }
   const content = Number(flex[1]) - 2 * px(panel, 'padding', '.history-panel');
   const row = ruleBody('.history-contrib li');
-  const swatch = px(ruleBody('.history-contrib .dot.autonomy-band'), 'width', '.history-contrib .dot.autonomy-band');
+  const swatch = px(ruleBody('.history-contrib .dot.autonomy-bars'), 'width', '.history-contrib .dot.autonomy-bars');
   const gap = px(row, 'gap', '.history-contrib li');
   return {
     content,
@@ -200,19 +201,16 @@ function panelGeometry() {
 }
 
 describe('the key rows fit the panel they are rendered in', () => {
-  // THE DEFECT: at the shipped width the band row rendered as
-  // `p5–p95 · where most runs…` with an ellipsis, and its value broke across
-  // two lines as `6s –` / `23m46s`. So the one row whose whole job is to
-  // explain the band cut off its own explanation, and a single span read as
-  // two numbers. jsdom has no layout engine, so this asserts the two things
-  // that CAUSE that geometry — the width budget, and the CSS that decides
-  // what happens when something exceeds it.
+  // THE DEFECT: at the shipped width a key row rendered with an ellipsis, so
+  // the one row whose whole job is to explain a mark cut off its own
+  // explanation. jsdom has no layout engine, so this asserts the two things
+  // that CAUSE that geometry — the width budget, and the CSS that decides what
+  // happens when something exceeds it.
   const geometry = panelGeometry();
   const width = (text) => text.length * geometry.fontSize * MONO_ADVANCE_EM;
   const unstyled = { getPropertyValue: () => '' };
-  const keyRows = () => autonomyPanelRows(
-    { p95: 1426, p50: 210, p5: 6, min: 4, max: 8040, count: 312 }, unstyled,
-  ).filter((r) => r.kind);
+  const summary = { longest: 41_940, peak: 5, runs: 312, projects: 12 };
+  const keyRows = () => autonomyPanelRows(summary, unstyled).filter((r) => r.kind);
 
   test('the panel is wide enough for every key label on one line', () => {
     expect(keyRows()).toHaveLength(2);
@@ -222,32 +220,31 @@ describe('the key rows fit the panel they are rendered in', () => {
     }
   });
 
-  // The QA case verbatim: p5 6s, p95 23m46s. It is the value that broke, and
-  // it breaks again the moment a label is allowed to crowd it.
-  test('the reported row fits: label and value each clear their line', () => {
-    const band = keyRows()[1];
-    expect(band.value).toBe('6s – 23m46s');
-    expect(width(band.label)).toBeLessThan(geometry.labelLine);
-    expect(width(band.value)).toBeLessThan(geometry.content);
+  test('both key rows’ figures clear their line', () => {
+    for (const row of keyRows()) {
+      expect(width(row.value)).toBeLessThan(geometry.content);
+    }
   });
 
-  // …and the widest figure this formatter can ever produce, so the check is
-  // not pinned to one lucky data set. autonomyDuration's longest output is a
-  // six-character `NNdNNh`, twice, with the separator between.
-  test('even the widest range this formatter can emit fits its line', () => {
-    const widest = autonomyDuration(12 * 86400 + 23 * 3600) + ' – ' + autonomyDuration(12 * 86400 + 23 * 3600);
-    expect(widest).toBe('12d23h – 12d23h');
+  // …and the widest figure this row can ever carry, so the check is not pinned
+  // to one lucky data set: autonomyDuration's longest output is a
+  // six-character `NNdNNh`, plus the still-going mark.
+  test('even the widest longest-run this formatter can emit fits its line', () => {
+    const widest = autonomyDuration(12 * 86400 + 23 * 3600) + ' · still going';
+    expect(widest).toBe('12d23h · still going');
     expect(width(widest)).toBeLessThan(geometry.content);
   });
 
-  // THE COMMITTED MUTATION: the label as it shipped. It is one character over
-  // the column, which is exactly why nobody caught it by eye — and it is the
-  // string the check has to reject, or the check is decoration.
-  test('the check rejects the label that shipped truncated', () => {
+  // THE COMMITTED MUTATION: the label as it once shipped, one character over
+  // the column — which is exactly why nobody caught it by eye. It is the string
+  // the check has to reject, or the check is decoration.
+  test('the check rejects a label one character too long', () => {
     expect(width('p5–p95 · where most runs land')).toBeGreaterThan(geometry.labelLine);
-    // …while the one that replaced it clears the column with room to spare,
-    // so a mono face a little wider than the estimate still fits.
-    expect(width('p5–p95 · the usual spread')).toBeLessThan(geometry.labelLine * 0.95);
+    // …while the ones that ship clear the column with room to spare, so a mono
+    // face a little wider than the estimate still fits.
+    for (const row of keyRows()) {
+      expect(width(row.label)).toBeLessThan(geometry.labelLine * 0.95);
+    }
   });
 
   test('a stylesheet the budget cannot be read from fails loudly', () => {
@@ -261,7 +258,7 @@ describe('nothing in the panel truncates a key label or splits a figure', () => 
   // The width budget above says the label FITS. These say what happens if it
   // ever stops fitting — it wraps, and the reader still gets the whole
   // sentence. A truncated explanation is unreadable; a wrapped one is merely
-  // taller, and this row explains the largest area of ink on the chart.
+  // taller.
   test('a key row’s label wraps rather than ellipsising', () => {
     const body = ruleBody('.history-contrib li.autonomy-key .label');
     expect(body).toMatch(/white-space:\s*normal/);
@@ -286,23 +283,24 @@ describe('nothing in the panel truncates a key label or splits a figure', () => 
   // every one of them is asserting about markup nothing renders.
   test('the panel actually marks its key rows', () => {
     const list = new JSDOM('<ul id="l"></ul>').window.document.getElementById('l');
-    for (const row of autonomyPanelRows({ p95: 60, p50: 30, p5: 10, min: 1, max: 99, count: 5 },
+    for (const row of autonomyPanelRows({ longest: 60, peak: 1, runs: 5, projects: 2 },
       { getPropertyValue: () => '' })) {
       const li = list.ownerDocument.createElement('li');
       if (row.kind) li.className = 'autonomy-key';
       list.appendChild(li);
     }
-    // Two key rows, three unswatched figures — the same split renderAutonomyPanel makes.
+    // Two key rows, two unswatched figures — the same split
+    // renderAutonomySidePanel makes.
     expect(list.querySelectorAll('li.autonomy-key')).toHaveLength(2);
     expect(js).toMatch(/li\.className\s*=\s*'autonomy-key'/);
   });
 });
 
 describe('the two surfaces name the key the same way', () => {
-  // Two clients must not explain one chart differently. Reads the Swift
-  // source rather than comparing against a hand-typed literal — the same
-  // technique sessionError.test.js uses for Tokens.swift, and the twin of
-  // macOS's own testBoundaryLabelsMatchTheWebs.
+  // Two clients must not explain one chart differently. Reads the Swift source
+  // rather than comparing against a hand-typed literal — the same technique
+  // sessionError.test.js uses for Tokens.swift, and the twin of macOS's own
+  // testBoundaryLabelsMatchTheWebs.
   const swift = readFileSync(
     join(WEB_DIR, '..', 'macos', 'Irrlicht', 'Views', 'HistoryAutonomyView.swift'), 'utf8',
   );

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -423,6 +423,13 @@ function syncHistoryMatrixVisibility(isState) {
   if (matrixScroll) matrixScroll.hidden = !isState;
   const panels = document.getElementById('history-autonomy-panels');
   if (panels) panels.hidden = !isAutonomy;
+  // The card GROWS for the panel stack rather than scrolling inside its own
+  // fixed height (QA-2). Five panels do not fit 360px at a readable height, and
+  // the two things an inner scrollbar cut off first were the x axis and the
+  // "+N more" line — the row that says what the view left out. The class is
+  // scoped to this chart, so every other chart keeps its fixed-height card.
+  const wrap = document.getElementById('history-chart-wrap');
+  if (wrap) wrap.classList.toggle('autonomy', isAutonomy);
 }
 
 // syncHistoryRangeRow hides the Day/Week/Month/… range selector for
@@ -1148,13 +1155,37 @@ export function autonomyKeyEntries(cs) {
 // Panel geometry, in CSS pixels. The line plot and the histogram share one
 // canvas per panel so their x axes cannot drift apart and one boundary rule can
 // run through both.
-const AUTONOMY_PANEL = {
-  padL: 46, padR: 6,
-  lineH: 32,   // the longest-run plot
-  gap: 2,
-  barsH: 10,   // the concurrency histogram, deliberately low
+//
+// TICK LABELS ON THE RIGHT, and the top inset that goes with them. Both are
+// QA fixes and both are copied from macOS, so the two surfaces read as one
+// design (QA-1):
+//
+//   - On the LEFT, the y-axis gutter sat directly under the panel header's
+//     project name, and the header row and the axis column were one column of
+//     text doing two jobs. On the right the header row is free.
+//   - `padT` is what stops the TOPMOST label being sliced. A label is drawn
+//     centred on its gridline; the top gridline is at the plot's own top edge,
+//     so without an inset half the glyph falls outside the canvas and reads as
+//     text cut off by the panel above. The inset has to be at least half the
+//     tick font — `autonomyTickPlacement` computes that and a test asserts it.
+export const AUTONOMY_PANEL = {
+  padL: 4,      // a hair of left margin; the labels are on the RIGHT now
+  padR: 46,     // the shared y axis's label gutter
+  padT: 6,      // clearance for the topmost tick label's upper half
+  lineH: 40,    // the longest-run plot
+  gap: 3,
+  barsH: 18,    // the concurrency histogram
+  tickFont: 9,  // px, the y-axis tick label
+  tickGap: 5,   // px between the plot's right edge and its labels
 };
-const AUTONOMY_PANEL_CANVAS_H = AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap + AUTONOMY_PANEL.barsH;
+export const AUTONOMY_PANEL_CANVAS_H =
+  AUTONOMY_PANEL.padT + AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap + AUTONOMY_PANEL.barsH;
+
+// AUTONOMY_BAR_MIN_H is the floor on a drawn bar (QA-3). A bucket where one
+// agent worked is a real reading and must be visible; at `barsH * 1/15` it was
+// a single device pixel and read as grit. The floor applies only to a bar that
+// is drawn at all — a bucket with nobody working still draws NOTHING.
+export const AUTONOMY_BAR_MIN_H = 2;
 
 // renderAutonomyPanels draws the stack: five project panels, the "+N more" line
 // and the window's own bounds under them.
@@ -1247,7 +1278,7 @@ function paintAutonomyPanel(canvas, panel, opts) {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, w, h);
 
-  const { padL, padR, lineH, gap, barsH } = AUTONOMY_PANEL;
+  const { padL, padR, padT, lineH } = AUTONOMY_PANEL;
   const plotW = Math.max(1, w - padL - padR);
   const points = autonomyPanelPoints(panel, opts.bucketStarts);
   const n = Math.max(1, points.length);
@@ -1255,39 +1286,73 @@ function paintAutonomyPanel(canvas, panel, opts) {
 
   const cs = opts.cs;
   const muted = (cs.getPropertyValue('--muted') || '#888').trim();
+  const gridColor = 'rgba(128,140,170,0.18)';
   const lineColor = autonomyKeyColor('line', cs);
   const barColor = autonomyKeyColor('bars', cs);
 
-  drawAutonomyGridlines(ctx, { domain: opts.domain, padL, w, padR, lineH, muted });
+  drawAutonomyGridlines(ctx, { domain: opts.domain, padL, padR, padT, lineH, w, muted, gridColor });
   // Under the marks, deliberately: a boundary explains the data, it is not part
   // of it, and a rule drawn over a line competes with what it annotates.
   drawAutonomyBoundaries(ctx, { boundaries: opts.boundaries, padL, plotW, h, muted, index: opts.index });
-  drawAutonomyBars(ctx, { points, xAt, plotW, n, top: lineH + gap, barsH, peakMax: opts.peakMax, color: barColor });
-  drawAutonomyLine(ctx, { points, xAt, domain: opts.domain, lineH, color: lineColor });
+  drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax: opts.peakMax, color: barColor, gridColor, padL, padR, w });
+  drawAutonomyLine(ctx, { points, xAt, domain: opts.domain, padT, lineH, color: lineColor });
 }
 
 // drawAutonomyGridlines draws the SHARED log Y gridlines, labelled in the same
 // duration units the panel headers use, so an axis tick and a headline figure
 // can never be read in different units.
-function drawAutonomyGridlines(ctx, { domain, padL, w, padR, lineH, muted }) {
+//
+// LABELS TO THE RIGHT OF THE PLOT (QA-1). On the left they shared a column with
+// the panel header's project name, and the topmost one was drawn half outside
+// the canvas — a figure sliced by the panel above, sitting on the same line as
+// that panel's own figures. `autonomyTickPlacement` is where the position is
+// decided, so both halves of the fix are testable without a canvas.
+function drawAutonomyGridlines(ctx, { domain, padL, padR, padT, lineH, w, muted, gridColor }) {
   if (!domain) return;
   ctx.save();
-  ctx.strokeStyle = 'rgba(128,140,170,0.18)';
+  ctx.strokeStyle = gridColor;
   ctx.fillStyle = muted;
-  ctx.font = '9px ui-monospace, monospace';
-  ctx.textAlign = 'right';
+  ctx.font = AUTONOMY_PANEL.tickFont + 'px ui-monospace, monospace';
+  ctx.textAlign = 'left';
   ctx.textBaseline = 'middle';
-  const steps = 2;
-  for (let i = 0; i <= steps; i++) {
-    const v = Math.exp(Math.log(domain.lo) + (Math.log(domain.hi) - Math.log(domain.lo)) * (i / steps));
-    const y = autonomyYAt(v, domain, lineH);
+  for (const v of autonomyTickValues(domain)) {
+    const at = autonomyTickPlacement(v, domain, w);
     ctx.beginPath();
-    ctx.moveTo(padL, y);
-    ctx.lineTo(w - padR, y);
+    ctx.moveTo(padL, at.y);
+    ctx.lineTo(w - padR, at.y);
     ctx.stroke();
-    ctx.fillText(autonomyDuration(v), padL - 5, y);
+    ctx.fillText(autonomyDuration(v), at.x, at.y);
   }
   ctx.restore();
+}
+
+// autonomyTickValues returns the durations the shared axis is labelled at,
+// evenly spaced on the log scale, lowest first.
+export function autonomyTickValues(domain, steps = 2) {
+  if (!domain) return [];
+  const out = [];
+  for (let i = 0; i <= steps; i++) {
+    out.push(Math.exp(Math.log(domain.lo) + (Math.log(domain.hi) - Math.log(domain.lo)) * (i / steps)));
+  }
+  return out;
+}
+
+// autonomyTickPlacement is where one tick's label is drawn, as a value.
+//
+// It carries the two properties QA-1 was about, so both can be asserted without
+// a canvas: the label sits in the gutter to the RIGHT of the plot (so the panel
+// header's row is free), and its upper edge is inside the canvas (so the
+// topmost figure is not sliced by the panel above). `top`/`bottom` are the
+// label's own extent, since it is drawn centred on its gridline.
+export function autonomyTickPlacement(v, domain, width, panel = AUTONOMY_PANEL) {
+  const y = panel.padT + autonomyYAt(v, domain, panel.lineH);
+  return {
+    y,
+    x: width - panel.padR + panel.tickGap,
+    top: y - panel.tickFont / 2,
+    bottom: y + panel.tickFont / 2,
+    plotRight: width - panel.padR,
+  };
 }
 
 // autonomyYAt maps a duration onto the shared log axis. Exported so a test can
@@ -1303,8 +1368,9 @@ export function autonomyYAt(v, domain, lineH) {
 // drawAutonomyLine strokes the longest-run line, BREAKING at every gap rather
 // than interpolating across it (autonomyLineSegments), and marking an isolated
 // bucket with a dot so the one bucket with no neighbour is not invisible.
-function drawAutonomyLine(ctx, { points, xAt, domain, lineH, color }) {
+function drawAutonomyLine(ctx, { points, xAt, domain, padT, lineH, color }) {
   if (!domain) return;
+  const yAt = (v) => padT + autonomyYAt(v, domain, lineH);
   ctx.save();
   ctx.strokeStyle = color;
   ctx.fillStyle = color;
@@ -1313,13 +1379,13 @@ function drawAutonomyLine(ctx, { points, xAt, domain, lineH, color }) {
   for (const seg of autonomyLineSegments(points)) {
     if (seg.from === seg.to) {
       ctx.beginPath();
-      ctx.arc(xAt(seg.from), autonomyYAt(points[seg.from].longest, domain, lineH), 1.8, 0, Math.PI * 2);
+      ctx.arc(xAt(seg.from), yAt(points[seg.from].longest), 1.8, 0, Math.PI * 2);
       ctx.fill();
       continue;
     }
     ctx.beginPath();
     for (let i = seg.from; i <= seg.to; i++) {
-      const x = xAt(i), y = autonomyYAt(points[i].longest, domain, lineH);
+      const x = xAt(i), y = yAt(points[i].longest);
       if (i === seg.from) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
@@ -1330,29 +1396,60 @@ function drawAutonomyLine(ctx, { points, xAt, domain, lineH, color }) {
     const p = points[i];
     if (!p || !(Number(p.longest) > 0) || !p.running) continue;
     ctx.beginPath();
-    ctx.arc(xAt(i), autonomyYAt(p.longest, domain, lineH), 2.4, 0, Math.PI * 2);
+    ctx.arc(xAt(i), yAt(p.longest), 2.4, 0, Math.PI * 2);
     ctx.stroke();
   }
   ctx.restore();
 }
 
-// drawAutonomyBars draws the concurrency histogram: one low bar per bucket,
-// scaled against the stack's shared peak.
+// autonomyBaselineY is the histogram's foot: the line every bar stands on, at
+// the very bottom of the panel canvas and directly beneath the plot.
+export function autonomyBaselineY(panel = AUTONOMY_PANEL) {
+  return panel.padT + panel.lineH + panel.gap + panel.barsH;
+}
+
+// autonomyBarRect is one bar's vertical extent, as a value (QA-3). null for a
+// bucket that draws no bar at all.
 //
-// A BUCKET WITH NO ONE WORKING DRAWS NOTHING — not a zero-height bar, and not a
-// hairline on the baseline. A mark on the axis reads as a measured zero, which
-// is a different and false claim from "no runs here".
-function drawAutonomyBars(ctx, { points, xAt, plotW, n, top, barsH, peakMax, color }) {
-  if (!(peakMax > 0)) return;
-  const barW = Math.max(1, Math.min(6, plotW / Math.max(1, n) - 1));
+// EVERY BAR STANDS ON autonomyBaselineY. They always did arithmetically, but at
+// two or three pixels with nothing to stand on they scanned as dashes scattered
+// under the line rather than as a distribution — so the baseline is now DRAWN,
+// and the band is tall enough that a bar of 1 and a bar of 15 are visibly
+// different heights rather than both being a smudge.
+export function autonomyBarRect(peak, peakMax, panel = AUTONOMY_PANEL) {
+  const n = Number(peak) || 0;
+  const max = Number(peakMax) || 0;
+  if (n <= 0 || max <= 0) return null;
+  const height = Math.max(AUTONOMY_BAR_MIN_H, panel.barsH * (n / max));
+  const bottom = autonomyBaselineY(panel);
+  return { top: bottom - height, bottom, height };
+}
+
+// drawAutonomyBars draws the concurrency histogram: one bar per bucket, scaled
+// against the stack's shared peak, all of them standing on one drawn baseline.
+//
+// A BUCKET WITH NO ONE WORKING DRAWS NOTHING — no bar, however short. The
+// BASELINE is not a mark on that rule: it is drawn uniformly across the whole
+// plot in the gridline colour, exactly like the y gridlines above it, so it
+// reads as furniture rather than as a per-bucket measurement of zero.
+function drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax, color, gridColor, padL, padR, w }) {
+  const baseline = autonomyBaselineY();
   ctx.save();
-  ctx.fillStyle = color;
-  for (let i = 0; i < points.length; i++) {
-    const p = points[i];
-    const peak = p ? (Number(p.peak) || 0) : 0;
-    if (peak <= 0) continue;
-    const hgt = Math.max(1, barsH * (peak / peakMax));
-    ctx.fillRect(xAt(i) - barW / 2, top + (barsH - hgt), barW, hgt);
+  // The foot first, so a bar sits ON it rather than the rule cutting across.
+  ctx.strokeStyle = gridColor;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(padL, baseline + 0.5);
+  ctx.lineTo(w - padR, baseline + 0.5);
+  ctx.stroke();
+  if (peakMax > 0) {
+    const barW = Math.max(1.5, Math.min(6, plotW / Math.max(1, n) - 1));
+    ctx.fillStyle = color;
+    for (let i = 0; i < points.length; i++) {
+      const rect = autonomyBarRect(points[i]?.peak, peakMax);
+      if (!rect) continue;
+      ctx.fillRect(xAt(i) - barW / 2, rect.top, barW, rect.height);
+    }
   }
   ctx.restore();
 }

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -12,43 +12,22 @@ const HISTORY_COLORS = [
 ];
 const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
 export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', state: 'Activity', yield: 'Yield', dora: 'DORA', autonomy: 'Autonomy' };
-// Autonomy (#1905). `autonomy` is a CLIENT-SIDE pseudo-chart: selecting it
-// fans out into the daemon's two real charts, chart=autonomy_duration (the
-// percentile lines) and chart=autonomy_spans (the run strip), because the
-// section shows both elements at once.
+// Autonomy (#1905). `autonomy` is a CLIENT-SIDE pseudo-chart name for the
+// daemon's chart=autonomy_projects: FIVE PER-PROJECT PANELS, one per project,
+// stacked, each carrying a longest-run line and a concurrency histogram under
+// it. One request, one payload — the section used to fan out into two charts
+// (a percentile band and a per-project run strip) and both are gone.
 //
 // WINDOW LENGTHS, not bucket widths. These keys overlap GRANULARITY_LABELS'
 // textually and mean something else entirely: there a key names a bucket width
 // that is multiplied by a count (so '24h' resolves to a THIRTY-DAY window),
-// here a key IS the window. The two tables must never be merged — see
+// here a key IS the window. The two tables must never be merged - see
 // autonomy window vocabularies in irrlicht.history.autonomy.test.js.
-export const AUTONOMY_RANGE_LABELS = { '30d': '30 days', '1y': 'Year' };
-export const AUTONOMY_SPAN_LABELS = { '8h': '8h', '24h': '24h', '7d': '7d', '30d': '30d', '12mo': '12mo' };
-// The strip's pixel-collapse ladder: when one device-pixel column holds
-// several runs, the column paints the highest-ranked reason in it. Same order
-// as the session-history strip's ladder (#1805) — one error in a column paints
-// the whole column. One state per line, because a single line naming three of
-// the four canonical states is what tools/state-vocabulary-lint.sh refuses.
-export const AUTONOMY_REASON_PRIORITY = {
-  error: 3,
-  waiting: 2,
-  ready: 1,
-};
-// Legend glyphs + wording, matching the issue's sketch and the macOS legend.
-export const AUTONOMY_REASON_LEGEND = [
-  ['error', '\u2717', 'error'],
-  ['waiting', '?', 'it asked'],
-  ['ready', '\u2713', 'turn finished'],
-];
-// The neutral fourth entry, appended only when the window actually holds a run
-// whose end reason nothing can name (#1905 back-fill). Two ways a run gets
-// here and both draw the same neutral column: a span reconstructed from the
-// cost log, which records that a session was working and never why it stopped,
-// and an old row written by a build that could not name the state.
 //
-// CONDITIONAL, because a legend entry for a colour the strip is not drawing is
-// noise \u2014 see autonomyLegendEntries.
-export const AUTONOMY_UNKNOWN_LEGEND = ['unknown', '\u00b7', 'end reason unknown'];
+// There is no Span control any more. It governed the run strip's own window,
+// and it went with the strip: one window, one control, and no pair of
+// textually-overlapping vocabularies for a reader to keep apart.
+export const AUTONOMY_RANGE_LABELS = { '30d': '30 days', '1y': 'Year' };
 // Granularity steps for chart=state's activity matrix (issue #981) — each
 // picks both the server's bucket width and the matrix's visible column
 // count at once (see historyGranularitySpecs on the daemon side).
@@ -87,14 +66,13 @@ const historyState = {
   // granularity is chart=state's own zoom-level axis (#981) — independent of
   // range, which every other chart uses instead.
   granularity: '24h',
-  // Autonomy (#1905): one window per element, neither of them `range`.
-  // autonomyData holds BOTH responses, since the section renders both at once.
+  // Autonomy (#1905): its own window, which is not `range`. One key now, not
+  // two - the run strip's Span went with the strip.
   autonomyRange: '30d',
-  autonomySpan: '24h',
-  // There is no run-scope key here any more (#1905 recording): the section
-  // counts every run, subagent runs included, because Irrlicht recorded them.
-  // Each row still carries its `kind` and `parent`, so a subagent's run stays
-  // identifiable — what went is the choice, not the classification.
+  // There is no run-scope key here (#1905 recording): the section counts every
+  // run, subagent runs included, because Irrlicht recorded them. What each run
+  // WAS still matters - the `kind` field is what splits a concurrency peak into
+  // sessions and subagents - but which runs are counted is not a choice.
   autonomyData: null,
   filters: { provider: [], token_type: [], project: [] },
   known: { provider: [], project: [] },
@@ -276,20 +254,13 @@ function setHistoryFilterParams(p, state) {
   }
 }
 
-// autonomyQuery builds one of the two Autonomy requests. `element` picks
-// which daemon chart and therefore which window vocabulary applies — they are
-// different sets, and neither endpoint accepts the other's keys.
-export function autonomyQuery(element, state = historyState) {
+// autonomyQuery builds the Autonomy request: one chart, one window.
+export function autonomyQuery(state = historyState) {
   const p = new URLSearchParams();
-  if (element === 'spans') {
-    p.set('chart', 'autonomy_spans');
-    p.set('window', state.autonomySpan);
-  } else {
-    p.set('chart', 'autonomy_duration');
-    p.set('window', state.autonomyRange);
-  }
+  p.set('chart', 'autonomy_projects');
+  p.set('window', state.autonomyRange);
   // No run-scope parameter (#1905 recording). Every run counts, so there is
-  // nothing to ask for — and sending the retired one would leave an OLD daemon
+  // nothing to ask for - and sending the retired one would leave an OLD daemon
   // serving a filtered payload while this panel's sentence said otherwise,
   // which is the exact "wrong number, nothing on screen saying so" the section
   // is built to avoid.
@@ -310,20 +281,18 @@ export function historyQuery(state = historyState) {
   return p.toString();
 }
 
-// fetchAutonomy fetches BOTH Autonomy elements. Either failing marks the whole
-// section unavailable rather than leaving one element beside a spinner that
-// never resolves.
+// fetchAutonomy fetches the section's single payload.
 function fetchAutonomy() {
   const seq = ++historyFetchSeq;
-  const get = (element) => fetch('/api/v1/history?' + autonomyQuery(element))
+  return fetch('/api/v1/history?' + autonomyQuery())
     .then(r => (r.ok ? r.json() : null))
-    .catch(() => null);
-  return Promise.all([get('duration'), get('spans')]).then(([duration, spans]) => {
-    if (seq !== historyFetchSeq) return; // superseded by a newer request
-    historyState.autonomyData = (duration && spans) ? { duration, spans } : null;
-    historyState.data = historyState.autonomyData ? duration : null;
-    renderHistory();
-  });
+    .catch(() => null)
+    .then(data => {
+      if (seq !== historyFetchSeq) return; // superseded by a newer request
+      historyState.autonomyData = data || null;
+      historyState.data = historyState.autonomyData;
+      renderHistory();
+    });
 }
 
 function fetchHistory() {
@@ -409,9 +378,8 @@ function paintActiveHistoryChart() {
       renderStatePanel();
       break;
     case 'autonomy':
-      paintAutonomyChart();
-      renderAutonomyStrip();
-      renderAutonomyPanel();
+      renderAutonomyPanels();
+      renderAutonomySidePanel();
       break;
     default:
       paintHistoryChart();
@@ -446,8 +414,15 @@ function renderHistory() {
 function syncHistoryMatrixVisibility(isState) {
   const canvas = document.getElementById('history-chart');
   const matrixScroll = document.getElementById('history-matrix-scroll');
-  if (canvas) canvas.hidden = isState;
+  const isAutonomy = historyState.chart === 'autonomy';
+  // Autonomy joins chart=state in replacing the shared canvas with its own DOM
+  // block inside the SAME card, rather than taking a full-width strip below it:
+  // the section is now one element, so it belongs where every other chart is
+  // drawn, with the side panel keeping its place beside it.
+  if (canvas) canvas.hidden = isState || isAutonomy;
   if (matrixScroll) matrixScroll.hidden = !isState;
+  const panels = document.getElementById('history-autonomy-panels');
+  if (panels) panels.hidden = !isAutonomy;
 }
 
 // syncHistoryRangeRow hides the Day/Week/Month/… range selector for
@@ -460,20 +435,17 @@ function syncHistoryRangeRow() {
   if (row) row.hidden = historyState.chart === 'state' || historyState.chart === 'autonomy';
 }
 
-// syncAutonomyRows shows the Autonomy controls and the run strip only while
-// the section is active, mirroring syncGranularityRow's per-chart row toggle.
+// syncAutonomyRows shows the Autonomy controls only while the section is
+// active, mirroring syncGranularityRow's per-chart row toggle.
 //
-// One row, not two: Range is the only Autonomy control up here now, because
-// Span moved into the strip's own header (which this same function shows and
-// hides, so the picker cannot outlive the element it drives).
+// ONE ROW, one control: Range. The strip's Span picker went with the strip, so
+// there is no second window vocabulary on screen to confuse with this one.
 function syncAutonomyRows(isAutonomy) {
   const ctl = document.getElementById('history-autonomy-range-row');
   if (ctl) ctl.hidden = !isAutonomy;
-  const strip = document.getElementById('history-autonomy-strip');
-  if (strip) strip.hidden = !isAutonomy;
   const groupRow = document.getElementById('history-group-sel')?.closest('.history-ctl-row');
-  // Group and the cross-filters do not apply to spans — the section has no
-  // stacking axis at all.
+  // Group and the cross-filters do not apply to the panels - the section has no
+  // stacking axis at all, and its own axis is the project.
   if (groupRow) groupRow.hidden = isAutonomy;
   const filterRow = document.getElementById('history-filter-row');
   if (filterRow) filterRow.hidden = isAutonomy;
@@ -746,22 +718,33 @@ function paintHistoryChart() {
 
 // --- Autonomy (#1905) ---
 //
-// Two elements over the always-on span log: a percentile line chart of
-// autonomous run duration over time (drawn on the shared canvas, like every
-// other time series here), and a per-project run strip (its own DOM section,
-// one canvas per project row).
+// FIVE PER-PROJECT PANELS over the always-on span log, stacked inside the
+// shared chart card. Every panel carries the same two things:
 //
-// An autonomy span is one unbroken stretch of `working`; the state the session
-// left `working` FOR is the signal both elements carry.
+//   A LINE — the longest run in each time bucket. Only `working` matters to
+//   this section now, so how a run ended is recorded and never drawn.
+//   A HISTOGRAM under it — how many runs were working AT THE SAME TIME in that
+//   bucket, derived by the daemon from the spans by overlap.
+//
+// WHAT THIS REPLACED. The section used to be two elements: a p5–p95 band with a
+// p50 line, and a per-project run strip coloured by end reason. Both are gone,
+// along with the strip's legend and glyphs, the Span picker that governed its
+// window, and the sample floor that marked buckets whose p95 was really their
+// maximum. A maximum over one run IS that run, so the floor has nothing left to
+// protect and is not carried over as decoration.
+//
+// SHARED LOG Y ACROSS THE FIVE PANELS. Shared, because comparing the projects is
+// the point of picking five; log, because a project whose best day is two
+// minutes would otherwise be a flat line under one whose best is eleven hours.
+// Each panel states its own longest as a NUMBER in its header, so the exact
+// figure never depends on reading the axis.
 
 // autonomyEverRecorded reports whether the span log holds anything at all,
 // anywhere — the fact that separates "no runs in this range" from "this
 // feature has not collected anything yet". Both are empty views; only one of
 // them means the user did nothing.
 export function autonomyEverRecorded(state = historyState) {
-  const d = state.autonomyData;
-  if (!d) return false;
-  return (d.duration?.total_recorded || 0) > 0 || (d.spans?.total_recorded || 0) > 0;
+  return (Number(state.autonomyData?.total_recorded) || 0) > 0;
 }
 
 // autonomyDuration formats a run length: "41s", "11m", "1h58m", "2d3h".
@@ -791,9 +774,9 @@ function autonomyDateLabel(ts) {
 // autonomyProvenanceLine states when collection started, so an empty or short
 // history is never read as "you did nothing" (#1905). This sentence is part of
 // the feature, not decoration.
-export function autonomyProvenanceLine(duration) {
-  const earliest = Number(duration?.earliest_span) || 0;
-  const total = Number(duration?.total_recorded) || 0;
+export function autonomyProvenanceLine(data) {
+  const earliest = Number(data?.earliest_span) || 0;
+  const total = Number(data?.total_recorded) || 0;
   if (!earliest) {
     return 'No autonomous runs recorded yet. Irrlicht began measuring them with this update — '
       + 'an empty chart means "nothing recorded", not "nothing happened".';
@@ -814,13 +797,13 @@ export function autonomyProvenanceLine(duration) {
 //   - the date BEFORE WHICH everything is reconstructed, which is the boundary
 //     between a measured trend and a rebuilt one;
 //   - whether any of it came from a source that cannot say how a run ended, so
-//     an `unknown` column in the strip reads as a limit of the source rather
-//     than as a bug.
-export function autonomyReconstructionNote(duration) {
-  const p = duration?.provenance || {};
+//     a missing concurrency split reads as a limit of the source rather than as
+//     a bug.
+export function autonomyReconstructionNote(data) {
+  const p = data?.provenance || {};
   const reconstructed = Number(p.reconstructed) || 0;
   if (reconstructed <= 0) return '';
-  const inView = Number(duration?.summary?.count) || reconstructed;
+  const inView = Number(data?.summary?.runs) || reconstructed;
   const costDerived = Number(p.cost_derived) || 0;
   const liveSince = Number(p.live_since) || 0;
   const parts = [
@@ -840,16 +823,18 @@ export function autonomyReconstructionNote(duration) {
 // autonomyCountingLine states, in words, WHAT the figures above it counted
 // (#1905 subagents, retargeted by #1905 recording).
 //
-// THERE IS NO MODE ANY MORE. Every run counts, subagent runs included, because
-// Irrlicht recorded them — so the sentence no longer reports an excluded count,
-// and there is no control whose position a reader has to remember. What it
-// still does is describe the window's MAKEUP, because "42 runs" reads
-// differently once you know how many of them were nested inside another.
+// THERE IS NO MODE. Every run counts, subagent runs included, because Irrlicht
+// recorded them — so the sentence no longer reports an excluded count, and
+// there is no control whose position a reader has to remember. What it still
+// does is describe the window's MAKEUP, because "42 runs" reads differently
+// once you know how many of them were nested inside another — and because the
+// same nesting is what the concurrency figure's caveat is about.
 //
 // THE UNKNOWN CLAUSE STAYS LOAD-BEARING. A row written before Irrlicht told the
 // two apart carries no classification, and such a row is counted like the rest
 // — but counting it silently would let the panel imply a classification nobody
-// made. So the sentence says how many.
+// made, and it is also the reason a panel's `at once` figure sometimes carries
+// no split. So the sentence says how many.
 //
 // '' only for a payload that carries no census at all, which is a daemon older
 // than the field: absence there means "this response never said", which is not
@@ -865,9 +850,219 @@ export function autonomyCountingLine(payload) {
     : 'Counting every run, subagent runs included. This window holds none.'];
   if (unknown > 0) {
     parts.push(unknown + ' run' + (unknown === 1 ? ' was' : 's were') + ' recorded before Irrlicht told '
-      + 'top-level and subagent runs apart, so which they were is unknown — those are counted either way.');
+      + 'top-level and subagent runs apart, so which they were is unknown — those are counted either way, '
+      + 'and a peak one of them was alive for is shown as a total with no split.');
   }
   return parts.join(' ');
+}
+
+// AUTONOMY_CONCURRENCY_CAVEAT is the sentence beside the `at once` figure, and
+// it is not optional: without it the number is read as "four independent
+// agents" and it is not that.
+//
+// The daemon deliberately holds a PARENT session in `working` while its
+// subagents run, so one agent with three subagents overlaps as four. Four things
+// really were working — the figure is not wrong — but a reader who takes it for
+// four independent agents has been misled by a true number, which is the exact
+// failure mode this section keeps writing sentences to avoid.
+export const AUTONOMY_CONCURRENCY_CAVEAT =
+  'A parent is held working while its subagents run, so one agent with three subagents counts as four at '
+  + 'once. Four things really were working — but not four independent agents. That is what the '
+  + '“N + M sub” split separates, and it is shown wherever every run at the peak said which it was.';
+
+// AUTONOMY_ERA_LABELS describes what lies to the LEFT of a source boundary —
+// the era the data before the line came from, and at what resolution.
+//
+// Resolution is the whole point (#1905 back-fill, QA-2). The cost log writes at
+// most every 60s and only when a value changed, so it cannot see a run shorter
+// than that; the event log records one-second runs. Across that boundary every
+// panel's line steps at the same instant, and five simultaneous steps read as
+// five findings when they are one change of INSTRUMENT.
+const AUTONOMY_ERA_LABELS = {
+  cost: 'cost log · 60s resolution',
+  log: 'event log · rebuilt',
+  live: 'measured',
+};
+
+// autonomyBoundaryLabel is the marker's caption. The arrow is load-bearing: it
+// is what makes the label describe the data BEFORE the line rather than the
+// line itself.
+export function autonomyBoundaryLabel(boundary) {
+  const from = boundary?.from || '';
+  return '← ' + (AUTONOMY_ERA_LABELS[from] || from || 'a different source');
+}
+
+// autonomyVisibleBoundaries returns the source boundaries that fall inside the
+// drawn domain, each with the x fraction (0..1) it sits at.
+//
+// STRICTLY inside: a boundary at the very first or very last bucket would draw
+// a rule on the axis itself, marking nothing and reading as a panel border. A
+// range that does not straddle a boundary gets none — which is every range on
+// a machine that was never back-filled, and most ranges on one that was.
+//
+// Pure, so both halves of the rule — draws one when it should, draws nothing
+// when it should not — are testable without a canvas.
+export function autonomyVisibleBoundaries(data) {
+  const starts = data?.bucket_starts || [];
+  if (starts.length < 2) return [];
+  const first = starts[0];
+  const last = starts[starts.length - 1];
+  if (!(last > first)) return [];
+  const out = [];
+  for (const b of (data?.provenance?.boundaries || [])) {
+    const ts = Number(b?.ts) || 0;
+    if (ts <= first || ts >= last) continue;
+    out.push({ ts, from: b.from, to: b.to, fraction: (ts - first) / (last - first) });
+  }
+  return out;
+}
+
+// autonomyBoundaryCaptionShown decides which panel carries a boundary's words.
+//
+// THE RULE READS ONCE ACROSS THE STACK. The dashed rule is drawn through EVERY
+// panel — it has to be, or it would annotate one project's line and leave the
+// four below it stepping for no stated reason — but the caption is drawn on the
+// TOP panel only. Five copies of "← cost log · 60s resolution" stacked down one
+// x position is five competing captions where the reader needs one, and at 9px
+// they would collide with four project names.
+export const AUTONOMY_BOUNDARY_CAPTION_PANEL = 0;
+export function autonomyBoundaryCaptionShown(panelIndex) {
+  return panelIndex === AUTONOMY_BOUNDARY_CAPTION_PANEL;
+}
+
+// autonomyMoreProjectsLabel names what the five panels left out, or '' when
+// nothing was left out.
+//
+// It says WHY those projects are the ones missing — they have less autonomous
+// time — so the reader knows the section took the tail rather than an arbitrary
+// slice. An omission nothing mentions is indistinguishable from a project that
+// never ran.
+export function autonomyMoreProjectsLabel(data) {
+  const more = Number(data?.more_projects) || 0;
+  if (more <= 0) return '';
+  return '+' + more + ' more project' + (more === 1 ? '' : 's') + ', each with less autonomous time';
+}
+
+// autonomyStackRows is what the stack renders, in order: one entry per panel
+// the daemon sent, and — when the window holds more projects than those — a
+// final `more` entry naming the rest.
+//
+// PURE, and the render loop's only source of truth about what appears, so
+// "exactly the panels the daemon sent, and the overflow line beside them" is
+// one assertion rather than a DOM crawl. The client never re-decides how many
+// panels there are: the daemon computes five and says how many it left out, so
+// the two surfaces cannot disagree the way the run strip's twelve-versus-six
+// row caps did.
+export function autonomyStackRows(data) {
+  const rows = (data?.panels || []).map(panel => ({ kind: 'panel', panel }));
+  const more = autonomyMoreProjectsLabel(data);
+  if (more) rows.push({ kind: 'more', label: more });
+  return rows;
+}
+
+// autonomyConcurrencyLabel renders one "at once" figure, with its split only
+// when the daemon says the split is derivable.
+//
+// NO SPLIT IS SHOWN OVER DATA THAT CANNOT SUPPORT ONE. Most rows written before
+// 18 Aug 2026 carry `kind: unknown` — they predate the classification, or the
+// back-fill rebuilt them from a source with no parent information — and there is
+// no way to recover which they were. The total alone is the honest answer there;
+// "5 (5 + 0 sub)" would be an invented one.
+export function autonomyConcurrencyLabel(peak, top, sub, splitKnown) {
+  const n = Number(peak) || 0;
+  if (n <= 0) return '';
+  if (!splitKnown) return n + ' at once';
+  return n + ' at once (' + (Number(top) || 0) + ' + ' + (Number(sub) || 0) + ' sub)';
+}
+
+// autonomyPanelHeadline is one panel's figure line: its longest run and its
+// widest moment, for the WHOLE window.
+//
+// A still-running longest run is marked rather than dropped: "already lasted
+// 3h" is a true statement about the longest run, and hiding it would make the
+// longest run on the machine the one thing the section cannot show.
+export function autonomyPanelHeadline(panel) {
+  let longest = 'longest ' + autonomyDuration(panel?.longest);
+  if (panel?.longest_running) longest += ' (still going)';
+  const concurrency = autonomyConcurrencyLabel(panel?.peak, panel?.peak_top, panel?.peak_sub, panel?.peak_split);
+  return concurrency ? longest + ' · ' + concurrency : longest;
+}
+
+// autonomyPanelPoints aligns one panel's sparse bucket list to bucket_starts,
+// with a null for every bucket the daemon OMITTED.
+//
+// The null is the honesty rule, not a convenience: an empty bucket is a GAP. A
+// day with no runs must not pull the line down to the axis, and must not draw a
+// zero-height bar that looks measured.
+export function autonomyPanelPoints(panel, bucketStarts) {
+  const byTs = new Map();
+  for (const b of (panel?.buckets || [])) byTs.set(b.ts, b);
+  return (bucketStarts || []).map(ts => byTs.get(ts) || null);
+}
+
+// autonomyLineSegments returns the index ranges the line may be stroked over.
+//
+// TWO KINDS OF GAP, and they are not the same gap. A bucket can be absent
+// entirely (nothing happened), or present with `longest === 0` — a run passed
+// THROUGH it without finishing in it, so something was working and nothing
+// finished. Both break the line; only the first also removes the bar. Drawing a
+// point at zero in the second case would claim a run of no length.
+export function autonomyLineSegments(points) {
+  const out = [];
+  let run = null;
+  for (let i = 0; i < (points?.length || 0); i++) {
+    const p = points[i];
+    if (p && Number(p.longest) > 0) {
+      if (run) run.to = i; else run = { from: i, to: i };
+    } else if (run) {
+      out.push(run);
+      run = null;
+    }
+  }
+  if (run) out.push(run);
+  return out;
+}
+
+// autonomyYDomain is the log Y domain SHARED by all five panels. null when
+// nothing in the window has a length to plot, which is the empty state.
+//
+// Shared, so the panels are comparable — that is the point of picking five.
+// Floored at 1s: a log scale cannot plot 0, and a sub-second span is not a run.
+export function autonomyYDomain(panels) {
+  const values = [];
+  for (const panel of (panels || [])) {
+    for (const b of (panel?.buckets || [])) {
+      const v = Number(b.longest) || 0;
+      if (v > 0) values.push(v);
+    }
+  }
+  if (!values.length) return null;
+  const lo = Math.max(1, Math.min(...values) * 0.8);
+  const hi = Math.max(lo * 2, Math.max(...values) * 1.25);
+  return { lo, hi };
+}
+
+// autonomyPeakScale is the histogram's SHARED full-height value: the highest
+// peak any panel reaches. 0 when nothing overlapped anywhere, in which case no
+// bar is drawn at all rather than every bar being drawn full height.
+export function autonomyPeakScale(panels) {
+  let max = 0;
+  for (const panel of (panels || [])) {
+    for (const b of (panel?.buckets || [])) {
+      const v = Number(b.peak) || 0;
+      if (v > max) max = v;
+    }
+  }
+  return max;
+}
+
+// autonomyAxisLabel formats one of the stack's two x bounds, coarsening with
+// the window the way stateBucketLabel does for the activity matrix.
+export function autonomyAxisLabel(ts, windowSeconds) {
+  const d = new Date((Number(ts) || 0) * 1000);
+  if (windowSeconds <= 36 * 3600) return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  if (windowSeconds <= 60 * 86400) return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
 }
 
 // autonomyMeasurementNote marks the runs in view whose duration is a FLOOR
@@ -876,18 +1071,16 @@ export function autonomyCountingLine(payload) {
 // daemon has been up all day.
 //
 // Two kinds, two sentences, because they are two different limits and a reader
-// who conflated them would misread the chart in opposite directions:
+// who conflated them would misread the panels in opposite directions:
 //
-//   - STILL RUNNING. The run has not ended, so its length is unknowable — it is
-//     shown, and deliberately left out of the percentiles, because folding a
-//     floor into a p95 as though it were final always shortens, and shortens
-//     the longest runs hardest. The sentence says both halves, so a reader who
-//     can see a 3-hour run on the strip is not left wondering why the median
-//     did not move.
+//   - STILL RUNNING. The run has not ended, so its length is how long it has
+//     lasted SO FAR. It COUNTS towards the longest — the section reports a
+//     maximum, and "already lasted 3h" is true — and the panel that shows it
+//     says "still going" rather than presenting a floor as final.
 //   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its start
-//     is where Irrlicht began watching rather than where the run began — a
-//     restart re-discovers every live session this way. Those ARE samples;
-//     dropping them is what left 5 of a day's 35 runs on the record.
+//     is where Irrlicht began watching rather than where the run began; a
+//     restart re-discovers every live session this way. Dropping those is what
+//     left 5 of a day's 35 runs on the record.
 export function autonomyMeasurementNote(payload) {
   const m = payload?.measurement || {};
   const running = Number(m.running) || 0;
@@ -896,8 +1089,8 @@ export function autonomyMeasurementNote(payload) {
   if (running > 0) {
     parts.push(running + ' run' + (running === 1 ? ' is' : 's are') + ' still going: '
       + (running === 1 ? 'its length is' : 'their lengths are') + ' how long '
-      + (running === 1 ? 'it has' : 'they have') + ' lasted SO FAR, so '
-      + (running === 1 ? 'it is' : 'they are') + ' shown but left out of the percentiles.');
+      + (running === 1 ? 'it has' : 'they have') + ' lasted SO FAR. '
+      + (running === 1 ? 'It counts' : 'They count') + ' towards the longest run, marked "still going".');
   }
   if (lowerBound > 0) {
     parts.push(lowerBound + ' run' + (lowerBound === 1 ? '' : 's') + ' already going when Irrlicht '
@@ -908,448 +1101,271 @@ export function autonomyMeasurementNote(payload) {
   return parts.join(' ');
 }
 
-// AUTONOMY_ERA_LABELS describes what lies to the LEFT of a source boundary —
-// the era the data before the line came from, and at what resolution.
-//
-// Resolution is the whole point (#1905 back-fill, QA-2). The cost log writes at
-// most every 60s and only when a value changed, so it cannot see a run shorter
-// than that; the event log records one-second runs. Across that boundary the p5
-// line steps by two orders of magnitude and a reader takes a change of
-// INSTRUMENT for a change of BEHAVIOUR. The provenance paragraph cannot fix it,
-// because the paragraph explains the data set while the eye reads the curve.
-const AUTONOMY_ERA_LABELS = {
-  cost: 'cost log · 60s resolution',
-  log: 'event log · rebuilt',
-  live: 'measured',
-};
-
-// autonomyBoundaryLabel is one marker's caption. The arrow is load-bearing: it
-// is what makes the label describe the data BEFORE the line rather than the
-// line itself.
-export function autonomyBoundaryLabel(boundary) {
-  const from = boundary?.from || '';
-  return '← ' + (AUTONOMY_ERA_LABELS[from] || from || 'a different source');
-}
-
-// autonomyVisibleBoundaries returns the source boundaries that fall inside the
-// chart's drawn domain, each with the x fraction (0..1) it sits at.
-//
-// STRICTLY inside: a boundary at the very first or very last bucket would draw
-// a rule on the axis itself, marking nothing and reading as a chart border. A
-// range that does not straddle a boundary gets none — which is every range on
-// a machine that was never back-filled, and most ranges on one that was.
-//
-// Pure, so both halves of the rule — draws one when it should, draws nothing
-// when it should not — are testable without a canvas.
-export function autonomyVisibleBoundaries(duration) {
-  const starts = duration?.bucket_starts || [];
-  if (starts.length < 2) return [];
-  const first = starts[0];
-  const last = starts[starts.length - 1];
-  if (!(last > first)) return [];
-  const out = [];
-  for (const b of (duration?.provenance?.boundaries || [])) {
-    const ts = Number(b?.ts) || 0;
-    if (ts <= first || ts >= last) continue;
-    out.push({ ts, from: b.from, to: b.to, fraction: (ts - first) / (last - first) });
-  }
-  return out;
-}
-
-// AUTONOMY_STRIP_MAX_ROWS caps how many project rows the run strip draws.
-//
-// The strip had no cap at all, which was invisible until there was history to
-// draw: a 12mo window over a back-filled log renders 95 rows and ~1900px of
-// strip, and the projects worth looking at are lost in the wall (#1905
-// back-fill, QA-1). Twelve is what this surface can show at once — at ~20px a
-// row it is a block you can take in without scrolling past the chart above it.
-//
-// The daemon already ranks `projects` by TOTAL AUTONOMOUS SECONDS, not by run
-// count, so the cap keeps the rows that matter: one four-hour run outranks
-// forty three-second ones. Taking a prefix of that ranking is also why the two
-// clients can cap differently without disagreeing — each shows a prefix of the
-// same order, neither invents one.
-export const AUTONOMY_STRIP_MAX_ROWS = 12;
-
-// autonomyStripOverflowLabel names what the cap left out, or '' when nothing
-// was left out.
-//
-// It says WHY those rows are the ones missing — they have less autonomous time
-// — so the reader knows the cap took the tail rather than an arbitrary slice.
-export function autonomyStripOverflowLabel(projects, cap = AUTONOMY_STRIP_MAX_ROWS) {
-  const hidden = (projects?.length || 0) - cap;
-  if (hidden <= 0) return '';
-  return '+' + hidden + ' more project' + (hidden === 1 ? '' : 's')
-    + ', each with less autonomous time than the rows above';
-}
-
-// autonomyLegendEntries is the strip legend for one window: the three measured
-// reasons, plus the neutral `unknown` entry ONLY when the window actually
-// holds a run whose reason nothing can name.
-//
-// Conditional on the data rather than always shown, because the legend
-// explains the colours in front of the reader. A permanent fourth swatch for a
-// colour the strip is not drawing invites the opposite mistake — reading the
-// absence of neutral columns as an absence of runs.
-export function autonomyLegendEntries(spans) {
-  const hasUnnamed = (spans?.spans || []).some(sp => !AUTONOMY_REASON_PRIORITY[sp.reason]);
-  return hasUnnamed ? AUTONOMY_REASON_LEGEND.concat([AUTONOMY_UNKNOWN_LEGEND]) : AUTONOMY_REASON_LEGEND;
-}
-
-// collapseAutonomyStrip is the strip's pixel-collapse rule (#1905 design
-// decision 4), as a pure function so it can be tested without a canvas — and
-// so this and the macOS AutonomyStripLayout draw the same strip.
-//
-// TWO HALVES, both load-bearing:
-//   - Every span draws at a minimum of ONE column. At 12mo a 40-second run is
-//     far under one device pixel; rounding it away would erase exactly the
-//     short runs the p5 line is about.
-//   - A column holding several spans takes the HIGHEST-priority end reason
-//     (AUTONOMY_REASON_PRIORITY). One error in a column paints the whole
-//     column, because what is worth seeing at a glance is that something broke.
-//
-// Returns one {occupied, reason} per column. occupied and reason are separate
-// because a run whose reason this build cannot name still HAPPENED: it holds
-// its column (drawn neutral) rather than reading as idle.
-export function collapseAutonomyStrip(spans, start, end, columns) {
-  if (columns <= 0 || end <= start) return [];
-  const out = [];
-  for (let i = 0; i < columns; i++) out.push({ occupied: false, reason: null });
-  for (const sp of (spans || [])) paintSpanColumns(out, sp, start, end, columns);
-  return out;
-}
-
-// paintSpanColumns writes one span into the column array, applying both halves
-// of the rule: the span's column range (never empty — the minimum-one-column
-// rule) and the ladder that decides a shared column's color.
-function paintSpanColumns(out, sp, start, end, columns) {
-  const width = end - start;
-  let first = Math.floor((sp.start - start) / width * columns);
-  let last = Math.floor((sp.end - start) / width * columns);
-  if (last < 0 || first > columns - 1) return; // wholly outside the window
-  first = Math.max(0, first);
-  last = Math.min(columns - 1, last);
-  if (last < first) last = first; // the minimum-one-column rule
-  const reason = AUTONOMY_REASON_PRIORITY[sp.reason] ? sp.reason : null;
-  const rank = AUTONOMY_REASON_PRIORITY[sp.reason] || 0;
-  for (let i = first; i <= last; i++) {
-    // -1 for an untouched column, so even an unnamed reason (rank 0) claims it.
-    const existingRank = out[i].occupied ? (AUTONOMY_REASON_PRIORITY[out[i].reason] || 0) : -1;
-    out[i].occupied = true;
-    if (rank > existingRank) out[i].reason = reason;
-  }
-}
-
-// autonomyReasonColor maps an end reason onto the shared state palette. An
-// unnamed reason draws neutral — the run happened, this build just cannot say
-// how it ended.
-function autonomyReasonColor(reason, cs) {
-  const pick = (name, fallback) => (cs.getPropertyValue(name) || fallback).trim();
-  if (reason === 'error') return pick('--pressure-high', '#FF3B30');
-  if (reason === 'waiting') return pick('--waiting', '#FF9500');
-  if (reason === 'ready') return pick('--ready', '#34C759');
-  return pick('--muted', '#888');
-}
-
-// autonomyChartPoints turns the sparse bucket list into per-series point lists
-// aligned to bucket_starts, with a null for every bucket the daemon OMITTED.
-//
-// The null is the honesty rule, not a convenience: an empty bucket is a GAP,
-// and a day with no runs must not pull the line down to the axis. The painter
-// below breaks the stroke at a null instead of interpolating through it.
-export function autonomyChartPoints(duration) {
-  const starts = duration?.bucket_starts || [];
-  const byTs = new Map();
-  for (const b of (duration?.buckets || [])) byTs.set(b.ts, b);
-  return starts.map(ts => byTs.get(ts) || null);
-}
-
-// The three drawn lines, in draw order: series key, the ROLE it plays in the
-// chart, the CSS custom property that colours it, and the fallback for a
-// stylesheet that has not loaded.
-//
-// ONE HUE, THREE WEIGHTS. The first round drew p95 green, p50 purple and p5
-// orange — three equally loud curves that a reader had to decode before the
-// chart said anything. It says one thing now: here is the typical run (the
-// solid `line`), and here is the spread around it (the translucent plane
-// between the two quiet `edge`s). Three hues cannot say that; a hue per
-// percentile makes p95 and p5 read as two independent measurements rather
-// than as the boundary of one range.
-//
-// EXPORTED, and read by both the canvas painter and the side panel's key. The
-// web also shipped a panel that explicitly blanked its dots, so a reader had
-// to infer which line was which from vertical order. A key drawn from a SECOND
-// colour table would be worse than none — it can disagree with the chart — so
-// there is one table and one resolver.
-export const AUTONOMY_SERIES = [
-  ['p95', 'edge', '--working', '#8B5CF6'],
-  ['p50', 'line', '--working', '#8B5CF6'],
-  ['p5', 'edge', '--working', '#8B5CF6'],
-];
-
-// The band's own colours — the fill between p5 and p95, the fainter fill a
-// thin bucket gets, and the weight its two edge lines are stroked at.
-//
-// A SECOND TABLE, not a second PALETTE: every entry is the --working hue at a
-// lower alpha (`the band is the p50 hue, not a fourth colour` pins that), and
-// both the canvas and the panel's band swatch read these same three entries,
-// so the key cannot show a plane the chart does not draw.
-export const AUTONOMY_BAND_TOKENS = {
-  fill: ['--autonomy-band', 'rgba(139, 92, 246, 0.20)'],
-  fillThin: ['--autonomy-band-thin', 'rgba(139, 92, 246, 0.08)'],
-  edge: ['--autonomy-edge', 'rgba(139, 92, 246, 0.45)'],
-};
-
-// Per-role stroke weights. The p50 line carries the chart: full alpha, the
-// heavier stroke. The two edges are present enough to bound the plane and
-// quiet enough not to compete with it.
-const AUTONOMY_ROLE_STYLE = {
-  line: { width: 1.8, alpha: 1, thinAlpha: 0.6, marker: 2.6 },
-  edge: { width: 1, alpha: 0.5, thinAlpha: 0.32, marker: 2 },
-};
-
-// The two key entries, in panel order. `from` names the AUTONOMY_SERIES row
-// each one takes its colour from, so neither can be given a colour the chart
-// does not stroke.
-//
-// Named for a reader who has never seen a percentile — the register the panel
-// already used ("the typical run") — with the p-labels kept in front for a
-// reader who has. Two noun phrases that read as a pair, which is the point:
-// the chart draws one line and one plane, and these name them as one thing
-// and its spread rather than as two measurements.
+// The side panel's key: exactly two entries, because a panel draws exactly two
+// things — a line and a row of bars.
 //
 // LENGTH IS A CONSTRAINT HERE, not a style preference. This panel is
-// `flex: 0 0 260px` with 16px padding, so a key row's label gets 204px once
-// its swatch and gap are taken out — about 28 monospace characters at 12px.
-// The band row first shipped as "p5–p95 · where most runs land" (29), which
-// ellipsised in the real panel: the one row whose job is to explain the band
-// cut off its own explanation. `autonomyLayout.test.js` computes that budget
-// from the stylesheet and fails a label that will not fit.
+// `flex: 0 0 260px` with 16px padding, so a key row's label gets 204px once its
+// swatch and gap are taken out — about 28 monospace characters at 12px. A label
+// that will not fit ellipsises the very row whose job is to explain the mark;
+// `autonomyLayout.test.js` computes that budget from the stylesheet and fails
+// one that is too long.
 //
-// Both strings are duplicated in AutonomyPalette.keyEntries on macOS, and
-// `the two surfaces name the key the same way` reads this table against that
-// one — two clients must not explain one chart differently.
+// Both strings are duplicated in AutonomyPalette.keyEntries on macOS, and `the
+// two surfaces name the key the same way` reads this table against that one —
+// two clients must not explain one chart differently.
 const AUTONOMY_KEY = [
-  ['line', 'p50', 'p50 · the typical run'],
-  ['band', 'p95', 'p5–p95 · the usual spread'],
+  ['line', 'longest run in a bucket'],
+  ['bars', 'working at once (peak)'],
 ];
 
-// autonomySeriesColor resolves one line's colour against the live theme,
-// falling back to the literal when the custom property is unset (an
-// unstyled document, or a test's stub). Returns '' for a key that is not a
-// drawn line, so a caller cannot silently paint a swatch for something the
-// chart never drew.
-export function autonomySeriesColor(key, cs) {
-  const row = AUTONOMY_SERIES.find(([k]) => k === key);
-  if (!row) return '';
-  const [, , cssVar, fallback] = row;
-  return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
-}
-
-// autonomySeriesRole reports whether a key is the headline `line` or one of
-// the band's `edge`s. '' for anything the chart does not draw.
-export function autonomySeriesRole(key) {
-  const row = AUTONOMY_SERIES.find(([k]) => k === key);
-  return row ? row[1] : '';
-}
-
-// autonomyBandColor resolves one of the band's three tokens, same fallback
-// rule as autonomySeriesColor. '' for a name the band has no token for.
-export function autonomyBandColor(name, cs) {
-  const token = AUTONOMY_BAND_TOKENS[name];
+// autonomyKeyColor resolves one key entry's colour against the live theme,
+// falling back to the literal when the custom property is unset (an unstyled
+// document, or a test's stub). '' for a name the key has no mark for.
+export function autonomyKeyColor(kind, cs) {
+  const token = AUTONOMY_MARK_TOKENS[kind];
   if (!token) return '';
   const [cssVar, fallback] = token;
   return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
 }
 
-// autonomyKeyEntries is the chart's key: exactly two entries, because the
-// chart draws exactly two things — a line and a plane.
-//
-// Every colour here is resolved through autonomySeriesColor / autonomyBandColor
-// — the same calls the canvas makes — so a swatch cannot disagree with the ink
-// beside it. `fill` is '' for the line entry: a line has no area.
+// The two marks' colours. ONE HUE: the bars are the line's hue at a lower
+// alpha, because they are a second reading of the same activity and not a
+// second subject. `the bars are the line hue, not a second colour` pins that.
+export const AUTONOMY_MARK_TOKENS = {
+  line: ['--working', '#8B5CF6'],
+  bars: ['--autonomy-bar', 'rgba(139, 92, 246, 0.45)'],
+};
+
+// autonomyKeyEntries is the key the side panel draws, resolved through the same
+// call the canvas painter makes so a swatch cannot disagree with the ink.
 export function autonomyKeyEntries(cs) {
-  return AUTONOMY_KEY.map(([kind, from, label]) => ({
-    kind,
-    from,
-    label,
-    color: kind === 'band' ? autonomyBandColor('edge', cs) : autonomySeriesColor(from, cs),
-    fill: kind === 'band' ? autonomyBandColor('fill', cs) : '',
-  }));
+  return AUTONOMY_KEY.map(([kind, label]) => ({ kind, label, color: autonomyKeyColor(kind, cs) }));
 }
 
-// autonomyBandSegments splits the gap-aligned point list into the areas the
-// band may actually be filled over.
-//
-// TWO RULES, both of them honesty rules the smooth shape would otherwise
-// erase, and both of them the reason this is a pure function rather than a
-// loop inside the painter:
-//
-//   - A FILLED AREA WANTS TO CLOSE ACROSS A GAP. The daemon omits empty
-//     buckets and the line breaks there (autonomyChartPoints); a polygon
-//     spanning the gap would draw a plane over days that hold no runs at all,
-//     which is a stronger false claim than the interpolated line #1905 already
-//     refuses. A segment therefore never crosses a null.
-//   - A THIN BUCKET IS NOT A PERCENTILE. Under sample_floor, p95 is that
-//     bucket's longest run and p5 its shortest. The stroke already dashes
-//     across such a bucket; the fill splits at the same place so the thin
-//     stretch can be painted in its own fainter plane.
-//
-// Returns index ranges into `points`, inclusive at both ends. Adjacent
-// segments SHARE their boundary index, so a thin→solid handover has no seam.
-// `from === to` is an isolated bucket: it has no neighbour to make an area
-// with, and the painter draws its spread as a whisker instead.
-export function autonomyBandSegments(points) {
-  const out = [];
-  const n = (points || []).length;
-  let i = 0;
-  while (i < n) {
-    if (!points[i]) { i++; continue; }
-    let last = i;
-    while (last + 1 < n && points[last + 1]) last++;
-    if (last === i) {
-      out.push({ from: i, to: i, thin: !!points[i].thin });
-      i = last + 1;
-      continue;
-    }
-    // Thinness belongs to the INTERVAL, not the bucket — matching
-    // drawAutonomySeries, which dashes a segment either of whose ends is thin.
-    let start = i;
-    let thin = !!(points[i].thin || points[i + 1].thin);
-    for (let j = i + 1; j < last; j++) {
-      const next = !!(points[j].thin || points[j + 1].thin);
-      if (next !== thin) {
-        out.push({ from: start, to: j, thin });
-        start = j;
-        thin = next;
-      }
-    }
-    out.push({ from: start, to: last, thin });
-    i = last + 1;
-  }
-  return out;
-}
+// --- Rendering --------------------------------------------------------------
 
-function paintAutonomyChart() {
-  const canvas = document.getElementById('history-chart');
+// Panel geometry, in CSS pixels. The line plot and the histogram share one
+// canvas per panel so their x axes cannot drift apart and one boundary rule can
+// run through both.
+const AUTONOMY_PANEL = {
+  padL: 46, padR: 6,
+  lineH: 32,   // the longest-run plot
+  gap: 2,
+  barsH: 10,   // the concurrency histogram, deliberately low
+};
+const AUTONOMY_PANEL_CANVAS_H = AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap + AUTONOMY_PANEL.barsH;
+
+// renderAutonomyPanels draws the stack: five project panels, the "+N more" line
+// and the window's own bounds under them.
+function renderAutonomyPanels() {
+  const host = document.getElementById('history-autonomy-panels');
   const wrap = document.getElementById('history-chart-wrap');
-  if (!canvas || !wrap) return;
-  const duration = historyState.autonomyData?.duration;
-  const { ctx, w, h } = setupHistoryCanvas(canvas, wrap);
-  const points = autonomyChartPoints(duration);
-  const drawn = points.filter(Boolean);
-  const hasData = drawn.length > 0;
-  wrap.classList.toggle('empty', !hasData);
-  if (!hasData) return;
+  if (!host) return;
+  const data = historyState.autonomyData;
+  host.innerHTML = '';
+  const panels = data?.panels || [];
+  if (wrap) wrap.classList.toggle('empty', panels.length === 0);
+  if (!panels.length) return;
 
   const cs = getComputedStyle(document.documentElement);
-  const muted = (cs.getPropertyValue('--muted') || '#888').trim();
-  const gridColor = 'rgba(128,140,170,0.18)';
-
-  // Log Y: the interesting range is seconds to hours, so a linear axis spends
-  // its whole height on the longest run. Floored at 1s — a log scale cannot
-  // plot 0, and a sub-second span is not a run.
-  const lo = Math.max(1, Math.min(...drawn.map(b => Math.max(1, b.p5))) * 0.8);
-  const hi = Math.max(lo * 2, Math.max(...drawn.map(b => Math.max(1, b.p95))) * 1.25);
-  const padL = 52, padR = 12, padT = 12, padB = 22;
-  const plotW = Math.max(1, w - padL - padR);
-  const plotH = Math.max(1, h - padT - padB);
-  const n = Math.max(1, points.length);
-  const xAt = (i) => (n <= 1 ? padL : padL + plotW * (i / (n - 1)));
-  const yAt = (v) => {
-    const clamped = Math.min(hi, Math.max(lo, Math.max(1, v)));
-    const t = (Math.log(clamped) - Math.log(lo)) / (Math.log(hi) - Math.log(lo));
-    return padT + plotH * (1 - t);
+  const opts = {
+    domain: autonomyYDomain(panels),
+    peakMax: autonomyPeakScale(panels),
+    boundaries: autonomyVisibleBoundaries(data),
+    bucketStarts: data.bucket_starts || [],
+    cs,
   };
-
-  // Draw order IS the visual hierarchy, cheapest thing first:
-  //
-  //   gridlines → band → boundary rules → edges → p50 → axis labels
-  //
-  // The band goes over the gridlines rather than under them. A gridline is
-  // furniture; drawn on top of the plane it would cut the band into slices
-  // that read as structure in the data, which is the one thing a soft fill
-  // must never do. Over it, the fill's own translucency dims each gridline
-  // where it crosses — the line stays legible, and stays furniture.
-  drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor });
-  drawAutonomyBand(ctx, {
-    points,
-    segments: autonomyBandSegments(points),
-    xAt,
-    yAt,
-    fill: autonomyBandColor('fill', cs),
-    fillThin: autonomyBandColor('fillThin', cs),
-    edge: autonomyBandColor('edge', cs),
-  });
-  // Under the lines, deliberately: the marker explains the data, it is not
-  // part of it, and a rule drawn over a curve competes with the thing it is
-  // annotating.
-  drawAutonomyBoundaries(ctx, { duration, padL, plotW, padT, plotH, muted });
-  // Edges before the line, whatever order the table lists them in: the
-  // headline curve is the last ink down, so nothing crosses over it.
-  for (const role of ['edge', 'line']) {
-    for (const [key, seriesRole] of AUTONOMY_SERIES) {
-      if (seriesRole !== role) continue;
-      drawAutonomySeries(ctx, { points, key, role, color: autonomySeriesColor(key, cs), xAt, yAt });
+  let panelIndex = 0;
+  for (const row of autonomyStackRows(data)) {
+    if (row.kind === 'panel') {
+      host.appendChild(buildAutonomyPanel(row.panel, { ...opts, index: panelIndex }));
+      panelIndex++;
+      continue;
     }
+    const el = document.createElement('div');
+    el.className = 'history-autonomy-more';
+    el.textContent = row.label;
+    host.appendChild(el);
   }
-  drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB });
+  host.appendChild(buildAutonomyAxis(data));
 }
 
-// drawAutonomyBand fills the plane between p5 and p95 — the spread around the
-// typical run — one polygon per autonomyBandSegments entry.
-//
-// It fills SEGMENT BY SEGMENT rather than as one path so the two rules that
-// function encodes survive the paint: a gap leaves real empty canvas (no
-// plane over days with no runs), and a thin stretch is filled from the
-// fainter token, so a range that is not a percentile spread does not look
-// like one.
-function drawAutonomyBand(ctx, { points, segments, xAt, yAt, fill, fillThin, edge }) {
+// buildAutonomyAxis puts the window's start on the left and "now" on the right,
+// once under the whole stack — the five panels share one x domain, so five
+// copies would be five statements of one fact.
+export function buildAutonomyAxis(data) {
+  const axis = document.createElement('div');
+  axis.className = 'history-autonomy-axis';
+  const from = document.createElement('i');
+  from.textContent = autonomyAxisLabel(data?.start, (data?.end || 0) - (data?.start || 0));
+  const to = document.createElement('i');
+  to.textContent = 'now';
+  axis.appendChild(from);
+  axis.appendChild(to);
+  return axis;
+}
+
+function buildAutonomyPanel(panel, opts) {
+  const el = document.createElement('div');
+  el.className = 'history-autonomy-panel';
+
+  const head = document.createElement('div');
+  head.className = 'history-autonomy-panel-head';
+  const name = document.createElement('span');
+  name.className = 'history-autonomy-panel-name';
+  name.textContent = panel.project;
+  const figs = document.createElement('span');
+  figs.className = 'history-autonomy-panel-figs';
+  figs.textContent = autonomyPanelHeadline(panel);
+  head.appendChild(name);
+  head.appendChild(figs);
+  el.appendChild(head);
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'history-autonomy-panel-canvas';
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', panel.project + ': ' + autonomyPanelHeadline(panel)
+    + ', ' + (Number(panel.runs) || 0) + ' runs');
+  el.appendChild(canvas);
+
+  // Painted on the next frame: the canvas has no layout width until it is in
+  // the document, and a zero-width canvas would collapse every bucket into
+  // nothing.
+  requestAnimationFrame(() => paintAutonomyPanel(canvas, panel, opts));
+  return el;
+}
+
+function paintAutonomyPanel(canvas, panel, opts) {
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.offsetWidth || 400;
+  const h = AUTONOMY_PANEL_CANVAS_H;
+  const pxW = Math.max(1, Math.round(w * dpr)), pxH = Math.max(1, Math.round(h * dpr));
+  if (canvas.width !== pxW || canvas.height !== pxH) { canvas.width = pxW; canvas.height = pxH; }
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+
+  const { padL, padR, lineH, gap, barsH } = AUTONOMY_PANEL;
+  const plotW = Math.max(1, w - padL - padR);
+  const points = autonomyPanelPoints(panel, opts.bucketStarts);
+  const n = Math.max(1, points.length);
+  const xAt = (i) => (n <= 1 ? padL : padL + plotW * (i / (n - 1)));
+
+  const cs = opts.cs;
+  const muted = (cs.getPropertyValue('--muted') || '#888').trim();
+  const lineColor = autonomyKeyColor('line', cs);
+  const barColor = autonomyKeyColor('bars', cs);
+
+  drawAutonomyGridlines(ctx, { domain: opts.domain, padL, w, padR, lineH, muted });
+  // Under the marks, deliberately: a boundary explains the data, it is not part
+  // of it, and a rule drawn over a line competes with what it annotates.
+  drawAutonomyBoundaries(ctx, { boundaries: opts.boundaries, padL, plotW, h, muted, index: opts.index });
+  drawAutonomyBars(ctx, { points, xAt, plotW, n, top: lineH + gap, barsH, peakMax: opts.peakMax, color: barColor });
+  drawAutonomyLine(ctx, { points, xAt, domain: opts.domain, lineH, color: lineColor });
+}
+
+// drawAutonomyGridlines draws the SHARED log Y gridlines, labelled in the same
+// duration units the panel headers use, so an axis tick and a headline figure
+// can never be read in different units.
+function drawAutonomyGridlines(ctx, { domain, padL, w, padR, lineH, muted }) {
+  if (!domain) return;
   ctx.save();
-  for (const seg of segments) {
+  ctx.strokeStyle = 'rgba(128,140,170,0.18)';
+  ctx.fillStyle = muted;
+  ctx.font = '9px ui-monospace, monospace';
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  const steps = 2;
+  for (let i = 0; i <= steps; i++) {
+    const v = Math.exp(Math.log(domain.lo) + (Math.log(domain.hi) - Math.log(domain.lo)) * (i / steps));
+    const y = autonomyYAt(v, domain, lineH);
+    ctx.beginPath();
+    ctx.moveTo(padL, y);
+    ctx.lineTo(w - padR, y);
+    ctx.stroke();
+    ctx.fillText(autonomyDuration(v), padL - 5, y);
+  }
+  ctx.restore();
+}
+
+// autonomyYAt maps a duration onto the shared log axis. Exported so a test can
+// assert two panels place the same duration at the same height — which is what
+// "shared" has to mean if the five panels are to be comparable at all.
+export function autonomyYAt(v, domain, lineH) {
+  if (!domain) return lineH;
+  const clamped = Math.min(domain.hi, Math.max(domain.lo, Math.max(1, Number(v) || 1)));
+  const t = (Math.log(clamped) - Math.log(domain.lo)) / (Math.log(domain.hi) - Math.log(domain.lo));
+  return lineH * (1 - t);
+}
+
+// drawAutonomyLine strokes the longest-run line, BREAKING at every gap rather
+// than interpolating across it (autonomyLineSegments), and marking an isolated
+// bucket with a dot so the one bucket with no neighbour is not invisible.
+function drawAutonomyLine(ctx, { points, xAt, domain, lineH, color }) {
+  if (!domain) return;
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = 1.6;
+  ctx.lineJoin = 'round';
+  for (const seg of autonomyLineSegments(points)) {
     if (seg.from === seg.to) {
-      // An isolated bucket has no neighbour to make an area with. Drawn as a
-      // whisker rather than dropped, or it would be the one bucket whose
-      // spread is invisible — and a lone bucket is exactly where the reader
-      // most needs to see how wide the range was.
-      const only = points[seg.from];
-      ctx.setLineDash(seg.thin ? [3, 3] : []);
-      ctx.strokeStyle = edge;
-      ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.moveTo(xAt(seg.from), yAt(only.p95));
-      ctx.lineTo(xAt(seg.from), yAt(only.p5));
-      ctx.stroke();
+      ctx.arc(xAt(seg.from), autonomyYAt(points[seg.from].longest, domain, lineH), 1.8, 0, Math.PI * 2);
+      ctx.fill();
       continue;
     }
     ctx.beginPath();
     for (let i = seg.from; i <= seg.to; i++) {
-      const x = xAt(i), y = yAt(points[i].p95);
+      const x = xAt(i), y = autonomyYAt(points[i].longest, domain, lineH);
       if (i === seg.from) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
-    for (let i = seg.to; i >= seg.from; i--) ctx.lineTo(xAt(i), yAt(points[i].p5));
-    ctx.closePath();
-    ctx.fillStyle = seg.thin ? fillThin : fill;
-    ctx.fill();
+    ctx.stroke();
+  }
+  // A bucket whose longest run has not ended is hollow rather than solid: its
+  // length is a floor, and the header says "still going" beside it.
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    if (!p || !(Number(p.longest) > 0) || !p.running) continue;
+    ctx.beginPath();
+    ctx.arc(xAt(i), autonomyYAt(p.longest, domain, lineH), 2.4, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+// drawAutonomyBars draws the concurrency histogram: one low bar per bucket,
+// scaled against the stack's shared peak.
+//
+// A BUCKET WITH NO ONE WORKING DRAWS NOTHING — not a zero-height bar, and not a
+// hairline on the baseline. A mark on the axis reads as a measured zero, which
+// is a different and false claim from "no runs here".
+function drawAutonomyBars(ctx, { points, xAt, plotW, n, top, barsH, peakMax, color }) {
+  if (!(peakMax > 0)) return;
+  const barW = Math.max(1, Math.min(6, plotW / Math.max(1, n) - 1));
+  ctx.save();
+  ctx.fillStyle = color;
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    const peak = p ? (Number(p.peak) || 0) : 0;
+    if (peak <= 0) continue;
+    const hgt = Math.max(1, barsH * (peak / peakMax));
+    ctx.fillRect(xAt(i) - barW / 2, top + (barsH - hgt), barW, hgt);
   }
   ctx.restore();
 }
 
 // drawAutonomyBoundaries marks each instant where the data's source changes: a
-// dashed hairline down the plot, captioned with what lies to its left.
-//
-// A HAIRLINE AND A SMALL LABEL, at low alpha, in the muted colour both themes
-// already resolve — it has to be findable when looked for and invisible when
-// not. The caption sits right of the rule and is dropped when it would spill
-// past the plot, because a label clipped by the canvas edge is worse than no
-// label: it reads as a rendering fault rather than as an annotation.
-function drawAutonomyBoundaries(ctx, { duration, padL, plotW, padT, plotH, muted }) {
-  const boundaries = autonomyVisibleBoundaries(duration);
-  if (!boundaries.length) return;
+// dashed hairline down the WHOLE panel — line plot and histogram both — so the
+// rule reads as one vertical through the stack rather than as five annotations.
+// The caption is drawn on the top panel only (autonomyBoundaryCaptionShown).
+function drawAutonomyBoundaries(ctx, { boundaries, padL, plotW, h, muted, index }) {
+  if (!boundaries?.length) return;
   ctx.save();
   ctx.font = '9px ui-monospace, monospace';
   ctx.textBaseline = 'top';
-  ctx.textAlign = 'left';
   for (const b of boundaries) {
     const x = padL + plotW * b.fraction;
     ctx.globalAlpha = 0.45;
@@ -1357,354 +1373,87 @@ function drawAutonomyBoundaries(ctx, { duration, padL, plotW, padT, plotH, muted
     ctx.lineWidth = 1;
     ctx.setLineDash([2, 3]);
     ctx.beginPath();
-    ctx.moveTo(x, padT);
-    ctx.lineTo(x, padT + plotH);
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, h);
     ctx.stroke();
+    if (!autonomyBoundaryCaptionShown(index)) continue;
     const label = autonomyBoundaryLabel(b);
+    ctx.setLineDash([]);
     if (x - 4 - ctx.measureText(label).width >= padL) {
       ctx.globalAlpha = 0.7;
       ctx.fillStyle = muted;
       ctx.textAlign = 'right';
-      ctx.fillText(label, x - 4, padT + 1);
+      ctx.fillText(label, x - 4, 1);
       ctx.textAlign = 'left';
     }
   }
   ctx.restore();
 }
 
-// drawAutonomyGridlines draws the log-scale Y gridlines, labelled in the same
-// duration units the summary row uses, so an axis tick and a headline figure
-// can never be read in different units.
-function drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor }) {
-  ctx.strokeStyle = gridColor;
-  ctx.fillStyle = muted;
-  ctx.font = '10px ui-monospace, monospace';
-  ctx.textAlign = 'right';
-  ctx.textBaseline = 'middle';
-  const decades = 4;
-  for (let i = 0; i <= decades; i++) {
-    const v = Math.exp(Math.log(lo) + (Math.log(hi) - Math.log(lo)) * (i / decades));
-    const y = yAt(v);
-    ctx.beginPath();
-    ctx.moveTo(padL, y);
-    ctx.lineTo(w - padR, y);
-    ctx.stroke();
-    ctx.fillText(autonomyDuration(v), padL - 6, y);
-  }
-}
-
-function drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB }) {
-  ctx.fillStyle = muted;
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'top';
-  const starts = duration.bucket_starts || [];
-  const labels = Math.min(5, starts.length);
-  for (let i = 0; i < labels; i++) {
-    const c = Math.round(i * (starts.length - 1) / Math.max(1, labels - 1));
-    ctx.fillText(histAxisLabel(starts[c], duration.bucket_seconds), xAt(c), h - padB + 5);
-  }
-}
-
-// drawAutonomySeries strokes one percentile line, breaking at every omitted
-// bucket and DASHING any segment that touches a thin bucket — so a bucket
-// under the sample floor is visibly different rather than hidden or smoothed.
-//
-// `role` decides the weight, not the colour: all three lines are one hue, and
-// what separates the headline p50 from the band's two edges is stroke width
-// and alpha (AUTONOMY_ROLE_STYLE).
-function drawAutonomySeries(ctx, { points, key, role, color, xAt, yAt }) {
-  const style = AUTONOMY_ROLE_STYLE[role] || AUTONOMY_ROLE_STYLE.line;
-  ctx.strokeStyle = color;
-  ctx.lineWidth = style.width;
-  for (let i = 1; i < points.length; i++) {
-    const a = points[i - 1], b = points[i];
-    if (!a || !b) continue; // a gap is a gap: never interpolate across it
-    const thin = a.thin || b.thin;
-    ctx.save();
-    ctx.setLineDash(thin ? [3, 3] : []);
-    ctx.globalAlpha = thin ? style.thinAlpha : style.alpha;
-    ctx.beginPath();
-    ctx.moveTo(xAt(i - 1), yAt(a[key]));
-    ctx.lineTo(xAt(i), yAt(b[key]));
-    ctx.stroke();
-    ctx.restore();
-  }
-  // Hollow markers on thin buckets, and a solid dot on an isolated bucket that
-  // has no neighbour to draw a segment to (which would otherwise vanish).
-  for (let i = 0; i < points.length; i++) {
-    const b = points[i];
-    if (!b) continue;
-    const isolated = !points[i - 1] && !points[i + 1];
-    if (!b.thin && !isolated) continue;
-    ctx.save();
-    ctx.beginPath();
-    ctx.arc(xAt(i), yAt(b[key]), style.marker, 0, Math.PI * 2);
-    if (b.thin) {
-      ctx.strokeStyle = color;
-      ctx.globalAlpha = style.alpha * 0.8;
-      ctx.stroke();
-    } else {
-      ctx.fillStyle = color;
-      ctx.globalAlpha = style.alpha;
-      ctx.fill();
-    }
-    ctx.restore();
-  }
-}
-
-// renderAutonomyStrip draws element 2: one row per project, ordered by the
-// daemon (busiest first), each a canvas of collapsed columns.
-function renderAutonomyStrip() {
-  const rowsEl = document.getElementById('history-autonomy-rows');
-  const titleEl = document.getElementById('history-autonomy-strip-title');
-  const legendEl = document.getElementById('history-autonomy-legend');
-  const noteEl = document.getElementById('history-autonomy-note');
-  const spans = historyState.autonomyData?.spans;
-  if (titleEl) titleEl.textContent = 'Runs · last ' + (AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan);
-  if (!rowsEl) return;
-  rowsEl.innerHTML = '';
-  if (legendEl) legendEl.innerHTML = '';
-  if (noteEl) noteEl.textContent = '';
-
-  const projects = spans?.projects || [];
-  if (!projects.length) {
-    rowsEl.appendChild(buildAutonomyStripEmpty(spans));
-    return;
-  }
-
-  const cs = getComputedStyle(document.documentElement);
-  // A header over the value column: the figure at the end of each row was a
-  // bare duration with nothing saying what it measured.
-  rowsEl.appendChild(buildAutonomyStripHeader());
-  for (const project of projects.slice(0, AUTONOMY_STRIP_MAX_ROWS)) {
-    rowsEl.appendChild(buildAutonomyStripRow(project, spans, cs));
-  }
-  // Everything the cap left out, named as a count rather than dropped in
-  // silence — an omission nothing mentions is indistinguishable from a
-  // project that never ran.
-  const overflow = autonomyStripOverflowLabel(projects);
-  if (overflow) {
-    const more = document.createElement('div');
-    more.className = 'history-autonomy-more';
-    more.textContent = overflow;
-    rowsEl.appendChild(more);
-  }
-  // …and the window's bounds under it, so a mark can be placed in time. Two
-  // labels, not a tick axis: at 12mo a full axis is more furniture than the
-  // strip is worth, but "from when to when" is the difference between a
-  // timeline and a texture.
-  rowsEl.appendChild(buildAutonomyStripAxis(spans));
-  if (legendEl) fillAutonomyLegend(legendEl, cs, spans);
-  if (noteEl && spans.truncated) {
-    noteEl.textContent = 'This window holds more runs than one request returns; the strip shows the oldest part of it. '
-      + 'Pick a shorter span for a complete picture.';
-  }
-}
-
-// buildAutonomyStripEmpty renders the strip's empty state. Two wordings, and
-// the distinction is the honesty rule: "no runs in this window" and "nothing
-// has ever been recorded" are different claims, and only the second one is
-// about the feature rather than about the user.
-function buildAutonomyStripEmpty(spans) {
-  const empty = document.createElement('div');
-  empty.className = 'history-autonomy-empty';
-  const label = AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan;
-  empty.textContent = autonomyEverRecorded()
-    ? 'No runs in the last ' + label + '. ' + (spans?.total_recorded || 0)
-      + ' runs are on record over a longer period.'
-    : 'No runs recorded yet — this strip fills in as sessions run.';
-  return empty;
-}
-
-function fillAutonomyLegend(legendEl, cs, spans) {
-  for (const [reason, glyph, label] of autonomyLegendEntries(spans)) {
-    const item = document.createElement('span');
-    item.className = 'history-autonomy-legend-item';
-    const swatch = document.createElement('i');
-    swatch.style.background = autonomyReasonColor(reason, cs);
-    item.appendChild(swatch);
-    item.appendChild(document.createTextNode(glyph + ' ' + label));
-    legendEl.appendChild(item);
-  }
-}
-
-// buildAutonomyStripHeader labels the value column. It reuses the row grid so
-// the header sits exactly over the values it names.
-export function buildAutonomyStripHeader() {
-  const head = document.createElement('div');
-  head.className = 'history-autonomy-row history-autonomy-head';
-  head.setAttribute('aria-hidden', 'true'); // each row's aria-label already says "longest"
-  const label = document.createElement('span');
-  label.className = 'history-autonomy-label';
-  label.textContent = 'project';
-  const spacer = document.createElement('span');
-  const val = document.createElement('span');
-  val.className = 'history-autonomy-val';
-  val.textContent = 'longest';
-  head.appendChild(label);
-  head.appendChild(spacer);
-  head.appendChild(val);
-  return head;
-}
-
-// buildAutonomyStripAxis puts the window's start on the left and "now" on the
-// right, under the strip, on the same grid so both land under the canvas
-// column rather than under the labels.
-export function buildAutonomyStripAxis(spans) {
-  const axis = document.createElement('div');
-  axis.className = 'history-autonomy-row history-autonomy-axis';
-  const label = document.createElement('span');
-  const bounds = document.createElement('span');
-  bounds.className = 'history-autonomy-axis-bounds';
-  const from = document.createElement('i');
-  from.textContent = autonomyAxisLabel(spans.start, (spans.end || 0) - (spans.start || 0));
-  const to = document.createElement('i');
-  to.textContent = 'now';
-  bounds.appendChild(from);
-  bounds.appendChild(to);
-  const tail = document.createElement('span');
-  axis.appendChild(label);
-  axis.appendChild(bounds);
-  axis.appendChild(tail);
-  return axis;
-}
-
-// autonomyAxisLabel formats the strip's left bound, coarsening with the window
-// the way stateBucketLabel does for the activity matrix: an 8h strip needs a
-// time of day, a 12mo strip needs a month.
-export function autonomyAxisLabel(ts, windowSeconds) {
-  const d = new Date((Number(ts) || 0) * 1000);
-  if (windowSeconds <= 36 * 3600) return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-  if (windowSeconds <= 60 * 86400) return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
-}
-
-function buildAutonomyStripRow(project, spans, cs) {
-  const row = document.createElement('div');
-  row.className = 'history-autonomy-row';
-
-  const label = document.createElement('span');
-  label.className = 'history-autonomy-label';
-  label.textContent = project;
-  row.appendChild(label);
-
-  const mine = (spans.spans || []).filter(sp => sp.project === project);
-  const longest = mine.reduce((m, sp) => Math.max(m, (sp.end || 0) - (sp.start || 0)), 0);
-
-  const canvas = document.createElement('canvas');
-  canvas.className = 'history-autonomy-canvas';
-  canvas.setAttribute('role', 'img');
-  canvas.setAttribute('aria-label', project + ': ' + mine.length + ' runs, longest ' + autonomyDuration(longest));
-  row.appendChild(canvas);
-
-  const val = document.createElement('span');
-  val.className = 'history-autonomy-val';
-  val.textContent = autonomyDuration(longest);
-  row.appendChild(val);
-
-  // Painted on the next frame: the canvas has no layout width until it is in
-  // the document, and a zero-width canvas would collapse every span into
-  // nothing — the exact failure the minimum-one-column rule exists to prevent.
-  requestAnimationFrame(() => paintAutonomyStripRow(canvas, mine, spans, cs));
-  return row;
-}
-
-function paintAutonomyStripRow(canvas, mine, spans, cs) {
-  const dpr = window.devicePixelRatio || 1;
-  const w = canvas.offsetWidth || 300;
-  const h = canvas.offsetHeight || 14;
-  const pxW = Math.max(1, Math.round(w * dpr)), pxH = Math.max(1, Math.round(h * dpr));
-  if (canvas.width !== pxW || canvas.height !== pxH) { canvas.width = pxW; canvas.height = pxH; }
-  const ctx = canvas.getContext('2d');
-  if (!ctx) return;
-  ctx.setTransform(1, 0, 0, 1, 0, 0); // draw in DEVICE pixels: one column = one pixel
-  ctx.clearRect(0, 0, pxW, pxH);
-  const cells = collapseAutonomyStrip(mine, spans.start, spans.end, pxW);
-  for (let i = 0; i < cells.length; i++) {
-    if (!cells[i].occupied) continue;
-    ctx.fillStyle = autonomyReasonColor(cells[i].reason, cs);
-    ctx.fillRect(i, 0, 1, pxH);
-  }
-}
-
 // autonomyPanelRows builds the side panel's rows, INCLUDING each row's swatch
 // colour, as a pure function.
 //
 // The swatch belongs here rather than at the DOM call site because that is
-// exactly where the defect was: the panel used to build the p95/p50/p5 rows and
-// then blank every dot, leaving three unlabelled curves on the canvas with no
-// key at all. As a value it is testable; as a `style.background =` buried in a
-// render loop it was not.
+// exactly where the defect was once: the panel built its rows and then blanked
+// every dot, leaving unlabelled curves on the canvas with no key at all. As a
+// value it is testable; as a `style.background =` buried in a render loop it
+// was not.
 //
-// The first TWO rows are the key, and they are the key because they are what
-// the chart draws: one line and one plane. Three swatches for three
-// percentiles distinguished nothing once the three curves became one hue —
-// worse, they promised a distinction the chart had stopped making. The
-// numbers did not collapse with the colours: p50 is the line row's value and
-// p5/p95 are the band row's, so all three figures are still on screen.
-//
-// longest/shortest/runs are FIGURES, not marks, and stay unswatched on
-// purpose: a swatch would claim ink the chart deliberately does not lay down.
+// The first TWO rows are the key, and they are the key because they are what a
+// panel draws: one line and one row of bars. runs/projects are FIGURES and stay
+// unswatched on purpose — a swatch would claim ink nothing lays down.
 export function autonomyPanelRows(summary, cs) {
   const s = summary || {};
-  const [lineKey, bandKey] = autonomyKeyEntries(cs);
-  const figure = (label, value) => ({ kind: null, label, value, swatch: 'transparent', fill: '' });
+  const [lineKey, barsKey] = autonomyKeyEntries(cs);
+  const figure = (label, value) => ({ kind: null, label, value, swatch: 'transparent' });
+  let longest = autonomyDuration(s.longest);
+  if (s.longest_running) longest += ' · still going';
   return [
-    { kind: lineKey.kind, label: lineKey.label, value: autonomyDuration(s.p50), swatch: lineKey.color, fill: lineKey.fill },
+    { kind: lineKey.kind, label: lineKey.label, value: longest, swatch: lineKey.color },
     {
-      kind: bandKey.kind,
-      label: bandKey.label,
-      // Both ends of the band, in the order they read on the chart: bottom
-      // edge to top edge. One row, three figures still visible.
-      value: autonomyDuration(s.p5) + ' – ' + autonomyDuration(s.p95),
-      swatch: bandKey.color,
-      fill: bandKey.fill,
+      kind: barsKey.kind,
+      label: barsKey.label,
+      value: String(Number(s.peak) || 0),
+      swatch: barsKey.color,
     },
-    figure('longest', autonomyDuration(s.max)),
-    figure('shortest', autonomyDuration(s.min)),
-    figure('runs', String(s.count || 0)),
+    figure('runs', String(Number(s.runs) || 0)),
+    figure('projects', String(Number(s.projects) || 0)),
   ];
 }
 
-// renderAutonomyPanel fills the shared side panel with element 1's figures.
-// The true extremes are FIGURES here and deliberately not lines on the chart:
-// one overnight run would otherwise redraw the whole Y scale.
-function renderAutonomyPanel() {
+// renderAutonomySidePanel fills the shared side panel with the window's own
+// figures and every sentence that qualifies them.
+function renderAutonomySidePanel() {
   const titleEl = document.getElementById('history-panel-title');
   const totalEl = document.getElementById('history-total');
   const fcEl = document.getElementById('history-forecast-line');
   const listEl = document.getElementById('history-contrib');
-  const duration = historyState.autonomyData?.duration;
+  const data = historyState.autonomyData;
   if (titleEl) titleEl.textContent = 'Autonomy · ' + (AUTONOMY_RANGE_LABELS[historyState.autonomyRange] || historyState.autonomyRange);
-  const s = duration?.summary || {};
-  if (totalEl) totalEl.textContent = (s.count || 0) > 0 ? autonomyDuration(s.p50) : '—';
-  if (fcEl) fcEl.textContent = (s.count || 0) > 0 ? 'median run · ' + s.count + ' runs' : '';
+  const s = data?.summary || {};
+  const runs = Number(s.runs) || 0;
+  if (totalEl) totalEl.textContent = runs > 0 ? autonomyDuration(s.longest) : '—';
+  if (fcEl) {
+    fcEl.textContent = runs > 0
+      ? 'longest run' + (s.longest_project ? ' · ' + s.longest_project : '') + ' · ' + runs + ' runs'
+      : '';
+  }
   if (!listEl) return;
   listEl.innerHTML = '';
-  if (!(s.count > 0)) {
-    appendHistoryEmpty(listEl, autonomyEverRecorded()
-      ? 'no runs in this range'
-      : 'nothing recorded yet');
+  if (!(runs > 0)) {
+    appendHistoryEmpty(listEl, autonomyEverRecorded() ? 'no runs in this range' : 'nothing recorded yet');
   } else {
     for (const row of autonomyPanelRows(s, getComputedStyle(document.documentElement))) {
       const li = document.createElement('li');
-      // The key rows lay out differently from the figure rows below them:
-      // they carry a sentence AND a two-ended figure, which do not fit one
-      // 228px line together. See .history-contrib li.autonomy-key.
+      // The key rows lay out differently from the figure rows below them: they
+      // carry a sentence AND a figure, which do not fit one 228px line.
       if (row.kind) li.className = 'autonomy-key';
       const dot = document.createElement('span');
-      // The two key swatches take the SHAPE of what they stand for — a rule
-      // for the line, a bounded plane for the band. A pair of identical dots
-      // in one hue would be a key that says nothing twice.
+      // The two key swatches take the SHAPE of what they stand for — a rule for
+      // the line, a pair of bars for the histogram. Two identical dots in one
+      // hue would be a key that says the same thing twice.
       dot.className = row.kind ? 'dot autonomy-' + row.kind : 'dot';
-      if (row.kind === 'band') {
-        dot.style.background = row.fill;
-        dot.style.borderColor = row.swatch;
-      } else if (row.kind === 'line') {
-        dot.style.borderColor = row.swatch;
-      } else {
-        dot.style.background = row.swatch;
-      }
+      if (row.kind) dot.style.color = row.swatch; else dot.style.background = row.swatch;
       const lbl = document.createElement('span');
       lbl.className = 'label';
       lbl.textContent = row.label;
@@ -1716,31 +1465,25 @@ function renderAutonomyPanel() {
       li.appendChild(val);
       listEl.appendChild(li);
     }
-    const thin = (duration.buckets || []).filter(b => b.thin).length;
-    if (thin > 0) {
-      appendHistoryEmpty(listEl, thin + ' of ' + duration.buckets.length + ' buckets hold fewer than '
-        + duration.sample_floor + ' runs (fainter band, dashed edges, hollow points): there p95 is '
-        + 'that bucket’s longest run and p5 its shortest — not percentiles.');
-    }
+    // The caveat belongs beside the number it qualifies, not in a tooltip: the
+    // `at once` figure is otherwise read as "N independent agents".
+    appendHistoryEmpty(listEl, AUTONOMY_CONCURRENCY_CAVEAT);
   }
   // What these figures counted (#1905 subagents). Above the provenance line
   // because it qualifies every number in the panel, where provenance qualifies
   // where they came from.
-  const countingLine = autonomyCountingLine(duration);
+  const countingLine = autonomyCountingLine(data);
   if (countingLine) appendHistoryEmpty(listEl, countingLine);
   // …and which of them are floors rather than measurements (#1905 recording).
-  // Same register, and the same reason: a lower bound rendered as a measurement
-  // is a wrong number with nothing on screen saying it is wrong. Silent when
-  // every run in view is finished and fully measured.
-  const measurement = autonomyMeasurementNote(duration);
+  const measurement = autonomyMeasurementNote(data);
   if (measurement) appendHistoryEmpty(listEl, measurement);
   // The provenance line is part of the feature: "no data" must never read as
   // "you did nothing".
-  appendHistoryEmpty(listEl, autonomyProvenanceLine(duration));
+  appendHistoryEmpty(listEl, autonomyProvenanceLine(data));
   // …and a back-filled view says so, for the same reason: a reconstructed
   // figure rendered as a measured one is the wrong number with nothing on
   // screen saying it is wrong. Silent when nothing in view was reconstructed.
-  const reconstruction = autonomyReconstructionNote(duration);
+  const reconstruction = autonomyReconstructionNote(data);
   if (reconstruction) appendHistoryEmpty(listEl, reconstruction);
 }
 
@@ -2592,11 +2335,10 @@ export function initHistoryTab() {
   const histAutonomySeg = document.getElementById('history-autonomy-sel');
   if (histAutonomySeg) histAutonomySeg.addEventListener('click', handleChartClick);
 
-  // The Autonomy segmented controls. Each re-fetches only because the section
-  // shows both elements together; the daemon serves them as two independent
-  // charts. `dataKey` is passed rather than derived from `attr`, so adding a
-  // third control is one more line instead of another branch in a ternary that
-  // silently defaulted every unrecognised attribute to the span picker.
+  // The Autonomy segmented control. `dataKey` is passed rather than derived
+  // from `attr`, so a second control would be one more line instead of another
+  // branch in a ternary that silently defaulted every unrecognised attribute to
+  // one particular picker.
   const wireAutonomyPicker = (id, attr, dataKey, stateKey) => {
     const seg = document.getElementById(id);
     if (!seg) return;
@@ -2609,7 +2351,6 @@ export function initHistoryTab() {
     });
   };
   wireAutonomyPicker('history-autonomy-range-sel', 'autonomy-range', 'autonomyRange', 'autonomyRange');
-  wireAutonomyPicker('history-autonomy-span-sel', 'autonomy-span', 'autonomySpan', 'autonomySpan');
 
   const histDoraProjectSel = document.getElementById('history-dora-project');
   if (histDoraProjectSel) histDoraProjectSel.addEventListener('change', () => {
@@ -2660,7 +2401,11 @@ export function initHistoryTab() {
   window.addEventListener('resize', () => {
     if (!historyTabOn() || !historyState.data) return;
     if (historyResizeRAF) cancelAnimationFrame(historyResizeRAF);
-    historyResizeRAF = requestAnimationFrame(paintHistoryChart);
+    // Autonomy repaints its own stack: each panel is its own width-dependent
+    // canvas, so the shared painter would leave five stale plots at the old
+    // width while redrawing a canvas that is hidden.
+    const repaint = historyState.chart === 'autonomy' ? renderAutonomyPanels : paintHistoryChart;
+    historyResizeRAF = requestAnimationFrame(repaint);
   });
 
   // Restore the History tab if it was active last session.

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -266,10 +266,10 @@
             <button type="button" data-chart="dora" title="Metrics: DORA deployment metrics per project">DORA</button>
           </fieldset>
           <!-- Autonomy (#1905) is its own top-level section, not another chart
-               type: it holds TWO elements over the span log and uses neither
-               Range, Group, nor the drilldown filters. On macOS it is a fifth
-               HistoryTab; here, where there is no tab strip, a third segmented
-               group is the equivalent. -->
+               type: it draws five per-project panels over the span log and uses
+               neither Range, Group, nor the drilldown filters. On macOS it is a
+               fifth HistoryTab; here, where there is no tab strip, a third
+               segmented group is the equivalent. -->
           <fieldset class="history-seg" id="history-autonomy-sel" aria-label="Autonomy">
             <button type="button" data-chart="autonomy" title="How long sessions ran without needing a human">Autonomy</button>
           </fieldset>
@@ -280,11 +280,11 @@
             <option value="">Select a project…</option>
           </select>
         </div>
-        <!-- Range governs the duration chart below and nothing else. Span,
-             which governs the run strip, used to sit on this same row — one
-             row of controls above two elements, with nothing saying which
-             control moved which. Each now sits directly above the thing it
-             changes; Span lives in the strip's own header. -->
+        <!-- Range is the section's ONLY control, and governs all five panels.
+             A second picker (Span) used to sit here governing the run strip's
+             own window, with two textually-overlapping vocabularies on one row
+             and nothing saying which control moved which; it went with the
+             strip. -->
         <div class="history-ctl-row" id="history-autonomy-range-row" hidden>
           <span class="history-ctl-label">Range</span>
           <fieldset class="history-seg" id="history-autonomy-range-sel" aria-label="Autonomy chart range">
@@ -294,9 +294,9 @@
           <!-- There is no Runs control (#1905 recording). The section counts
                every run, subagent runs included, because Irrlicht recorded
                them — so there is no choice to offer, and no mode a reader has
-               to remember before reading a figure. Each row still carries its
-               kind and parent, and the panel says how much of a window was
-               subagent work. -->
+               to remember before reading a figure. What a run WAS still
+               matters: it is what splits a concurrency peak into sessions and
+               subagents. -->
         </div>
         <div class="history-ctl-row" id="history-granularity-row" hidden>
           <span class="history-ctl-label">Granularity</span>
@@ -348,6 +348,16 @@
           <div class="history-matrix-scroll" id="history-matrix-scroll" hidden>
             <div class="history-matrix" id="history-matrix"></div>
           </div>
+          <!-- Autonomy (#1905): five per-project panels, stacked, replacing the
+               shared canvas inside this same card the way the activity matrix
+               does. Inside the card rather than in a full-width block below it
+               because the section is ONE element now — the run strip that used
+               to be the second one is gone — so it belongs where every other
+               chart is drawn, with the side panel keeping its place beside it.
+               Scrolls: five panels plus the "+N more" line and the axis run a
+               little past a 360px card, and clipping the explanation would be
+               worse than a scrollbar. -->
+          <div class="history-autonomy-panels" id="history-autonomy-panels" hidden></div>
           <div class="history-chart-empty" id="history-chart-empty">no cost data in this range yet</div>
           <a id="history-co2-info" class="history-co2-info" href="https://irrlicht.io/docs/co2-methodology.html" target="_blank" rel="noopener" title="How the CO2e estimate and its equivalents are calculated" hidden>How is this calculated?</a>
         </div>
@@ -362,31 +372,6 @@
           </div>
         </aside>
       </div>
-
-      <!-- Element 2 of the Autonomy section (#1905): one row per project,
-           each span drawn at its true length and colored by what ended it.
-           Full width under the chart because it is a SECOND element, not
-           another rendering of the first. -->
-      <section class="history-autonomy" id="history-autonomy-strip" hidden aria-label="Autonomous runs">
-        <!-- The strip's own header row: its title and the Span picker that
-             changes it, together. Span is NOT the chart's Range — the two
-             elements answer different questions over different windows, and
-             a shared control row above both said otherwise. -->
-        <div class="history-autonomy-header">
-          <div class="history-autonomy-title" id="history-autonomy-strip-title">Runs</div>
-          <span class="history-ctl-label">Span</span>
-          <fieldset class="history-seg" id="history-autonomy-span-sel" aria-label="Autonomy strip span">
-            <button type="button" data-autonomy-span="8h">8h</button>
-            <button type="button" data-autonomy-span="24h" class="active">24h</button>
-            <button type="button" data-autonomy-span="7d">7d</button>
-            <button type="button" data-autonomy-span="30d">30d</button>
-            <button type="button" data-autonomy-span="12mo">12mo</button>
-          </fieldset>
-        </div>
-        <div class="history-autonomy-rows" id="history-autonomy-rows"></div>
-        <div class="history-autonomy-legend" id="history-autonomy-legend"></div>
-        <div class="history-autonomy-note" id="history-autonomy-note"></div>
-      </section>
     </section>
   </main>
 

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -46,24 +46,19 @@
          differs per theme AND from the macOS side). Like --cancelled, it is
          defined once: a mid-grey that reads on both light and dark surfaces. */
       --unknown: #8E8E93;
-      /* Autonomy chart (#1905) — ONE hue, three weights. The p50 line is
-         --working at full strength; the p5–p95 band is the same hue as a
-         translucent plane, and its two edges the same hue again, quiet enough
-         to read as the band's boundary rather than as two more curves.
-         Tokens rather than an rgba typed into the canvas painter, because the
+      /* Autonomy panels (#1905) — ONE hue, two weights. The longest-run line
+         is --working at full strength; the concurrency histogram under it is
+         the same hue, quieter, because the bars are a second reading of the
+         same activity and not a second subject.
+         A token rather than an rgba typed into the canvas painter, because the
          two grounds need different alphas and a literal cannot have two
-         values: on #0f1628 a violet wash has to LIGHTEN the surface to show
-         at all, while on #ffffff the same alpha reads as a solid lavender
-         block that shouts louder than the line it surrounds. Measured by eye
-         against .history-chart-wrap's --surface in both themes.
-         All three are the --working RGB triple; `the band is the p50 hue, not
-         a fourth colour` in irrlicht.history.autonomy.test.js pins that. */
-      --autonomy-band: rgba(139, 92, 246, 0.20);
-      /* Thin buckets (under sample_floor) keep their own, fainter plane: there
-         p95 IS the maximum and p5 IS the minimum, so the area is a range, not
-         a percentile spread, and must not read as one. */
-      --autonomy-band-thin: rgba(139, 92, 246, 0.08);
-      --autonomy-edge: rgba(139, 92, 246, 0.45);
+         values: on #0f1628 a violet bar has to LIGHTEN the surface to show at
+         all, while on #ffffff the same alpha reads as a solid lavender block
+         that shouts louder than the line above it. Measured by eye against
+         .history-chart-wrap's --surface in both themes.
+         It is the --working RGB triple; `the bars are the line hue, not a
+         second colour` in irrlicht.history.autonomy.test.js pins that. */
+      --autonomy-bar: rgba(139, 92, 246, 0.45);
       /* Pressure-bar colors — mirror overlay's ContextBarColor / pressure_level mapping:
          safe → low, caution → medium, warning → high, critical → critical. */
       --pressure-low: #34C759;
@@ -108,15 +103,12 @@
         --waiting-dim: rgba(136, 79, 0, 0.12);
         --ready: #207936;
         --ready-dim: rgba(32, 121, 54, 0.12);
-        /* Autonomy band, re-tuned for the light ground (see the dark block).
-           Two things change at once and both push the alpha DOWN: the hue is
-           the darker light-theme --working (#6526F3), and the surface under it
-           is #ffffff rather than #0f1628, so the same 0.20 that reads as a
-           faint haze on the dark card reads as a solid lavender slab here —
-           louder than the p50 line it is supposed to sit behind. */
-        --autonomy-band: rgba(101, 38, 243, 0.11);
-        --autonomy-band-thin: rgba(101, 38, 243, 0.05);
-        --autonomy-edge: rgba(101, 38, 243, 0.38);
+        /* Autonomy bars, re-tuned for the light ground (see the dark block).
+           Two things change at once: the hue is the darker light-theme
+           --working (#6526F3), and the surface under it is #ffffff rather than
+           #0f1628, so a bar that is a faint wash on the dark card reads as a
+           solid lavender block here — louder than the line it sits under. */
+        --autonomy-bar: rgba(101, 38, 243, 0.38);
         /* #1801, same rule as the three above and measured the same way. The
            dark --error (#FF3B30) reads 3.01:1 against its own 12% wash on
            --surface #ffffff — under the 4.5:1 minimum, and the worst possible
@@ -154,9 +146,7 @@
       --ready: #207936;
       --ready-dim: rgba(32, 121, 54, 0.12);
       /* See the matching comment in the media-query block above. */
-      --autonomy-band: rgba(101, 38, 243, 0.11);
-      --autonomy-band-thin: rgba(101, 38, 243, 0.05);
-      --autonomy-edge: rgba(101, 38, 243, 0.38);
+      --autonomy-bar: rgba(101, 38, 243, 0.38);
       --error: #CC0C00;
       --error-dim: rgba(204, 12, 0, 0.12);
     }
@@ -1786,73 +1776,46 @@
     .history-co2-info:hover { color: var(--text-bright); background: var(--working); }
     .history-co2-info[hidden] { display: none; }
 
-    /* Autonomy run strip (#1905), element 2 of the Autonomy section. A
-       full-width block UNDER the chart card rather than inside it: it is a
-       second element, not another rendering of the first, and it grows a row
-       per project instead of living in a fixed-height card. */
-    .history-autonomy { margin-top: 18px; }
-    .history-autonomy[hidden] { display: none; }
-    .history-autonomy-title {
-      font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em;
-      text-transform: uppercase; color: var(--muted); margin-bottom: 8px;
+    /* Autonomy per-project panels (#1905). Five stacked panels inside the
+       shared chart card, replacing the canvas the way the activity matrix does
+       (see syncHistoryMatrixVisibility). SCROLLS rather than compresses: five
+       panels plus the "+N more" line and the axis run a little past a 360px
+       card, and a panel squeezed until its histogram is a smear explains
+       nothing. The run strip this replaced was a full-width block BELOW the
+       card, because it was a second element; there is only one now. */
+    .history-autonomy-panels { position: absolute; inset: 10px; overflow: auto; }
+    .history-autonomy-panels[hidden] { display: none; }
+    .history-autonomy-panel { margin-bottom: 5px; }
+    .history-autonomy-panel-head {
+      display: flex; align-items: baseline; gap: 10px;
+      font-size: 11px; line-height: 14px;
     }
-    /* The strip's header: its title and the Span picker that changes it, on
-       one row. Span used to sit above BOTH elements next to the chart's
-       Range, which said the two controls governed the same thing. Wraps
-       rather than compressing, so a narrow window stacks the picker under the
-       title instead of squeezing the segmented buttons. */
-    .history-autonomy-header {
-      display: flex; align-items: center; flex-wrap: wrap; gap: 8px 10px; margin-bottom: 8px;
+    .history-autonomy-panel-name {
+      color: var(--text); overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto;
     }
-    .history-autonomy-header .history-autonomy-title { margin-bottom: 0; margin-right: auto; }
-    .history-autonomy-row {
-      display: grid; grid-template-columns: 140px 1fr 56px;
-      align-items: center; gap: 10px; margin-bottom: 6px;
-    }
-    .history-autonomy-label {
-      font-size: 12px; color: var(--text); overflow: hidden;
-      text-overflow: ellipsis; white-space: nowrap;
-    }
-    .history-autonomy-canvas {
-      width: 100%; height: 14px; display: block;
-      background: var(--surface); border: 1px solid var(--border); border-radius: 3px;
-    }
-    .history-autonomy-val {
-      font-family: var(--font-mono); font-size: 11px; color: var(--muted); text-align: right;
-    }
-    /* Column header over the per-row "longest" figure, and the window's own
-       bounds under the strip — both reuse .history-autonomy-row's grid so they
-       line up with the column they describe. */
-    .history-autonomy-head .history-autonomy-label,
-    .history-autonomy-head .history-autonomy-val {
-      font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em;
-      text-transform: uppercase; color: var(--muted);
-    }
-    .history-autonomy-axis { margin-top: 2px; }
-    .history-autonomy-axis-bounds {
-      display: flex; justify-content: space-between;
+    /* The two figures the maintainer asked for, on the panel that carries them
+       — so the exact longest never depends on reading a shared log axis, and
+       the concurrency split is legible rather than buried in a tooltip. */
+    .history-autonomy-panel-figs {
       font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+      margin-left: auto; white-space: nowrap;
     }
-    .history-autonomy-axis-bounds i { font-style: normal; }
-    /* "+N more projects" — what the row cap left out (#1905 back-fill, QA-1).
-       Quieter than a row and clearly not one: it is a statement about the
-       strip, not another line of it. */
+    .history-autonomy-panel-canvas { width: 100%; height: 44px; display: block; }
+    /* "+N more projects" — what the five-panel view left out. Quieter than a
+       panel and clearly not one: it is a statement about the stack, not another
+       row of it. */
     .history-autonomy-more {
       font-family: var(--font-mono); font-size: 10px; color: var(--muted);
       opacity: 0.85; padding: 4px 0 0;
     }
-    .history-autonomy-empty, .history-autonomy-note {
-      font-size: 12px; color: var(--muted); padding: 8px 0; line-height: 1.5;
+    /* The window's bounds, once under the whole stack: the five panels share
+       one x domain, so five copies would be five statements of one fact. */
+    .history-autonomy-axis {
+      display: flex; justify-content: space-between; padding-left: 46px;
+      font-family: var(--font-mono); font-size: 10px; color: var(--muted);
     }
-    .history-autonomy-note { color: var(--waiting); }
-    .history-autonomy-legend {
-      display: flex; flex-wrap: wrap; gap: 14px; margin-top: 8px;
-      font-size: 11px; color: var(--muted);
-    }
-    .history-autonomy-legend-item { display: inline-flex; align-items: center; gap: 5px; }
-    .history-autonomy-legend-item i {
-      display: inline-block; width: 10px; height: 8px; border-radius: 1px;
-    }
+    .history-autonomy-axis i { font-style: normal; }
 
     /* Activity matrix (chart=state, issue #981): projects × time buckets,
        each cell a stacked working/waiting/ready mini bar. Replaces the
@@ -1947,18 +1910,20 @@
     }
     .history-contrib li { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 12px; }
     .history-contrib .dot { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
-    /* The Autonomy key's two swatches (#1905 redesign). The chart draws one
-       line and one plane in a single hue, so the key has to distinguish them
-       by SHAPE — two identically-coloured dots would be a key that says the
-       same thing twice. Colours come from the JS resolvers (the same calls the
-       canvas painter makes), never from here. */
+    /* The Autonomy key's two swatches. A panel draws one line and one row of
+       bars in a single hue, so the key has to distinguish them by SHAPE — two
+       identically-coloured dots would be a key that says the same thing twice.
+       Both take their colour from `currentColor`, which the JS resolvers set
+       from the same tokens the canvas painter reads, never from here. */
     .history-contrib .dot.autonomy-line {
       width: 16px; height: 0; border-radius: 0; background: none;
       border-top: 2px solid currentColor;
     }
-    .history-contrib .dot.autonomy-band {
-      width: 16px; height: 10px; border-radius: 1px;
-      border-top: 1px solid currentColor; border-bottom: 1px solid currentColor;
+    .history-contrib .dot.autonomy-bars {
+      width: 16px; height: 9px; border-radius: 0; background: none;
+      border-left: 3px solid currentColor;
+      border-right: 3px solid currentColor;
+      border-bottom: 3px solid currentColor;
     }
     .history-contrib .label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* A figure is never split across two lines: "6s – 23m46s" broken after
@@ -1967,12 +1932,12 @@
        the figure is the thing being reported. */
     .history-contrib .val { margin-left: auto; color: var(--text-bright); white-space: nowrap; }
     /* The two Autonomy key rows are the only rows here carrying BOTH a
-       sentence and a two-ended figure, and one 228px line cannot hold them:
+       sentence and a figure, and one 228px line cannot hold them:
        the label wants 180px and the value another 79px against a 196px
        budget once the swatch and gaps are out (the arithmetic is in
        autonomyLayout.test.js, computed from this stylesheet). Shipped as one
        flex line it ellipsised the very label whose job is to explain the
-       band, and wrapped the range mid-figure.
+       mark.
        So the value takes a line of its own, right-aligned in the same column
        the figures below use, and the label is allowed to WRAP rather than
        ellipsise: a truncated explanation is unreadable, a wrapped one is

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1778,17 +1778,31 @@
 
     /* Autonomy per-project panels (#1905). Five stacked panels inside the
        shared chart card, replacing the canvas the way the activity matrix does
-       (see syncHistoryMatrixVisibility). SCROLLS rather than compresses: five
-       panels plus the "+N more" line and the axis run a little past a 360px
-       card, and a panel squeezed until its histogram is a smear explains
-       nothing. The run strip this replaced was a full-width block BELOW the
-       card, because it was a second element; there is only one now. */
-    .history-autonomy-panels { position: absolute; inset: 10px; overflow: auto; }
+       (see syncHistoryMatrixVisibility). The run strip this replaced was a
+       full-width block BELOW the card, because it was a second element; there
+       is only one now.
+
+       THE CARD GROWS; THE STACK DOES NOT SCROLL (QA-2). Five panels at a
+       readable height do not fit a 360px card, and an inner scrollbar cut off
+       the x axis and the "+N more" line — the row that says what the view left
+       out — while a couple of hundred pixels of page sat empty below the card.
+       So .autonomy releases the fixed height and the stack flows at its natural
+       size. `min-height` keeps the empty state's overlay a sensible size; it is
+       a FLOOR, never a ceiling, so nothing can be clipped by it. */
+    .history-chart-wrap.autonomy { height: auto; min-height: 220px; }
+    .history-autonomy-panels { position: static; overflow: visible; }
     .history-autonomy-panels[hidden] { display: none; }
-    .history-autonomy-panel { margin-bottom: 5px; }
+    .history-autonomy-panel { margin-bottom: 7px; }
+    /* The header gets a ROW OF ITS OWN, above the plot and clear of it (QA-1).
+       It shared a line with the topmost y-axis tick when the ticks were on the
+       left: the tick was drawn centred on the plot's top edge, so half of it
+       fell outside the canvas and landed on the header's line, and the figure
+       the panel is about overprinted a sliced axis label. The ticks moved to
+       the right gutter and the canvas gained a top inset; this row is now the
+       only thing on its line. */
     .history-autonomy-panel-head {
       display: flex; align-items: baseline; gap: 10px;
-      font-size: 11px; line-height: 14px;
+      font-size: 11px; line-height: 15px; padding-bottom: 1px;
     }
     .history-autonomy-panel-name {
       color: var(--text); overflow: hidden;
@@ -1801,7 +1815,11 @@
       font-family: var(--font-mono); font-size: 10px; color: var(--muted);
       margin-left: auto; white-space: nowrap;
     }
-    .history-autonomy-panel-canvas { width: 100%; height: 44px; display: block; }
+    /* MUST equal AUTONOMY_PANEL_CANVAS_H in historyTab.js: the painter sizes
+       its backing store from the constant and lays out against it, so a
+       stylesheet that disagreed would scale every panel. autonomyLayout.test.js
+       reads both and fails on a mismatch. */
+    .history-autonomy-panel-canvas { width: 100%; height: 67px; display: block; }
     /* "+N more projects" — what the five-panel view left out. Quieter than a
        panel and clearly not one: it is a statement about the stack, not another
        row of it. */
@@ -1810,9 +1828,13 @@
       opacity: 0.85; padding: 4px 0 0;
     }
     /* The window's bounds, once under the whole stack: the five panels share
-       one x domain, so five copies would be five statements of one fact. */
+       one x domain, so five copies would be five statements of one fact. The
+       padding matches the plot's own inset (AUTONOMY_PANEL.padL / .padR), so
+       each bound sits under the end of the line it describes rather than under
+       the right-hand tick gutter. */
     .history-autonomy-axis {
-      display: flex; justify-content: space-between; padding-left: 46px;
+      display: flex; justify-content: space-between;
+      padding-left: 4px; padding-right: 46px;
       font-family: var(--font-mono); font-size: 10px; color: var(--muted);
     }
     .history-autonomy-axis i { font-style: normal; }

--- a/platforms/web/irrlicht.history.autonomy.backfill.test.js
+++ b/platforms/web/irrlicht.history.autonomy.backfill.test.js
@@ -1,17 +1,14 @@
-import { describe, test, expect } from 'vitest'
-
 import {
-  AUTONOMY_REASON_LEGEND,
-  AUTONOMY_REASON_PRIORITY,
-  AUTONOMY_STRIP_MAX_ROWS,
-  AUTONOMY_UNKNOWN_LEGEND,
+  autonomyBoundaryCaptionShown,
   autonomyBoundaryLabel,
-  autonomyLegendEntries,
+  autonomyMoreProjectsLabel,
   autonomyReconstructionNote,
-  autonomyStripOverflowLabel,
+  autonomyStackRows,
   autonomyVisibleBoundaries,
-  collapseAutonomyStrip,
 } from './historyTab.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { WEB_DIR } from './shippedFiles.testutil.js'
 
 // The back-fill's marking (#1905). tools/autonomy-backfill reconstructs runs
 // from logs a machine already had; the daemon serves them like any other row,
@@ -19,12 +16,10 @@ import {
 // reconstructed figure rendered as a measured one is the wrong number with
 // nothing on screen admitting it.
 
-const span = (start, end, reason, project = 'p') => ({ start, end, reason, project, session: 's' + start })
-
-// A duration payload with an arbitrary provenance block.
+// A panels payload with an arbitrary provenance block.
 const durationWith = (provenance, count = 100) => ({
-  summary: { p95: 60, p50: 30, p5: 10, min: 5, max: 90, count },
-  buckets: [],
+  panels: [],
+  summary: { longest: 90, peak: 2, runs: count, projects: 1 },
   earliest_span: 1_700_000_000,
   total_recorded: count,
   provenance,
@@ -40,7 +35,7 @@ describe('autonomyReconstructionNote — the panel marks a back-filled view', ()
 
   test('says nothing when the payload carries no provenance at all', () => {
     // An older daemon, or a client reading a response it did not expect.
-    expect(autonomyReconstructionNote({ summary: { count: 12 } })).toBe('')
+    expect(autonomyReconstructionNote({ summary: { runs: 12 } })).toBe('')
     expect(autonomyReconstructionNote(null)).toBe('')
     expect(autonomyReconstructionNote(undefined)).toBe('')
   })
@@ -109,128 +104,97 @@ describe('autonomyReconstructionNote — the panel marks a back-filled view', ()
   })
 })
 
-describe('the strip legend gains a neutral entry only when it needs one', () => {
-  test('three measured reasons and nothing more, when every reason is named', () => {
-    // One reason per line: a single line naming three of the four canonical
-    // states is what tools/state-vocabulary-lint.sh refuses, and rightly.
-    const spans = { spans: [
-      span(0, 10, 'ready'),
-      span(20, 30, 'waiting'),
-      span(40, 50, 'error'),
-    ] }
-    expect(autonomyLegendEntries(spans)).toEqual(AUTONOMY_REASON_LEGEND)
+// The percentile band and the run strip were REMOVED, not hidden (#1905
+// redesign). Dead code that still parses is the thing a later reader restores
+// by accident, so their identifiers are checked out of the shipped files.
+describe('the percentile band and the run strip are gone from the shipped files', () => {
+  const js = readFileSync(join(WEB_DIR, 'historyTab.js'), 'utf8')
+  const css = readFileSync(join(WEB_DIR, 'irrlicht.css'), 'utf8')
+  const html = readFileSync(join(WEB_DIR, 'index.html'), 'utf8')
+
+  test('the files were actually read', () => {
+    // Absence of a finding and inability to look must not read the same. A
+    // positive control per file, so "not found" below means removed rather
+    // than mis-pathed.
+    expect(js).toContain('autonomyPanelHeadline')
+    expect(css).toContain('.history-autonomy-panel')
+    expect(html).toContain('history-autonomy-panels')
   })
 
-  test('a fourth neutral entry once a run has an unknown end reason', () => {
-    const spans = { spans: [span(0, 10, 'ready'), span(20, 30, 'unknown')] }
-    const entries = autonomyLegendEntries(spans)
-    expect(entries).toHaveLength(AUTONOMY_REASON_LEGEND.length + 1)
-    expect(entries[entries.length - 1]).toEqual(AUTONOMY_UNKNOWN_LEGEND)
+  test('no p5/p50/p95 apparatus survives', () => {
+    for (const gone of ['AUTONOMY_SERIES', 'AUTONOMY_BAND_TOKENS', 'autonomyBandSegments',
+      'autonomyBandColor', 'autonomySeriesColor', 'sample_floor', 'autonomyChartPoints']) {
+      expect(js).not.toContain(gone)
+    }
+    expect(css).not.toContain('--autonomy-band')
+    expect(css).not.toContain('--autonomy-edge')
   })
 
-  // Two different rows draw the same neutral column: a cost-derived span
-  // (reason `unknown`) and an old row written before the reason was recorded
-  // (reason absent). One legend entry has to cover both, or one of them is a
-  // colour with no key.
-  test('an old row with no reason at all also earns the neutral entry', () => {
-    const spans = { spans: [span(0, 10, 'ready'), { start: 20, end: 30, project: 'p', session: 's' }] }
-    expect(autonomyLegendEntries(spans)).toHaveLength(AUTONOMY_REASON_LEGEND.length + 1)
-  })
-
-  test('an empty or absent window does not invent a legend entry', () => {
-    expect(autonomyLegendEntries({ spans: [] })).toEqual(AUTONOMY_REASON_LEGEND)
-    expect(autonomyLegendEntries(null)).toEqual(AUTONOMY_REASON_LEGEND)
-  })
-
-  // The neutral entry must not be given a rank, or one reconstructed span
-  // would grey out a strip column that also holds a real error.
-  test('`unknown` has no rank on the collapse ladder', () => {
-    expect(AUTONOMY_REASON_PRIORITY.unknown).toBeUndefined()
-    const cells = collapseAutonomyStrip(
-      [span(1_000, 1_100, 'unknown'), span(1_200, 1_300, 'error')], 0, 100_000, 10)
-    expect(cells[0].reason).toBe('error')
-  })
-
-  // …and a column holding ONLY unknown runs is still occupied, drawn neutral.
-  // The run happened; nothing can say how it ended.
-  test('an unknown-only column is occupied and neutral, never idle', () => {
-    const cells = collapseAutonomyStrip([span(1_000, 1_100, 'unknown')], 0, 100_000, 10)
-    expect(cells[0].occupied).toBe(true)
-    expect(cells[0].reason).toBe(null)
+  test('no run strip, end-reason colours, glyphs or legend survive', () => {
+    for (const gone of ['collapseAutonomyStrip', 'AUTONOMY_REASON_PRIORITY', 'AUTONOMY_REASON_LEGEND',
+      'AUTONOMY_UNKNOWN_LEGEND', 'autonomyLegendEntries', 'autonomyReasonColor',
+      'AUTONOMY_STRIP_MAX_ROWS']) {
+      expect(js).not.toContain(gone)
+    }
+    expect(css).not.toContain('history-autonomy-legend')
+    expect(html).not.toContain('history-autonomy-strip')
   })
 })
 
-// The run strip had no row cap at all, which nobody could see until the
-// back-fill gave it history to draw: a 12mo window over a back-filled log
-// renders 95 project rows (QA-1). The daemon ranks `projects` by TOTAL
-// AUTONOMOUS SECONDS, so the cap keeps the rows that matter, and the omission
-// is stated rather than silent.
-describe('the run strip caps its project rows', () => {
-  const projects = (n) => Array.from({ length: n }, (_, i) => 'p' + i)
-
-  test('nothing is said when every project fits', () => {
-    expect(autonomyStripOverflowLabel(projects(AUTONOMY_STRIP_MAX_ROWS))).toBe('')
-    expect(autonomyStripOverflowLabel([])).toBe('')
-    expect(autonomyStripOverflowLabel(null)).toBe('')
+// The section is a per-project view of the FIVE most important projects. The
+// daemon computes the five and says how many it left out; the client renders
+// what it was sent and names the rest.
+describe('the stack draws the panels it was sent and names the rest', () => {
+  const stack = (panelCount, more) => ({
+    panels: Array.from({ length: panelCount }, (_, i) => ({ project: 'p' + i, buckets: [] })),
+    more_projects: more,
+    panel_limit: 5,
   })
 
-  test('the overflow line names how many rows were left out', () => {
-    const label = autonomyStripOverflowLabel(projects(AUTONOMY_STRIP_MAX_ROWS + 83))
-    expect(label).toContain('+83 more projects')
-    // …and WHY they are the missing ones, so the cap does not read as an
-    // arbitrary slice of an unknown ordering.
-    expect(label).toContain('less autonomous time')
+  test('five panels and one overflow line, in that order', () => {
+    const rows = autonomyStackRows(stack(5, 7))
+    expect(rows.filter(r => r.kind === 'panel')).toHaveLength(5)
+    expect(rows[rows.length - 1]).toEqual({ kind: 'more', label: '+7 more projects, each with less autonomous time' })
+    expect(rows).toHaveLength(6)
+  })
+
+  test('nothing is said when every project already has a panel', () => {
+    const rows = autonomyStackRows(stack(3, 0))
+    expect(rows.map(r => r.kind)).toEqual(['panel', 'panel', 'panel'])
+  })
+
+  test('the overflow line says WHY those are the projects missing', () => {
+    // Ranked by total autonomous time, so the tail is what went — not an
+    // arbitrary slice, and not the projects with the shortest single run.
+    expect(autonomyMoreProjectsLabel({ more_projects: 90 }))
+      .toContain('each with less autonomous time')
   })
 
   test('one hidden project is singular', () => {
-    expect(autonomyStripOverflowLabel(projects(AUTONOMY_STRIP_MAX_ROWS + 1)))
-      .toContain('+1 more project,')
+    expect(autonomyStackRows(stack(5, 1)).at(-1).label).toMatch(/^\+1 more project,/)
   })
 
-  // The measured case from QA: 95 projects in a 12mo window.
-  test('a 95-project window draws exactly the cap and accounts for the rest', () => {
-    const all = projects(95)
-    const drawn = all.slice(0, AUTONOMY_STRIP_MAX_ROWS)
-    expect(drawn).toHaveLength(AUTONOMY_STRIP_MAX_ROWS)
-    // A PREFIX of the daemon's ranking — the cap must never reorder, or the two
-    // clients would disagree about which projects are the busiest.
-    expect(drawn).toEqual(all.slice(0, drawn.length))
-    expect(autonomyStripOverflowLabel(all))
-      .toContain('+' + (95 - AUTONOMY_STRIP_MAX_ROWS) + ' more projects')
+  // The committed mutation: a client that re-decides the panel count itself.
+  // Two surfaces doing that is exactly how the run strip ended up drawing
+  // twelve rows on the web against six on macOS from one ranked list.
+  test('the client renders what it was sent, never its own count', () => {
+    const clientCap = (data) => data.panels.slice(0, 3)
+    const data = stack(5, 7)
+    expect(clientCap(data)).toHaveLength(3)
+    expect(autonomyStackRows(data).filter(r => r.kind === 'panel')).toHaveLength(data.panels.length)
   })
 
-  test('the cap is a fixed number, not something a caller can talk out of', () => {
-    expect(AUTONOMY_STRIP_MAX_ROWS).toBeGreaterThan(0)
-    expect(Number.isInteger(AUTONOMY_STRIP_MAX_ROWS)).toBe(true)
-  })
-
-  // The committed mutation, in the idiom this suite already uses. An
-  // always-silent build (the one shipped before QA-1) and an always-speaking
-  // one both answer identically for the two fixtures; production must not.
-  test('production tells a capped strip from an uncapped one', () => {
-    const fits = projects(AUTONOMY_STRIP_MAX_ROWS)
-    const overflows = projects(AUTONOMY_STRIP_MAX_ROWS + 1)
-
-    const neverSpeaks = () => ''
-    const alwaysSpeaks = () => '+N more projects'
-    expect(neverSpeaks(fits)).toBe(neverSpeaks(overflows))
-    expect(alwaysSpeaks(fits)).toBe(alwaysSpeaks(overflows))
-
-    expect(autonomyStripOverflowLabel(fits)).not.toBe(autonomyStripOverflowLabel(overflows))
-    expect(autonomyStripOverflowLabel(fits)).toBe('')
-    expect(autonomyStripOverflowLabel(overflows)).not.toBe('')
+  test('an empty window draws no panels and claims no overflow', () => {
+    expect(autonomyStackRows({ panels: [], more_projects: 0 })).toEqual([])
+    expect(autonomyStackRows(null)).toEqual([])
   })
 })
 
-// The p5 line steps by two orders of magnitude at the cost→log boundary,
-// because the cost log cannot see a run shorter than its 60s write interval
-// while the event log records one-second runs (QA-2). A reader takes that for a
-// change in behaviour. The marker puts the explanation where the artefact is.
-describe('source boundaries are marked on the chart', () => {
+describe('source boundaries are marked across the panel stack', () => {
   const durationOver = (starts, boundaries) => ({
     bucket_starts: starts,
-    buckets: [],
-    summary: { count: 0 },
+    panels: [],
+    summary: { runs: 0 },
     provenance: { reconstructed: 0, cost_derived: 0, live_since: 0, boundaries },
   })
 
@@ -309,5 +273,30 @@ describe('source boundaries are marked on the chart', () => {
 
     expect(autonomyVisibleBoundaries(straddles)).toHaveLength(1)
     expect(autonomyVisibleBoundaries(misses)).toHaveLength(0)
+  })
+})
+
+// WITH FIVE PANELS THE RULE HAS TO READ ONCE. Every panel's line steps at the
+// same instant — they share one x domain — so the rule is drawn through all of
+// them, and the caption is drawn on exactly one. Five stacked copies of
+// "← cost log · 60s resolution" are five competing captions where the reader
+// needs one, and at 9px they collide with four project names.
+describe('the boundary caption is written once, not once per panel', () => {
+  test('exactly one of five panels carries it', () => {
+    const carrying = [0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)
+    expect(carrying).toHaveLength(1)
+  })
+
+  test('it is the top panel, so the caption sits above the whole stack', () => {
+    expect(autonomyBoundaryCaptionShown(0)).toBe(true)
+    expect(autonomyBoundaryCaptionShown(4)).toBe(false)
+  })
+
+  // The committed mutation: captioning every panel. It passes "a caption is
+  // drawn" and fails the thing that matters, which is that there is one.
+  test('production tells one caption from five', () => {
+    const captionEverywhere = () => true
+    expect([0, 1, 2, 3, 4].filter(captionEverywhere)).toHaveLength(5)
+    expect([0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)).toHaveLength(1)
   })
 })

--- a/platforms/web/irrlicht.history.autonomy.measurement.test.js
+++ b/platforms/web/irrlicht.history.autonomy.measurement.test.js
@@ -7,8 +7,10 @@ import { autonomyMeasurementNote } from './historyTab.js'
 //
 // Two kinds, and they are two different limits:
 //
-//   - STILL RUNNING — the run has not ended, so its length is unknowable. Shown
-//     on the strip, deliberately absent from the percentiles.
+//   - STILL RUNNING — the run has not ended, so its length is how long it has
+//     lasted SO FAR. It COUNTS towards the longest run (the section reports a
+//     maximum, and "already lasted 3h" is true) and is marked "still going"
+//     rather than presented as final.
 //   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
 //     start is where Irrlicht began watching. Those ARE samples; dropping them
 //     is what left 5 of a day's 35 runs on the record.
@@ -28,14 +30,18 @@ describe('autonomyMeasurementNote', () => {
     expect(autonomyMeasurementNote(undefined)).toBe('')
   })
 
-  // A running run is SHOWN and left OUT of the percentiles, and the sentence
-  // has to say both — otherwise a reader who can see a 3-hour run on the strip
-  // is left wondering why the median did not move.
-  test('a running run is named as still going AND as absent from the percentiles', () => {
+  // A running run COUNTS towards the longest and is MARKED, and the sentence
+  // has to say both — otherwise a reader who can see "longest 3h" beside a
+  // project is left unsure whether that figure is finished.
+  test('a running run is named as still going AND as counted', () => {
     const line = autonomyMeasurementNote(payload({ running: 1 }))
     expect(line).toContain('1 run is still going')
     expect(line).toContain('SO FAR')
-    expect(line).toContain('left out of the percentiles')
+    expect(line).toContain('counts towards the longest run')
+    expect(line).toContain('still going')
+    // The percentile-era wording must be gone with the percentiles: a sentence
+    // claiming an exclusion that no longer happens is a wrong number's alibi.
+    expect(line).not.toContain('percentile')
   })
 
   test('an unmeasured start says which end of the run is the estimate', () => {
@@ -44,8 +50,8 @@ describe('autonomyMeasurementNote', () => {
     expect(line).toContain('not when the run began')
     expect(line).toContain('minimums')
     // It must NOT claim those runs were dropped from the figures: they are
-    // finished runs and they are samples.
-    expect(line).not.toContain('left out of the percentiles')
+    // finished runs and they are counted.
+    expect(line).not.toContain('counts towards the longest run')
   })
 
   test('both at once read as two separate facts', () => {

--- a/platforms/web/irrlicht.history.autonomy.subagents.test.js
+++ b/platforms/web/irrlicht.history.autonomy.subagents.test.js
@@ -16,7 +16,6 @@ import { autonomyCountingLine, autonomyQuery } from './historyTab.js'
 
 const state = (over = {}) => ({
   autonomyRange: '30d',
-  autonomySpan: '24h',
   ...over,
 })
 
@@ -28,20 +27,17 @@ describe('autonomyQuery — no run-scope parameter reaches the daemon', () => {
   // "wrong number with nothing on screen saying so" the section exists to
   // avoid. So the query is exactly the chart and its window, and nothing else.
   test('the query is the chart and its window, and nothing else', () => {
-    expect(autonomyQuery('duration', state())).toBe('chart=autonomy_duration&window=30d')
-    expect(autonomyQuery('spans', state())).toBe('chart=autonomy_spans&window=24h')
+    expect(autonomyQuery(state())).toBe('chart=autonomy_projects&window=30d')
   })
 
   test('no leftover state key can revive the parameter', () => {
     // The mutation this catches: a stale `autonomyRuns` left in local state (a
     // stored preference, a resumed session) silently re-filtering the view.
     const s = state({ autonomyRuns: 'all' })
-    expect(autonomyQuery('duration', s)).not.toContain('include_subagents')
-    expect(autonomyQuery('spans', s)).not.toContain('include_subagents')
-    // …and neither element loses its own window: the two vocabularies are
-    // different sets and neither endpoint accepts the other's keys.
-    expect(autonomyQuery('duration', s)).toContain('window=30d')
-    expect(autonomyQuery('spans', s)).toContain('window=24h')
+    expect(autonomyQuery(s)).not.toContain('include_subagents')
+    // …and the window survives: the section has one, and it is not one of
+    // chart=state's same-looking granularity keys.
+    expect(autonomyQuery(s)).toContain('window=30d')
   })
 })
 
@@ -69,6 +65,17 @@ describe('the Runs control is gone from the markup and the wiring', () => {
     expect(js).not.toContain('history-autonomy-runs-sel')
     expect(js).not.toContain('autonomyRuns')
     expect(js).not.toContain('include_subagents')
+  })
+
+  // The Span picker went with the run strip it governed (#1905 redesign). Same
+  // two-file rule: markup without wiring is a control that does nothing, and
+  // wiring without markup is a listener on a state key no request reads.
+  test('no Span fieldset, buttons or wiring survive either', () => {
+    expect(html).not.toContain('history-autonomy-span-sel')
+    expect(html).not.toContain('data-autonomy-span')
+    expect(js).not.toContain('history-autonomy-span-sel')
+    expect(js).not.toContain('autonomySpan')
+    expect(js).not.toContain('AUTONOMY_SPAN_LABELS')
   })
 })
 
@@ -108,6 +115,9 @@ describe('autonomyCountingLine — the panel states what it counted', () => {
     const line = autonomyCountingLine({ kinds: kinds({ subagent: 3, unknown: 8148 }) })
     expect(line).toContain('8148 runs were recorded before Irrlicht told')
     expect(line).toContain('counted either way')
+    // …and the clause now carries its consequence for the concurrency figure:
+    // a peak one of those runs was alive for cannot be split.
+    expect(line).toContain('no split')
   })
 
   test('a window with no unknown runs says nothing about them', () => {

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -2,169 +2,255 @@ import { describe, test, expect } from 'vitest'
 
 import {
   AUTONOMY_RANGE_LABELS,
-  AUTONOMY_SPAN_LABELS,
-  AUTONOMY_REASON_PRIORITY,
-  AUTONOMY_SERIES,
-  AUTONOMY_BAND_TOKENS,
+  AUTONOMY_MARK_TOKENS,
+  AUTONOMY_BOUNDARY_CAPTION_PANEL,
+  AUTONOMY_CONCURRENCY_CAVEAT,
   autonomyQuery,
-  autonomyChartPoints,
-  autonomyBandSegments,
+  autonomyPanelPoints,
+  autonomyLineSegments,
+  autonomyYDomain,
+  autonomyYAt,
+  autonomyPeakScale,
+  autonomyConcurrencyLabel,
+  autonomyPanelHeadline,
+  autonomyMoreProjectsLabel,
+  autonomyBoundaryCaptionShown,
+  autonomyBoundaryLabel,
+  autonomyVisibleBoundaries,
   autonomyDuration,
   autonomyProvenanceLine,
   autonomyAxisLabel,
-  autonomySeriesColor,
-  autonomySeriesRole,
-  autonomyBandColor,
+  autonomyKeyColor,
   autonomyKeyEntries,
   autonomyPanelRows,
-  buildAutonomyStripHeader,
-  buildAutonomyStripAxis,
-  collapseAutonomyStrip,
+  buildAutonomyAxis,
 } from './historyTab.js'
-import { historyPriorityForState } from './irrlicht.js'
 
-// The Autonomy section (#1905): the strip's pixel-collapse rule, the
-// gap-not-zero rule, the two window vocabularies staying distinct, and the
-// wording that keeps an empty view from reading as "you did nothing".
+// The Autonomy section (#1905), redesigned: five per-project panels, each a
+// longest-run line over a concurrency histogram.
+//
+// What these pin is the set of claims the panels make about data they cannot
+// show in full — the gap rule on BOTH marks, the shared axis that makes five
+// panels comparable, the split that is only ever shown where the data supports
+// one, and the wording that keeps an empty view from reading as "you did
+// nothing".
 
-const span = (start, end, reason, project = 'p') => ({ start, end, reason, project, session: 's' + start })
-
-describe('collapseAutonomyStrip — the pixel-collapse rule', () => {
-  // Every span draws at a minimum of one column. At 12mo a 40-second run is
-  // far under one device pixel; rounding it away would erase exactly the short
-  // runs the p5 line is about.
-  test('a sub-pixel run still occupies exactly one column', () => {
-    const cells = collapseAutonomyStrip([span(50_000, 50_001, 'ready')], 0, 100_000, 10)
-    expect(cells).toHaveLength(10)
-    const occupied = cells.filter(c => c.occupied)
-    expect(occupied).toHaveLength(1)
-    expect(occupied[0].reason).toBe('ready')
-  })
-
-  test('a shared column takes the highest-priority reason, whatever the order', () => {
-    // One state per line: a line naming three of the four canonical states is
-    // what tools/state-vocabulary-lint.sh refuses, and rightly — such a list is
-    // complete when written and silently stale one state later.
-    const spans = [
-      span(1_000, 1_100, 'ready'),
-      span(1_200, 1_300, 'error'),
-      span(1_400, 1_500, 'waiting'),
-    ]
-    expect(collapseAutonomyStrip(spans, 0, 100_000, 10)[0].reason).toBe('error')
-    expect(collapseAutonomyStrip([...spans].reverse(), 0, 100_000, 10)[0].reason).toBe('error')
-    // …and without the error, waiting beats ready.
-    const noError = [span(1_000, 1_100, 'ready'), span(1_400, 1_500, 'waiting')]
-    expect(collapseAutonomyStrip(noError, 0, 100_000, 10)[0].reason).toBe('waiting')
-  })
-
-  test('the ladder matches the session-history strip’s', () => {
-    // Two hand-written copies of one ORDER (the bar also ranks `working`,
-    // which is never an end reason, so only the order can be compared).
-    const ordered = Object.keys(AUTONOMY_REASON_PRIORITY)
-      .sort((a, b) => AUTONOMY_REASON_PRIORITY[b] - AUTONOMY_REASON_PRIORITY[a])
-    expect(ordered[0]).toBe('error')
-    expect(ordered[1]).toBe('waiting')
-    expect(ordered[2]).toBe('ready')
-    expect(ordered).toHaveLength(3)
-    for (let i = 1; i < ordered.length; i++) {
-      expect(historyPriorityForState(ordered[i - 1]))
-        .toBeGreaterThan(historyPriorityForState(ordered[i]))
-    }
-  })
-
-  test('a long run covers every column it spans', () => {
-    const cells = collapseAutonomyStrip([span(0, 50_000, 'waiting')], 0, 100_000, 10)
-    expect(cells.filter(c => c.occupied)).toHaveLength(6)
-  })
-
-  test('runs outside the window are clipped, not drawn', () => {
-    const before = collapseAutonomyStrip([span(-5_000, -1_000, 'ready')], 0, 100_000, 10)
-    expect(before.some(c => c.occupied)).toBe(false)
-    const straddling = collapseAutonomyStrip([span(-5_000, 10_000, 'ready')], 0, 100_000, 10)
-    expect(straddling[0].occupied).toBe(true)
-    expect(straddling[5].occupied).toBe(false)
-  })
-
-  test('an unnamed reason still occupies its column and never outranks a real one', () => {
-    const unknown = span(10, 20, 'martian')
-    const cells = collapseAutonomyStrip([unknown], 0, 100, 10)
-    expect(cells[1].occupied).toBe(true)
-    expect(cells[1].reason).toBe(null)
-    expect(collapseAutonomyStrip([unknown, span(11, 19, 'error')], 0, 100, 10)[1].reason).toBe('error')
-  })
-
-  test('degenerate inputs produce no columns', () => {
-    expect(collapseAutonomyStrip([], 0, 0, 10)).toEqual([])
-    expect(collapseAutonomyStrip([], 0, 100, 0)).toEqual([])
-  })
+// bucket builds one panel bucket. `longest` 0 means "no run ended here";
+// `peak` 0 means "nobody was working here".
+const bucket = (ts, longest, peak, extra = {}) => ({ ts, longest, peak, peak_top: 0, peak_sub: 0, ...extra })
+const panel = (project, buckets, extra = {}) => ({
+  project, buckets, longest: 0, total_seconds: 0, runs: buckets.length,
+  peak: 0, peak_top: 0, peak_sub: 0, ...extra,
 })
 
-describe('autonomyChartPoints — an empty bucket is a gap, not a zero', () => {
-  // The daemon omits empty buckets; the client must keep them absent so the
-  // stroke BREAKS there. Interpolating (or substituting a zero) would pull the
-  // line to the axis on a day with no runs, which reads as "runs got shorter".
-  test('omitted buckets come back as nulls aligned to the axis', () => {
-    const points = autonomyChartPoints({
-      bucket_starts: [100, 200, 300, 400],
-      buckets: [
-        { ts: 100, p95: 90, p50: 50, p5: 10, min: 10, max: 90, count: 30 },
-        { ts: 400, p95: 80, p50: 40, p5: 8, min: 8, max: 80, count: 25 },
-      ],
-    })
-    expect(points).toHaveLength(4)
-    expect(points[0]).not.toBeNull()
+describe('a bucket with no runs is a gap, not a zero', () => {
+  // The honesty rule, and it now binds TWO marks rather than one: the line has
+  // to break, and the histogram has to draw nothing. A zero-height bar sitting
+  // on the axis looks measured; a zero point pulls the line down to it.
+  const starts = [100, 200, 300, 400, 500]
+
+  test('an omitted bucket becomes a null, aligned to bucket_starts', () => {
+    const points = autonomyPanelPoints(panel('p', [bucket(100, 60, 1), bucket(400, 90, 2)]), starts)
+    expect(points).toHaveLength(5)
+    expect(points[0].longest).toBe(60)
     expect(points[1]).toBeNull()
     expect(points[2]).toBeNull()
-    expect(points[3]).not.toBeNull()
-
-    // THE COMMITTED MUTATION: the "just densify with zeros" build. If
-    // production ever did this, a quiet day would draw a point at the floor
-    // instead of a break in the line — and this expectation is what fails.
-    const densified = points.map(b => b || { ts: 0, p95: 0, p50: 0, p5: 0, min: 0, max: 0, count: 0 })
-    expect(densified.filter(b => b.count === 0)).toHaveLength(2)
-    expect(points.filter(b => b === null)).toHaveLength(2)
+    expect(points[3].longest).toBe(90)
+    expect(points[4]).toBeNull()
   })
 
-  test('a fully populated range has no gaps', () => {
-    const points = autonomyChartPoints({
-      bucket_starts: [1, 2],
-      buckets: [{ ts: 1, p50: 5 }, { ts: 2, p50: 6 }],
-    })
-    expect(points.every(Boolean)).toBe(true)
+  test('the line breaks at a gap instead of spanning it', () => {
+    const points = autonomyPanelPoints(panel('p', [bucket(100, 60, 1), bucket(400, 90, 2)]), starts)
+    // The MUTATION this refuses: `points.filter(Boolean)`, a dense list in
+    // which the gap simply is not there and the stroke runs straight across.
+    const dense = points.filter(Boolean)
+    expect(autonomyLineSegments(dense)).toEqual([{ from: 0, to: 1 }])
+    expect(autonomyLineSegments(points)).toEqual([{ from: 0, to: 0 }, { from: 3, to: 3 }])
   })
 
-  test('a missing payload is an empty axis, not a crash', () => {
-    expect(autonomyChartPoints(null)).toEqual([])
-    expect(autonomyChartPoints({})).toEqual([])
+  test('a bar is drawn only where somebody was working', () => {
+    const points = autonomyPanelPoints(panel('p', [bucket(100, 60, 2), bucket(400, 90, 0)]), starts)
+    const drawn = points.map(p => (p && Number(p.peak) > 0 ? p.peak : null))
+    expect(drawn).toEqual([2, null, null, null, null])
+  })
+
+  test('a run that passed through breaks the line but keeps its bar', () => {
+    // A bucket a long run merely crossed: something WAS working, nothing
+    // finished. Two true facts, and neither may be borrowed for the other.
+    const points = autonomyPanelPoints(
+      panel('p', [bucket(100, 60, 1), bucket(200, 0, 3), bucket(300, 90, 1)]), starts)
+    expect(autonomyLineSegments(points)).toEqual([{ from: 0, to: 0 }, { from: 2, to: 2 }])
+    expect(points[1].peak).toBe(3)
+  })
+
+  test('an empty panel has no segments at all', () => {
+    expect(autonomyLineSegments(autonomyPanelPoints(panel('p', []), starts))).toEqual([])
+    expect(autonomyLineSegments(null)).toEqual([])
   })
 })
 
-describe('the two window vocabularies stay distinct', () => {
+describe('the five panels share one log Y axis', () => {
+  // Shared, so the projects are comparable — that is the point of picking
+  // five. Log, because a project whose best is two minutes would otherwise be
+  // a flat line under one whose best is eleven hours.
+  const panels = [
+    panel('big', [bucket(1, 41_940, 5)]),   // 11h39m
+    panel('small', [bucket(1, 120, 1)]),    // 2m
+  ]
+
+  test('the domain spans every panel, not just the one being drawn', () => {
+    const domain = autonomyYDomain(panels)
+    expect(domain.lo).toBeLessThanOrEqual(120)
+    expect(domain.hi).toBeGreaterThanOrEqual(41_940)
+  })
+
+  test('the same duration lands at the same height in every panel', () => {
+    // The MUTATION this refuses: a per-panel domain. Under it `small`'s own
+    // 120s would sit at the top of its plot while `big`'s 120s sat near the
+    // bottom, and the five panels would not be comparable at all.
+    const shared = autonomyYDomain(panels)
+    const perPanel = autonomyYDomain([panels[1]])
+    expect(autonomyYAt(120, shared, 32)).toBeCloseTo(autonomyYAt(120, shared, 32))
+    expect(autonomyYAt(120, perPanel, 32)).not.toBeCloseTo(autonomyYAt(120, shared, 32))
+  })
+
+  test('a log axis keeps a two-minute project off the floor', () => {
+    const domain = autonomyYDomain(panels)
+    const y = autonomyYAt(120, domain, 32)
+    // Linear, 120 of 41 940 would be 0.3% of the plot height — indistinguishable
+    // from the axis itself.
+    expect(y).toBeLessThan(32 * 0.997)
+    expect(y).toBeGreaterThan(0)
+  })
+
+  test('an empty window has no domain rather than a fabricated one', () => {
+    expect(autonomyYDomain([])).toBeNull()
+    expect(autonomyYDomain([panel('p', [bucket(1, 0, 2)])])).toBeNull()
+  })
+
+  test('the histogram scale is shared too, and absent when nothing overlapped', () => {
+    expect(autonomyPeakScale(panels)).toBe(5)
+    expect(autonomyPeakScale([panel('p', [bucket(1, 60, 0)])])).toBe(0)
+  })
+})
+
+describe('the concurrency figure, and the split it may not invent', () => {
+  test('a derivable split is spelled out beside the total', () => {
+    expect(autonomyConcurrencyLabel(5, 3, 2, true)).toBe('5 at once (3 + 2 sub)')
+  })
+
+  test('an underivable split shows the total alone', () => {
+    // Most rows before 18 Aug 2026 carry `kind: unknown`; there is no way to
+    // recover which they were, and "5 (5 + 0 sub)" would be an invented answer.
+    expect(autonomyConcurrencyLabel(5, 0, 0, false)).toBe('5 at once')
+    expect(autonomyConcurrencyLabel(5, 0, 0, false)).not.toMatch(/sub/)
+  })
+
+  test('a window nobody overlapped in says nothing at all', () => {
+    expect(autonomyConcurrencyLabel(0, 0, 0, true)).toBe('')
+  })
+
+  test('the caveat is on screen, and says what the number is not', () => {
+    // The number is otherwise misread: a parent is held `working` while its
+    // subagents run, so one agent with three subagents reads as four at once.
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/parent/i)
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/subagents/i)
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/not four independent agents/i)
+  })
+})
+
+describe('a panel states its own two figures in its header', () => {
+  test('longest and at-once, in the order the sketch has them', () => {
+    expect(autonomyPanelHeadline({ longest: 41_940, peak: 5, peak_top: 3, peak_sub: 2, peak_split: true }))
+      .toBe('longest 11h39m · 5 at once (3 + 2 sub)')
+  })
+
+  test('a still-running longest run is marked, not dropped', () => {
+    const head = autonomyPanelHeadline({ longest: 10_800, longest_running: true, peak: 1, peak_split: false })
+    expect(head).toMatch(/longest 3h/)
+    expect(head).toMatch(/still going/)
+  })
+
+  test('a project nobody overlapped in still states its longest', () => {
+    expect(autonomyPanelHeadline({ longest: 600, peak: 0 })).toBe('longest 10m')
+  })
+})
+
+describe('the five-panel stack names what it left out', () => {
+  test('the overflow line says how many projects and why they are the ones missing', () => {
+    const label = autonomyMoreProjectsLabel({ more_projects: 7 })
+    expect(label).toBe('+7 more projects, each with less autonomous time')
+  })
+
+  test('one hidden project is singular', () => {
+    expect(autonomyMoreProjectsLabel({ more_projects: 1 })).toMatch(/^\+1 more project,/)
+  })
+
+  test('nothing is said when every project fits', () => {
+    expect(autonomyMoreProjectsLabel({ more_projects: 0 })).toBe('')
+    expect(autonomyMoreProjectsLabel(undefined)).toBe('')
+  })
+})
+
+describe('the source-boundary rule reads once across the stack', () => {
+  const data = {
+    bucket_starts: [1000, 2000, 3000, 4000],
+    provenance: { boundaries: [{ ts: 2500, from: 'cost', to: 'log' }] },
+  }
+
+  test('a boundary inside the drawn domain gets its x fraction', () => {
+    const visible = autonomyVisibleBoundaries(data)
+    expect(visible).toHaveLength(1)
+    expect(visible[0].fraction).toBeCloseTo(0.5)
+  })
+
+  test('a boundary on the axis itself is not drawn', () => {
+    // A rule on the first or last bucket marks nothing and reads as a border.
+    expect(autonomyVisibleBoundaries({
+      ...data, provenance: { boundaries: [{ ts: 1000, from: 'cost', to: 'log' }] },
+    })).toEqual([])
+    expect(autonomyVisibleBoundaries({
+      ...data, provenance: { boundaries: [{ ts: 4000, from: 'cost', to: 'log' }] },
+    })).toEqual([])
+  })
+
+  test('the caption is drawn on exactly one panel', () => {
+    // The rule runs through all five — it has to, or it annotates one project's
+    // line and leaves the four below it stepping for no stated reason — but
+    // five stacked copies of "← cost log · 60s resolution" would be five
+    // competing captions where the reader needs one.
+    const shown = [0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)
+    expect(shown).toEqual([AUTONOMY_BOUNDARY_CAPTION_PANEL])
+    expect(shown).toHaveLength(1)
+  })
+
+  test('the caption describes the era to the LEFT of the rule', () => {
+    // The arrow is load-bearing: without it the caption reads as a label for
+    // the line rather than for the data before it.
+    expect(autonomyBoundaryLabel({ from: 'cost' })).toBe('← cost log · 60s resolution')
+    expect(autonomyBoundaryLabel({ from: 'log' })).toMatch(/^← event log/)
+    expect(autonomyBoundaryLabel({ from: 'nonsense' })).toBe('← nonsense')
+    expect(autonomyBoundaryLabel({})).toMatch(/different source/)
+  })
+})
+
+describe('the window vocabulary stays distinct from chart=state’s', () => {
   // The trap #1905 calls out by name: chart=state's granularity keys and the
   // Autonomy windows OVERLAP textually and mean different things — a
-  // granularity is a bucket width times a count ('24h' → a 30-DAY window),
-  // an autonomy window IS the window.
-  test('each element sends its own ?window=, and neither is a granularity', () => {
-    const state = { autonomyRange: '1y', autonomySpan: '12mo' }
-    expect(autonomyQuery('duration', state)).toBe('chart=autonomy_duration&window=1y')
-    expect(autonomyQuery('spans', state)).toBe('chart=autonomy_spans&window=12mo')
+  // granularity is a bucket width times a count ('24h' → a 30-DAY window), an
+  // autonomy window IS the window.
+  test('the section sends one chart and one window', () => {
+    expect(autonomyQuery({ autonomyRange: '1y' })).toBe('chart=autonomy_projects&window=1y')
+    expect(autonomyQuery({ autonomyRange: '30d' })).toBe('chart=autonomy_projects&window=30d')
   })
 
-  test('the two pickers offer different sets, and neither is the granularity set', () => {
+  test('the picker offers two windows, neither of them a granularity key', () => {
     expect(Object.keys(AUTONOMY_RANGE_LABELS)).toEqual(['30d', '1y'])
-    expect(Object.keys(AUTONOMY_SPAN_LABELS)).toEqual(['8h', '24h', '7d', '30d', '12mo'])
-    // 12mo is the strip's own key and has no granularity twin; if it ever
-    // disappears, the vocabularies may have been merged.
-    expect(AUTONOMY_SPAN_LABELS['12mo']).toBeTruthy()
-    // The chart's range vocabulary must not silently gain the strip's keys.
-    expect(AUTONOMY_RANGE_LABELS['24h']).toBeUndefined()
-  })
-
-  test('a strip key is never sent to the duration chart', () => {
-    // The daemon 400s this pairing; the client must not be the thing that
-    // constructs it in the first place.
-    expect(autonomyQuery('duration', { autonomyRange: '30d', autonomySpan: '8h' }))
-      .toBe('chart=autonomy_duration&window=30d')
+    // The run strip's own vocabulary went with the strip. If any of its keys
+    // reappears here, two textually-overlapping sets are back on one screen.
+    for (const stripKey of ['8h', '24h', '7d', '12mo']) {
+      expect(AUTONOMY_RANGE_LABELS[stripKey]).toBeUndefined()
+    }
   })
 })
 
@@ -182,295 +268,98 @@ describe('“no data” never reads as “you did nothing”', () => {
   })
 })
 
-describe('the chart is one hue in three weights', () => {
-  // The first round drew p95 green, p50 purple and p5 orange — three equally
-  // loud curves, and a key that had to be decoded before the chart said
-  // anything. It says one thing now: here is the typical run, and here is the
-  // spread around it. These pin that the collapse actually happened, in the
-  // one table both the canvas and the panel read.
-  //
+describe('the panels are one hue in two weights', () => {
   // `cs` here returns '' for every custom property, which is what an unstyled
-  // document (and jsdom) gives — so this exercises the fallback branch, the
-  // one a stylesheet-less render actually takes.
+  // document (and jsdom) gives — so this exercises the fallback branch, the one
+  // a stylesheet-less render actually takes.
   const unstyled = { getPropertyValue: () => '' }
 
   // rgb triple of a '#rrggbb' or 'rgba(r, g, b, a)' literal, as a string.
-  // Throws on anything else rather than returning a value nothing can trust:
-  // a colour this cannot parse is the last place to drop the comparison.
+  // Throws on anything else rather than returning a value nothing can trust: a
+  // colour this cannot parse is the last place to drop the comparison.
   const rgbOf = (color) => {
     const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color)
-    if (hex) return hex.slice(1).map(h => parseInt(h, 16)).join(',')
-    const fn = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(color)
-    if (fn) return fn.slice(1, 4).join(',')
-    throw new Error(`fail-loud: cannot read an rgb triple out of "${color}"`)
+    if (hex) return [1, 2, 3].map(i => parseInt(hex[i], 16)).join(',')
+    const rgba = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(color)
+    if (rgba) return [1, 2, 3].map(i => Number(rgba[i])).join(',')
+    throw new Error('unparseable colour: ' + color)
   }
 
-  test('every drawn line resolves to a non-empty colour', () => {
-    for (const [key] of AUTONOMY_SERIES) {
-      expect(autonomySeriesColor(key, unstyled)).toBeTruthy()
-    }
+  test('the bars are the line hue, not a second colour', () => {
+    expect(rgbOf(autonomyKeyColor('bars', unstyled))).toBe(rgbOf(autonomyKeyColor('line', unstyled)))
   })
 
-  // The inversion of the old `the three line colours are distinct`. Distinct
-  // hues are what the redesign removed: p95 and p5 are the two EDGES of one
-  // range, and a hue each made them read as two independent measurements.
-  test('the three lines share one colour, and roles carry the difference', () => {
-    const colors = AUTONOMY_SERIES.map(([key]) => autonomySeriesColor(key, unstyled))
-    expect(new Set(colors).size).toBe(1)
-    expect(AUTONOMY_SERIES.map(([key]) => autonomySeriesRole(key))).toEqual(['edge', 'line', 'edge'])
-    // Exactly one headline line, or "the typical run" is ambiguous.
-    expect(AUTONOMY_SERIES.filter(([, role]) => role === 'line')).toHaveLength(1)
+  test('the bars are quieter than the line', () => {
+    // A histogram at the line's full strength competes with the line above it;
+    // the bars are a second reading of the same activity, not a second subject.
+    const alpha = /rgba\([^)]*,\s*([\d.]+)\s*\)/.exec(AUTONOMY_MARK_TOKENS.bars[1])
+    expect(alpha).toBeTruthy()
+    expect(Number(alpha[1])).toBeLessThan(1)
   })
 
-  test('the series table covers exactly the three drawn lines', () => {
-    expect(AUTONOMY_SERIES.map(([key]) => key)).toEqual(['p95', 'p50', 'p5'])
+  test('a mark the panels do not draw has no colour to give it', () => {
+    expect(autonomyKeyColor('band', unstyled)).toBe('')
+    expect(autonomyKeyColor('p50', unstyled)).toBe('')
   })
 
-  test('a key that is not a drawn line gets no colour and no role', () => {
-    // longest/shortest/runs are FIGURES, not lines. A swatch for one of them
-    // would claim a curve the chart deliberately does not draw.
-    expect(autonomySeriesColor('longest', unstyled)).toBe('')
-    expect(autonomySeriesColor('p90', unstyled)).toBe('')
-    expect(autonomySeriesRole('p90')).toBe('')
-  })
-
-  test('a themed document wins over the fallback', () => {
-    const themed = { getPropertyValue: (name) => (name === '--working' ? ' #123456 ' : '') }
-    expect(autonomySeriesColor('p50', themed)).toBe('#123456')
-    expect(autonomySeriesColor('p95', themed)).toBe('#123456')
-  })
-
-  // The band is a WEIGHT of the line's hue, not a fourth colour. Were it an
-  // independent value, "one hue" would hold for the three strokes and quietly
-  // fail for the largest area of ink on the chart.
-  test('the band is the p50 hue, not a fourth colour', () => {
-    const line = rgbOf(autonomySeriesColor('p50', unstyled))
-    for (const name of Object.keys(AUTONOMY_BAND_TOKENS)) {
-      expect(rgbOf(autonomyBandColor(name, unstyled)), `${name} is a different hue from the p50 line`)
-        .toBe(line)
-    }
-  })
-
-  test('a band token that does not exist resolves to nothing', () => {
-    expect(autonomyBandColor('nope', unstyled)).toBe('')
-  })
-
-  test('a themed document wins over the band fallback too', () => {
-    const themed = { getPropertyValue: (name) => (name === '--autonomy-band' ? ' rgba(1, 2, 3, 0.5) ' : '') }
-    expect(autonomyBandColor('fill', themed)).toBe('rgba(1, 2, 3, 0.5)')
+  test('a live stylesheet wins over the fallback', () => {
+    const styled = { getPropertyValue: (n) => (n === '--working' ? ' #123456 ' : '') }
+    expect(autonomyKeyColor('line', styled)).toBe('#123456')
   })
 })
 
-describe('the key has two entries, and both come from the chart’s own tables', () => {
+describe('the key has two entries, and both stand for a mark on the panel', () => {
   const unstyled = { getPropertyValue: () => '' }
 
-  // Two entries because the chart draws two things. Three percentile swatches
-  // in one hue would promise a distinction the chart stopped making.
-  test('exactly two entries: a line and a band', () => {
+  test('one line and one row of bars, and nothing else', () => {
     const entries = autonomyKeyEntries(unstyled)
-    expect(entries).toHaveLength(2)
-    expect(entries.map(e => e.kind)).toEqual(['line', 'band'])
+    expect(entries.map(e => e.kind)).toEqual(['line', 'bars'])
+    for (const e of entries) expect(e.color).toBeTruthy()
   })
 
-  test('both entries resolve from the one colour table, never a second one', () => {
-    const drawn = new Set(AUTONOMY_SERIES.map(([key]) => autonomySeriesColor(key, unstyled)))
-    const band = new Set(Object.keys(AUTONOMY_BAND_TOKENS).map(n => autonomyBandColor(n, unstyled)))
-    for (const entry of autonomyKeyEntries(unstyled)) {
-      // `from` names a row of AUTONOMY_SERIES — not a label a caller invented.
-      expect(AUTONOMY_SERIES.some(([key]) => key === entry.from)).toBe(true)
-      expect(drawn.has(entry.color) || band.has(entry.color)).toBe(true)
-    }
-    const [line, area] = autonomyKeyEntries(unstyled)
-    expect(line.color).toBe(autonomySeriesColor('p50', unstyled))
-    expect(area.fill).toBe(autonomyBandColor('fill', unstyled))
-    expect(area.color).toBe(autonomyBandColor('edge', unstyled))
-    // A line has no area; a swatch with a fill would claim one.
-    expect(line.fill).toBe('')
-  })
-
-  test('a themed document moves the key with the chart', () => {
-    const themed = { getPropertyValue: (name) => (name === '--working' ? '#abcdef' : '') }
-    expect(autonomyKeyEntries(themed)[0].color).toBe('#abcdef')
-    expect(autonomyKeyEntries(themed)[0].color).toBe(autonomySeriesColor('p50', themed))
-  })
-
-  // Both labels name the percentile AND say what it means in words, because
-  // "p5–p95" is not a thing a reader who has never seen a percentile can read.
-  test('each entry names its percentiles and explains them in words', () => {
-    const [line, area] = autonomyKeyEntries(unstyled)
-    expect(line.label).toContain('p50')
-    expect(line.label).toContain('the typical run')
-    expect(area.label).toContain('p5')
-    expect(area.label).toContain('p95')
-    expect(area.label.replace(/p5|p95/g, '').trim().length).toBeGreaterThan(6)
+  test('the p50/band key went with the percentiles', () => {
+    const labels = autonomyKeyEntries(unstyled).map(e => e.label).join(' ')
+    expect(labels).not.toMatch(/p50|p95|p5\b|spread/)
+    expect(labels).toMatch(/longest run/)
+    expect(labels).toMatch(/at once/)
   })
 })
 
-describe('the panel keeps every figure the key stopped colouring', () => {
-  // THE ORIGINAL DEFECT still stands guard here: the panel used to build these
-  // rows and then set every dot to `transparent`, so the key existed in the
-  // markup and said nothing. Asserting on the resolver alone would not have
-  // caught that; these assert on the rows the panel actually renders.
-  const summary = { p95: 3600, p50: 600, p5: 30, min: 8, max: 7200, count: 312 }
-  const unstyledCS = { getPropertyValue: () => '' }
+describe('the side panel carries the window’s figures', () => {
+  const unstyled = { getPropertyValue: () => '' }
 
-  test('the two key rows carry a real swatch, and the band row carries a fill', () => {
-    const rows = autonomyPanelRows(summary, unstyledCS)
-    const keyed = rows.filter(r => r.kind)
-    expect(keyed.map(r => r.kind)).toEqual(['line', 'band'])
-    for (const row of keyed) {
-      expect(row.swatch).toBeTruthy()
-      expect(row.swatch).not.toBe('transparent')
-    }
-    expect(keyed[1].fill).toBeTruthy()
-    expect(keyed[0].fill).toBe('')
+  test('the two key rows carry the two headline numbers', () => {
+    const rows = autonomyPanelRows({ longest: 41_940, peak: 5, runs: 312, projects: 12 }, unstyled)
+    expect(rows[0].value).toBe('11h39m')
+    expect(rows[1].value).toBe('5')
+    expect(rows.map(r => r.label)).toContain('runs')
+    expect(rows.map(r => r.label)).toContain('projects')
   })
 
-  // The colours collapsed; the NUMBERS did not. All three percentiles are
-  // still on screen — p50 as the line row's value, p5 and p95 as the band's.
-  test('p50, p5 and p95 all still show their figures', () => {
-    const rows = autonomyPanelRows(summary, unstyledCS)
-    expect(rows[0].value).toBe(autonomyDuration(600))
-    expect(rows[1].value).toContain(autonomyDuration(30))
-    expect(rows[1].value).toContain(autonomyDuration(3600))
-  })
-
-  test('the figures stay unswatched — they are not marks', () => {
-    const figures = autonomyPanelRows(summary, unstyledCS).filter(r => !r.kind)
-    expect(figures.map(r => r.label)).toEqual(['longest', 'shortest', 'runs'])
-    for (const row of figures) expect(row.swatch).toBe('transparent')
-  })
-
-  test('an empty summary still produces the full panel', () => {
-    const rows = autonomyPanelRows(undefined, unstyledCS)
-    expect(rows).toHaveLength(5)
-    expect(rows[4].value).toBe('0')
-  })
-})
-
-describe('autonomyBandSegments — the plane breaks where the line breaks', () => {
-  const bucket = (ts, thin = false) => ({ ts, p95: 90, p50: 50, p5: 10, min: 10, max: 90, count: thin ? 3 : 30, thin })
-
-  // THE RULE A FILL WANTS TO BREAK. A line drawn across a gap interpolates; a
-  // polygon drawn across one paints a whole plane over days that hold no runs.
-  test('a segment never spans an empty bucket', () => {
-    const points = autonomyChartPoints({
-      bucket_starts: [100, 200, 300, 400, 500],
-      buckets: [{ ts: 100, p95: 90, p50: 50, p5: 10 }, { ts: 200, p95: 80, p50: 40, p5: 8 },
-                { ts: 400, p95: 70, p50: 30, p5: 6 }, { ts: 500, p95: 60, p50: 20, p5: 4 }],
-    })
-    const segments = autonomyBandSegments(points)
-    expect(segments.map(s => [s.from, s.to])).toEqual([[0, 1], [3, 4]])
-    // Stated as the property, not just the shape: no segment may contain the
-    // index of a bucket the daemon omitted.
-    for (const seg of segments) {
-      for (let i = seg.from; i <= seg.to; i++) expect(points[i]).not.toBeNull()
+  test('every key row has a real swatch colour', () => {
+    // The defect this pins: rows built and then every dot blanked, leaving
+    // marks on the canvas with no key at all.
+    for (const row of autonomyPanelRows({ longest: 60, peak: 1, runs: 1, projects: 1 }, unstyled)) {
+      if (row.kind) expect(row.swatch).toBeTruthy()
     }
   })
 
-  // THE COMMITTED MUTATION: the "one polygon over everything present" build —
-  // the shape a fill takes by default, and the shape that silently claims the
-  // gap. It answers identically for a gapped range and an unbroken one;
-  // production must not.
-  test('production tells a gapped range from an unbroken one', () => {
-    const gapped = autonomyChartPoints({
-      bucket_starts: [1, 2, 3],
-      buckets: [{ ts: 1, p95: 9, p50: 5, p5: 1 }, { ts: 3, p95: 9, p50: 5, p5: 1 }],
-    })
-    const whole = autonomyChartPoints({
-      bucket_starts: [1, 2, 3],
-      buckets: [{ ts: 1, p95: 9, p50: 5, p5: 1 }, { ts: 2, p95: 9, p50: 5, p5: 1 },
-                { ts: 3, p95: 9, p50: 5, p5: 1 }],
-    })
-
-    const bridging = (pts) => [{ from: 0, to: pts.length - 1, thin: false }]
-    expect(bridging(gapped)).toEqual(bridging(whole))
-
-    expect(autonomyBandSegments(whole)).toEqual([{ from: 0, to: 2, thin: false }])
-    expect(autonomyBandSegments(gapped)).not.toEqual(autonomyBandSegments(whole))
-    // The gapped range is TWO isolated buckets, and a bridging build would
-    // have drawn one plane straight over the empty day between them.
-    expect(autonomyBandSegments(gapped)).toEqual([
-      { from: 0, to: 0, thin: false },
-      { from: 2, to: 2, thin: false },
-    ])
+  test('a still-running longest run says so here too', () => {
+    const rows = autonomyPanelRows({ longest: 10_800, longest_running: true, runs: 1, projects: 1 }, unstyled)
+    expect(rows[0].value).toMatch(/still going/)
   })
 
-  // A thin bucket's p95 IS its maximum and its p5 IS its minimum. Inside one
-  // smooth plane that distinction disappears, so the plane splits there and
-  // the thin stretch is filled from its own fainter token.
-  test('a thin stretch is its own segment, and the seam is shared', () => {
-    const points = [bucket(1), bucket(2), bucket(3, true), bucket(4), bucket(5)]
-    const segments = autonomyBandSegments(points)
-    expect(segments.map(s => [s.from, s.to, s.thin])).toEqual([
-      [0, 1, false],
-      [1, 3, true],
-      [3, 4, false],
-    ])
-    // Adjacent segments SHARE their boundary index — a seam would show as a
-    // hairline crack down the band.
-    for (let i = 1; i < segments.length; i++) {
-      expect(segments[i].from).toBe(segments[i - 1].to)
-    }
-  })
-
-  test('a thin bucket makes both of its intervals thin, matching the dashed stroke', () => {
-    // The stroke dashes a segment either of whose ends is thin; the fill must
-    // split on the same rule or the dashes and the plane disagree.
-    const segments = autonomyBandSegments([bucket(1), bucket(2, true), bucket(3)])
-    expect(segments).toEqual([{ from: 0, to: 2, thin: true }])
-  })
-
-  test('an all-thin range is one faint segment, never mistaken for a measured one', () => {
-    const segments = autonomyBandSegments([bucket(1, true), bucket(2, true), bucket(3, true)])
-    expect(segments).toEqual([{ from: 0, to: 2, thin: true }])
-  })
-
-  // A lone bucket has no neighbour to make an area with. It is reported as a
-  // zero-width segment so the painter can draw its spread as a whisker rather
-  // than leaving the one bucket that most needs a range with none.
-  test('an isolated bucket is a zero-width segment, not a dropped one', () => {
-    const points = autonomyChartPoints({
-      bucket_starts: [1, 2, 3],
-      buckets: [{ ts: 2, p95: 9, p50: 5, p5: 1 }],
-    })
-    expect(autonomyBandSegments(points)).toEqual([{ from: 1, to: 1, thin: false }])
-  })
-
-  test('an empty or absent axis produces no segments at all', () => {
-    expect(autonomyBandSegments([])).toEqual([])
-    expect(autonomyBandSegments(null)).toEqual([])
-    expect(autonomyBandSegments([null, null])).toEqual([])
+  test('the figure rows stay unswatched', () => {
+    // A swatch would claim ink the panels deliberately do not lay down.
+    const rows = autonomyPanelRows({ longest: 60, peak: 1, runs: 4, projects: 2 }, unstyled)
+    for (const row of rows.filter(r => !r.kind)) expect(row.swatch).toBe('transparent')
   })
 })
 
-describe('the strip labels its value column and its window', () => {
-  test('the header names the value column', () => {
-    const head = buildAutonomyStripHeader()
-    expect(head.textContent).toContain('longest')
-    // Same grid as a data row, so the header lands over the column it names.
-    expect(head.className).toContain('history-autonomy-row')
-    expect(head.children).toHaveLength(3)
-  })
-
-  test('the axis states where the window starts and that it ends now', () => {
-    const now = Math.floor(Date.UTC(2026, 0, 9) / 1000)
-    const start = now - 7 * 86400
-    const axis = buildAutonomyStripAxis({ start, end: now })
-    const bounds = axis.querySelector('.history-autonomy-axis-bounds')
-    expect(bounds).toBeTruthy()
-    expect(bounds.children).toHaveLength(2)
-    expect(bounds.children[1].textContent).toBe('now')
-    // The left bound must be a HUMAN label, not the raw epoch seconds — the
-    // whole point is that a mark can be placed in time by reading it.
-    expect(bounds.children[0].textContent).toBe(autonomyAxisLabel(start, now - start))
-    expect(bounds.children[0].textContent).not.toContain(String(start))
-  })
-})
-
-describe('the strip states its own time bounds', () => {
-  // Without them the strip is texture: at 30d and 12mo a mark cannot be
-  // placed in time at all.
+describe('the stack states its own time bounds', () => {
+  // Without them the panels are texture: at 30d and 1y a mark cannot be placed
+  // in time at all. ONE axis under the whole stack, because the five panels
+  // share one x domain and five copies would be five statements of one fact.
   const jan2 = Date.UTC(2026, 0, 2, 15, 30) / 1000
 
   test('a short window labels a time of day, a long one a date', () => {
@@ -487,6 +376,15 @@ describe('the strip states its own time bounds', () => {
 
   test('a missing timestamp still renders something', () => {
     expect(autonomyAxisLabel(undefined, 86400)).toBeTruthy()
+  })
+
+  test('the axis names the window start on the left and now on the right', () => {
+    const now = Math.floor(Date.UTC(2026, 0, 9) / 1000)
+    const axis = buildAutonomyAxis({ start: now - 30 * 86400, end: now })
+    const bounds = [...axis.querySelectorAll('i')].map(i => i.textContent)
+    expect(bounds).toHaveLength(2)
+    expect(bounds[1]).toBe('now')
+    expect(bounds[0]).toMatch(/Dec/)
   })
 })
 

--- a/tools/autonomy-backfill/reconstruct_test.go
+++ b/tools/autonomy-backfill/reconstruct_test.go
@@ -280,13 +280,11 @@ func TestUnknownIsNotASessionState(t *testing.T) {
 			t.Fatal("AutonomyEndReasons() yields `unknown`")
 		}
 	}
-	// It also has to rank below every measured reason on the strip's collapse
-	// ladder, or one unknown span would grey out a column holding a real error.
-	for _, r := range session.AutonomyEndReasons() {
-		if session.AutonomyReasonPriority(session.AutonomyReasonUnknown) >= session.AutonomyReasonPriority(r) {
-			t.Fatalf("`unknown` outranks or ties %q on the collapse ladder", r)
-		}
-	}
+	// The rank it used to carry on the run strip's collapse ladder went with
+	// the strip (#1905 redesign): nothing renders an end reason any more, so
+	// there is no ordering left to check. What still has to hold — and is
+	// checked above — is that `unknown` stays OUTSIDE the vocabulary, so no
+	// consumer derived from it can start treating it as a fifth state.
 }
 
 // The cost era stops where the event log begins. The two sources must never


### PR DESCRIPTION
Rebuilds the History view's Autonomy section around the shape the maintainer
chose: **five per-project panels, one per project, stacked**, each carrying the
same two things — a **line** (the longest run in each time bucket) and, under
it, a low **histogram** (how many agents were working at the same time in that
bucket). Version one, per-project, for the five most important projects.

```
   irrlicht                              longest 11h39m · 5 at once (3 + 2 sub)

   4h ┤                       ╭╮
  30m ┤     ╭───╮   ╱─╲──╮   ╱  ╲     ╭───╮
   2m ┤  ╱─╯     ╰─╯      ╰──╯    ╰───╯     ╰──
       ░░▁▁▂▃▃▂▁░░▂▄▆█▆▄▂░░▁▂▃▄▄▃▂▁░░▁▂▃▅▅▃▁░
   … four more panels …
   +7 more projects, each with less autonomous time
   8/6                                                                   9/4
```

One request, one payload: `chart=autonomy_projects` replaces
`chart=autonomy_duration` and `chart=autonomy_spans`.

## What this deletes, and why

| Deleted | Why |
|---|---|
| p5–p95 band, p50 line, their two-entry key, `AUTONOMY_SERIES`, `AUTONOMY_BAND_TOKENS`, `autonomyBandSegments`, `AutonomyBandLayout`, `--autonomy-band{,-thin}`, `--autonomy-edge`, `IrrColors.autonomyBand{,Thin}`/`autonomyEdge` | The section reports the **longest** run now, so a percentile envelope has nothing left to describe. |
| The run strip: `collapseAutonomyStrip` / `AutonomyStripLayout`, end-reason colours, glyphs, legend, `AutonomyEndReason`, `AUTONOMY_REASON_PRIORITY`, and `session.AutonomyReasonPriority` + `autonomyPriority*` in the domain | Only `working` matters. The collapse ladder's own doc comment named it as the strip's; with the strip gone it had no production consumer left — only tests. |
| The sample floor (`autonomySampleFloor`, `sample_floor`, `thin`, the fainter plane / dashed edges / hollow points) | It existed because a p95 over four samples is that bucket's maximum wearing a percentile's name. A **maximum over one run is simply that run**, so the floor has nothing to protect. Not carried over as decoration. |
| The `Span` control (`AUTONOMY_SPAN_LABELS`, `HistoryAutonomySpanWindow`, `autonomySpanWindowSeconds`, both pickers' markup and wiring) | It governed the strip's window. One element, one window, one control — and no second vocabulary that overlaps `Range`'s textually (`30d` used to be both). |
| The 20 000-row read cap (`autonomySpanLimit`) | A concurrency peak from a clipped span list is wrong, silently, and always downwards. |

**`reason` stays a recorded field.** Nothing renders it; it costs one string per
row and it is the only fact about a run that cannot be recovered afterwards. Its
tests stay (`TestAutonomyReason_IsStillCarriedByEveryStoredSpan`, the vocabulary
tests in `core/domain/session`, the back-fill's `TestUnknownIsNotASessionState`).

## How concurrency is derived, and what it costs

From the **span log, by overlap** — never from `ConcurrencyTracker`. That tracker
reads the opt-in lifecycle recordings; a machine with no `recordings` directory
has a blank Agents chart and a complete span log at the same moment, so a
recordings-derived figure would be missing exactly where the rest of the section
is present, and a missing number that renders as zero is indistinguishable from a
measured one.

`core/cmd/irrlichd/history_autonomy_concurrency.go`:

- one sorted endpoint list per project, one linear sweep across the whole bucket
  row — **O(R log R) per project** for R runs (the sort), not O(buckets × runs);
- **half-open intervals**: ends applied before starts at the same instant, so a
  run that ends as the next begins is a handover, not an overlap. Getting that
  backwards would report every back-to-back turn as concurrency 2;
- **peak per bucket, never average.** Peak answers "how wide did I go"; an
  average over a day is dominated by the idle hours;
- the header's `at once` is the same sweep over the window as a single bucket, so
  the header can never contradict the bars below it;
- kind counters ride along, so the composition at the peak instant is read off
  the same pass. **The split is shown only when every run alive at the peak
  carried a known kind** — before 18 Aug 2026 most back-filled rows are
  `kind: unknown`, and the total is shown alone rather than a guess.

Verified against the real span log on this machine (`irrlicht`, last 7 days):
peak **5**, composition **4 top + 1 sub**, over 182 rows — matching the figure in
the brief. Reproduce:

```
python3 - <<'PY'
import json, time, collections
rows=[]; now=int(time.time()); start=now-7*86400
for line in open("<data-dir>/autonomy/irrlicht.jsonl"):
    r=json.loads(line); s,e=r.get("start",0),r.get("end",0)
    if start<=e<=now and e>s: rows.append((s,e,r.get("kind","")))
ev=sorted([(s,1,k) for s,_,k in rows]+[(e,-1,k) for _,e,k in rows], key=lambda x:(x[0],x[1]))
cur=collections.Counter(); peak=0; comp=None
for t,d,k in ev:
    cur[k if k in ("top","sub") else "unknown"]+=d
    if sum(cur.values())>peak: peak=sum(cur.values()); comp=dict(cur)
print(len(rows), peak, comp)
PY
```

**The caveat is on screen, not in a comment.** A parent is held `working` while
its subagents run, so one agent with three subagents reads as four at once — four
things really were working, but not four independent agents. The sentence says
so, and the `3 + 2 sub` split in each panel header is what makes the shape
legible. `AUTONOMY_CONCURRENCY_CAVEAT` / `AutonomyFormat.concurrencyCaveat` are
pinned by a test on both surfaces.

## Judgement calls implemented

- **Ranking is by total autonomous time**, not longest run — one lucky overnight
  run must not promote a project nobody has touched. `total_seconds` ships on
  every panel so the order can be checked rather than trusted.
- **Shared log Y across the five panels**, so they are comparable; each panel
  states its own longest as a number in its header, so the exact figure never
  depends on reading the axis. The histogram's full-height value is shared too.
- **A still-running run counts towards the longest and is marked** — "already
  lasted 3h" is true, unlike its old effect on a percentile. Marked three ways:
  `(still going)` in the panel header, a hollow point on the bucket, and the
  measurement sentence.
- **A gap is a gap on both marks.** A bucket with nothing in it is omitted by the
  daemon; the line breaks and no bar is drawn. A bucket a long run merely passed
  *through* carries a bar and no line point — two true facts, neither borrowed
  for the other.
- **The source-boundary rule reads once across the stack**: the dashed rule is
  drawn through *every* panel (they share one x domain, so all five step at the
  same instant — five simultaneous steps read as five findings when they are one
  change of instrument), and the caption is drawn on the **top panel only**.
- **The provenance sentence stays**, with the reconstructed counts, the
  still-running note and the counting line — whose `unknown` clause now also
  explains why a peak sometimes carries no split.

## How five panels fit each surface

- **Web** — the stack replaces the shared canvas *inside* the same chart card, the
  way the activity matrix does, so the `flex: 0 0 260px` side panel keeps its
  place beside it (it now holds the window-wide figures, the two-entry key, the
  caveat and the provenance paragraphs). A panel is 14 px header + 44 px canvas;
  five of those plus the `+N more` line and the axis run slightly past the 360 px
  card, so `.history-autonomy-panels` is `overflow: auto` and **scrolls**.
  Clipping was the one option that silently removes the row saying what was left
  out. The key labels are 22–23 chars against the 204 px a key row gets —
  `autonomyLayout.test.js` computes that budget from the stylesheet.
- **macOS** — 380 pt popover, and `HistoryView.content` is already a `ScrollView`,
  so the stack **scrolls** rather than compresses: a 58 pt panel (14 pt header +
  32 pt plot + 10 pt bars) × 5 = 290 pt, then the axis, key, caveat, summary row
  and provenance paragraphs. Compressing instead would leave a two-point-tall
  histogram — a smear — and the paragraphs that explain the figures are the last
  thing that may be clipped.

Both surfaces render exactly the panels the daemon sends (`panel_limit` is on the
wire); neither re-decides the count.

## What the `Span` control became

**Removed.** It governed the run strip's window and the strip is gone; keeping it
would leave a second window vocabulary on screen that overlaps `Range`'s
textually. `Range` (`30 days` / `Year`) is kept and now governs all five panels.
`irrlicht.history.autonomy.subagents.test.js` fails on a Span leftover in either
the markup or the wiring — markup without wiring is a control that does nothing;
wiring without markup is a listener on a state key no request reads.

## Mutation fixture per new check

Every check below was **seen red** by mutating what it protects, and each
mutation is committed as a fixture inside the test that would catch it.

| Check | Mutation, and where it lives |
|---|---|
| Concurrency peaks come from overlap and match a hand-built fixture | `meanConcurrency` in `TestAutonomyConcurrency_PeakFromOverlap` — the average the maintainer rejected. Also seen red by deleting the in-bucket max (reports carry-in only): `window peak = 0, want 3`. |
| A handover is not an overlap | `closedIntervals` in `TestAutonomyConcurrency_HandoverIsNotAnOverlap`. Flipping the tie ordering in production: `peak = 2 over two back-to-back runs, want 1`. |
| The subagent split appears only where `kind` is known | `unknownAsTopLevel` in `TestAutonomyConcurrency_SplitOnlyWhereKindIsKnown` + `TestAutonomy_BlankKindResolvesToUnknownNotTopLevel`. Counting unknown as top-level: `split reported as known (2 + 0 sub)`. |
| A gap breaks the line **and** the histogram | `denseBuckets` in `TestAutonomy_EmptyBucketIsAGapNotAZero`; `dense` in web's *"the line breaks at a gap"*; `testProductionTellsAGappedRangeFromAnUnbrokenOne` on macOS. Removing the omit branch: `bucket ts=… was emitted with longest=0 AND peak=0`. |
| Exactly the panels sent, with the `+N more` line | `clientCap` in web's *"the client renders what it was sent"* and macOS's `testTheClientRendersWhatItWasSentNeverItsOwnCount`; `neverSpeaks`/`alwaysSpeaks` in `testProductionTellsTheOverflowAndStraddlingFixturesApart`. |
| Ranking is by total autonomous time, not longest run | `byLongestRun` in `TestAutonomy_RanksByTotalTimeNotLongestRun` (`steady` 50 h total / 1 h longest vs `lucky` 11 h / 11 h). Ranking by longest in production: `panels ranked "lucky" first`. |
| A still-running run counts towards the longest | `excludeRunning` in `TestAutonomy_RunningRunIsTheLongestAndIsMarked`. Skipping running rows: `longest = 60, want 14400`. |
| The shared Y axis is shared | `testProductionTellsASharedDomainFromAPerPanelOne` (small panel first, so a first-panel-only mutation goes red here too). Reading only `panels.first`: red in both that test and `testTheYDomainSpansEveryPanel`. |
| The boundary caption is written once, not five times | `captionEverywhere` in web's and macOS's *"production tells one caption from five"*. |
| The deleted apparatus is really gone | `irrlicht.history.autonomy.backfill.test.js` greps the three shipped files for every removed identifier, with a positive control per file so "not found" cannot mean "mis-pathed". |
| The window vocabulary is not chart=state's | `mergedResolver` in `TestAutonomyWindows_AreNotHistoryGranularities`, now deriving the shared-key list by intersection and **failing loudly** when the intersection is empty. |

## Gates

`tools/preflight.sh --only <group>`, each its own foreground run:
`go` **PASS** · `web` **PASS** · `swift` **PASS** · `tools` **PASS** ·
`arch` **PASS** (composite 7.9330 → 7.9351, no category regression) ·
`skills` **PASS** · `posix` **PASS** · `bash` **PASS** · `security` **PASS**.
`--only linux` not run (opt-in, needs Docker).

Not merging — QA on the running app first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
