### PR TITLE
fix(rig): wire run-cell.sh to the teardown timings #1917 said it collected (#1828)

### DIFF
--- a/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
@@ -686,6 +686,46 @@ assert_eq "...with the maximum"      "15.0"     "$(jq -r '.max_s'  <<<"$TJ")"
 # without that distinction comes out tighter than the behaviour it describes.
 assert_eq "...and the censored rows counted apart" "1" "$(jq -r '.capped' <<<"$TJ")"
 
+
+echo "== both rigs actually SET the timings path and fold it in (#1828) =="
+# WHY THIS EXISTS, stated plainly: it was written after the hole it closes.
+# teardown_timings_json and require_tmux_session_gone were both covered above,
+# in isolation, and both passed — while run-cell.sh carried NO wiring at all.
+# A failed edit had left the rig untouched; `bash -n` passed, `git add` added an
+# unchanged file without complaint, and a live recording produced a manifest
+# with `teardown_timings: null` and no TSV. Every unit test was green over a
+# half-missing feature, because nothing asserted that the RIG holds up its end.
+#
+# This is a TEXTUAL check, and that is a real limit worth naming: it proves the
+# lines are present, not that they run. It would not catch a path set inside a
+# branch that never executes. What it does catch is the failure that actually
+# happened — the wiring silently absent — and that one is worth a grep.
+RIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The pre-creation reads differently in the two rigs — run-cell.sh has one
+# staging dir and exports the variable, run-cell-multi.sh creates one file per
+# adapter under $sub — so each carries its own needle rather than a loose
+# pattern that would match either by accident.
+for spec in \
+  'run-cell.sh|: >"$DRIVE_TEARDOWN_TIMINGS"' \
+  'run-cell-multi.sh|: >"$sub/teardown-timings.tsv"'
+do
+  rig="${spec%%|*}"; needle="${spec#*|}"
+  f="$RIG_DIR/$rig"
+  if [[ ! -r "$f" ]]; then
+    fail "$rig is readable" "a readable rig script at $f" \
+         "missing or unreadable — being unable to look must not read as agreement"
+    continue
+  fi
+  src="$(cat "$f")"
+  assert_contains "$rig sets DRIVE_TEARDOWN_TIMINGS" "DRIVE_TEARDOWN_TIMINGS=" "$src"
+  assert_contains "$rig pre-creates the file, so absent means the rig failed" \
+    "$needle" "$src"
+done
+# Only run-cell.sh writes the summary manifest the table will be read from.
+RC="$(cat "$RIG_DIR/run-cell.sh")"
+assert_contains "run-cell.sh folds the timings into its manifest" \
+  'teardown_timings_json "$DRIVE_TEARDOWN_TIMINGS"' "$RC"
+assert_contains "...under a manifest key of its own" "teardown_timings: \$teardown_timings" "$RC"
 if [[ "$fails" -eq 0 ]]; then
   echo "tmux-teardown-check_test: ALL PASS"
   exit 0

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -674,6 +674,24 @@ write_driver_env
 # Ctrl-C on the recording operator's terminal, to learn a pid the exec wrapper
 # hands over for free. The wrapper keeps the call in the foreground, in the same
 # process group, with the same stdin, argv and exit status as before.
+# Teardown timings (#1828 item 5). teardown.sh's require_tmux_session_gone
+# appends one row per exit_clean teardown when this path is set, so every
+# ordinary recording contributes a data point toward the per-adapter table
+# DRIVE_EXIT_CLEAN_CAP_S's own comment says it could not measure. Exported
+# rather than passed as an argument: nine drivers already call that poll, and
+# the environment reaches an adapter added tomorrow without touching this file.
+#
+# Pre-created empty, and that matters: teardown_timings_json reads an ABSENT
+# file as "the rig failed" and an EMPTY one as "this recipe tore nothing down".
+# Without the pre-creation those two collapse, and a staging dir nobody could
+# write to would report as a clean run with nothing to measure.
+DRIVE_TEARDOWN_TIMINGS="$STAGING/teardown-timings.tsv"
+export DRIVE_TEARDOWN_TIMINGS
+if ! : >"$DRIVE_TEARDOWN_TIMINGS" 2>/dev/null; then
+  echo "WARNING: could not create $DRIVE_TEARDOWN_TIMINGS — this run contributes" \
+       "no teardown timing (#1828). The recording itself is unaffected." >&2
+fi
+
 # BEGIN driver_pid_capture
 DRIVER_PID_FILE="$STAGING/driver.pid"
 set +e
@@ -1163,10 +1181,12 @@ jq -n \
   --arg driver_exit_reason "$DRIVER_REASON" \
   --arg daemon_shutdown "$(daemon_shutdown_state)" \
   --argjson timeout_seconds "$TIMEOUT_S" \
+  --argjson teardown_timings "$(teardown_timings_json "$DRIVE_TEARDOWN_TIMINGS")" \
   --arg execution_profile "$EXECUTION_PROFILE" \
   --arg desktop_versions "$STAGING/desktop.versions.json" \
   --arg execution_results "$STAGING/execution-results.json" \
   '{adapter: $adapter,
+    teardown_timings: $teardown_timings,
     scenario: $scenario,
     session_uuid: $session_uuid,
     verdict: "STAGED",


### PR DESCRIPTION
Follow-up to #1917, which merged half-wired.

## The defect

#1917 added teardown-timing collection (item 5 of #1828) and stated that both
rigs set `$DRIVE_TEARDOWN_TIMINGS`. `run-cell-multi.sh` does. `run-cell.sh`
never did.

```
$ git show origin/main:tools/onboarding-factory/scripts/run-cell.sh | grep -c DRIVE_TEARDOWN_TIMINGS
0
```

So on main today every `run-cell.sh` recording writes `teardown_timings: null`
and no TSV. It is inert rather than harmful — nothing else reads the field — but
the feature does nothing on the primary rig.

## Why nothing caught it

This is the part worth reading. A scripted edit aborted on an ambiguous anchor
before writing the file, and every signal that could have said so stayed quiet:

- `bash -n` passed, as it always would for an unmodified file.
- `git add <path>` added an unchanged file without complaint.
- Every test covered `teardown_timings_json` and `require_tmux_session_gone`
  **in isolation**. Both were genuinely correct. Nothing asserted that the RIG
  sets the path or folds the field.

All gates green over a half-missing feature. It surfaced only when a live
recording produced a manifest with a null field.

So this PR adds the wiring **and** a contract check over both rig scripts. The
check is textual and its own comment says so: it proves the lines are present,
not that they run, and would miss a path set inside a branch that never
executes. It does catch the failure that actually happened, which is the one
that got through.

## Evidence

Mutation against the real defect, not a synthetic one — removing only the wiring
from this file fails exactly the four rig assertions and nothing else:

```
FAIL: run-cell.sh sets DRIVE_TEARDOWN_TIMINGS
FAIL: run-cell.sh pre-creates the file, so absent means the rig failed
FAIL: run-cell.sh folds the timings into its manifest
FAIL: ...under a manifest key of its own
```

Confirmed live, before and after, coexisting with the production daemon on an
isolated port (`IRRLICHT_ONBOARD_BIND_ADDR=127.0.0.1:7841`):

| | `run-cell.sh claudecode 1-2_session-end` |
|---|---|
| before | `teardown_timings: null`, no TSV |
| after | `{"status":"recorded","rows":1,"capped":0,"max_s":0.6}` |

Raw row: `claudecode-onboard-1788651426-69214  0.6  observed`

**First data point toward the table item 5 exists for.** claudecode's
`exit_clean` teardown settled in 0.6 s against a 15 s cap. One observation on an
unloaded host is not a fit, and 15 stays a bound until there is a tail worth
reading.

## Gates

`--only bash` PASS. `--only go` PASS on every gate except `core module tests`,
which failed on `kirocli`'s `TestRefreshReachesTheConfigOnlyThroughTheConsentGatedRepairPath`
with `kiro-cli agent create: signal: killed` at load average 18.4 — another
session was driving Claude Desktop recordings concurrently. That test shells out
to the real `kiro-cli` binary. It passes twice in a row with this change
applied, and this diff is two shell files no Go test reads. Environmental, not
this change — stated rather than waved away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01615niHdVNthGbskmVG4JVt
