### PR TITLE
feat(history): restore the aggregate percentile chart, and pick one project at a time (#1905)

### DIFF
--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -507,9 +507,10 @@ func historyChartKnown(w http.ResponseWriter, chart string) bool {
 	case "state":
 		// implemented (#981, the "Activity Matrix" — time-in-state, the
 		// optional second half of #751) — handled after range resolution below
-	case chartAutonomyProjects:
-		// implemented (#1905, the Autonomy section's per-project panels) — it
-		// brings its OWN ?window= vocabulary, resolved in resolveHistoryQuery
+	case chartAutonomyProjects, chartAutonomyDuration:
+		// implemented (#1905, the Autonomy section's two elements — the
+		// aggregate percentile chart and the per-project panels) — both bring
+		// the SAME ?window= vocabulary, resolved in resolveHistoryQuery
 	default:
 		http.Error(w, "unknown chart: "+chart, http.StatusBadRequest)
 		return false
@@ -717,7 +718,7 @@ func resolveHistoryWindow(w http.ResponseWriter, q url.Values, chart string) (ra
 		}
 		bs, s, e, known := resolveAutonomyWindow(window)
 		if !known {
-			http.Error(w, autonomyWindowError(), http.StatusBadRequest)
+			http.Error(w, autonomyWindowError(chart), http.StatusBadRequest)
 			return "", 0, 0, 0, false
 		}
 		return window, s, e, bs, true
@@ -829,6 +830,11 @@ func serveNonCostHistoryChart(w http.ResponseWriter, r *http.Request, hq history
 		// history_autonomy_concurrency.go for why the concurrency figure is
 		// derived from those same spans rather than from ConcurrencyReader.
 		serveHistoryAutonomyProjectsChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
+	case chartAutonomyDuration:
+		// The same section's aggregate element, over the same store and the
+		// same window (#1905) — see history_autonomy_duration.go for why a
+		// percentile over every project and a maximum over one are both needed.
+		serveHistoryAutonomyDurationChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
 	case "yield":
 		// A per-project aggregate over completed sessions, not a time series (#373).
 		writeHistoryJSON(w, buildYieldResponse(hq.rangeKey, hq.group, hq.start, hq.end, deps.sessions))

--- a/core/cmd/irrlichd/history_autonomy.go
+++ b/core/cmd/irrlichd/history_autonomy.go
@@ -8,29 +8,31 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
-// Autonomy (#1905) — the History view's own top-level section: FIVE PER-PROJECT
-// PANELS, one per project, stacked, each carrying the same two things.
+// Autonomy (#1905) — the History view's own top-level section: TWO ELEMENTS
+// over one data source, sharing one window vocabulary and one Range control.
 //
-//	A LINE — the longest run in each time bucket. Only `working` matters here;
-//	how a run ended is recorded but no longer drawn.
-//	A HISTOGRAM under it — how many runs were working AT THE SAME TIME in that
-//	bucket, derived from the span log by overlap.
+//	THE AGGREGATE CHART (chart=autonomy_duration, history_autonomy_duration.go)
+//	— p95/p50/p5 of run duration over EVERY project, with the plane between
+//	p95 and p5 filled as a band. "Is autonomy getting better across the
+//	machine."
+//	THE PROJECT PANELS (chart=autonomy_projects, this file) — per project, a
+//	LINE of the longest run in each time bucket and a HISTOGRAM under it of how
+//	many runs were working at the same time. "What did THIS project do." Only
+//	one panel is drawn at a time; the client picks which.
 //
-// WHAT THIS REPLACED, and why the replacement is smaller rather than richer:
+// The two are not redundant, and the reason is the shape of the figure. A
+// maximum over one project is that project's own story, and a maximum charted
+// across every project is a chart of whoever ran longest that day. A percentile
+// over the whole population is the trend, and a percentile over one project's
+// four runs is not a percentile. Each element carries the figure the other
+// cannot.
 //
-//   - The p5–p95 band and the p50 line are gone. The section reports the
-//     LONGEST run now, so a percentile envelope has nothing left to describe.
-//   - The per-project run strip, its end-reason colours and its legend are
-//     gone with them: the strip's whole subject was how a run ENDED.
-//   - The sample floor and the thin-bucket marking went with the percentiles.
-//     They existed because a p95 over four samples is not a percentile — it is
-//     that bucket's maximum wearing a percentile's name. A MAXIMUM over one run
-//     is simply that run, so there is nothing left for a floor to protect, and
-//     carrying it over as decoration would mark buckets whose figure is exact.
-//
-// `Reason` stays on the wire and in the store. Nothing renders it today; it
-// costs one string per row and it is the one field that cannot be recovered
-// after the fact, so it keeps being recorded.
+// WHAT IS STILL GONE. chart=autonomy_spans — the per-project run strip, its
+// end-reason colours, glyphs, legend and pixel-collapse ladder — stays deleted:
+// the section's subject is how LONG a run was, not how it ended. `Reason` stays
+// on the wire and in the store all the same. Nothing renders it today; it costs
+// one string per row and it is the one field that cannot be recovered after the
+// fact, so it keeps being recorded.
 //
 // Everything is served from the always-on span log (outbound.AutonomySpanStore),
 // never from the opt-in lifecycle recordings that back chart=agents/state — the
@@ -40,21 +42,23 @@ import (
 // missing exactly where this one is not.
 const chartAutonomyProjects = "autonomy_projects"
 
-// autonomyPanelCount is how many project panels the section draws.
+// autonomyPanelCount is how many project panels the daemon puts on the wire.
 //
-// FIVE, and the number is the design rather than a cap bolted onto an unbounded
-// list: the section is a per-project view of the five most important projects,
-// so the daemon computes five panels and says how many projects it left out.
-// Both clients draw what they are sent, which is why they cannot disagree about
-// how many panels a stack has (the run strip they replaced shipped twelve rows
-// on the web against six on macOS).
+// A SAFETY CAP, NOT A DESIGN. It was 5 when the section drew five panels
+// stacked; the client draws ONE at a time now and picks it from a dropdown, so
+// the daemon has to send every project the dropdown can offer or the picker
+// would be a list of five with the rest invisible. 200 is high enough that no
+// real machine reaches it (the reference machine's 1-year window holds 93
+// projects) and low enough that a pathological install cannot make the payload
+// unbounded. MoreProjects keeps counting anything past it, honestly, so a
+// machine that DOES reach it says so rather than silently truncating.
 //
-// "MOST IMPORTANT" IS GREATEST TOTAL AUTONOMOUS TIME IN THE WINDOW, never
-// longest single run: one lucky overnight run would otherwise promote a project
-// nobody has touched in a month over the one that has been working all week.
-// The rank is stated on the wire (historyAutonomyPanel.TotalSeconds) so it can
-// be checked rather than trusted.
-const autonomyPanelCount = 5
+// The panels stay RANKED — greatest total autonomous time in the window first,
+// never longest single run: one lucky overnight run would otherwise promote a
+// project nobody has touched in a month over the one that has been working all
+// week. Rank 1 is what a client defaults to, and each panel states its own
+// TotalSeconds so the ranking can be checked rather than trusted.
+const autonomyPanelCount = 200
 
 // autonomyWindowSpec pairs one Range's bucket width with its bucket count.
 //
@@ -69,20 +73,29 @@ type autonomyWindowSpec struct {
 	buckets       int64
 }
 
-// autonomyWindowSpecs is the section's Range vocabulary. Two ranges — the
-// section's only control now that the run strip's Span has gone with the strip.
+// autonomyWindowSpecs is the section's Range vocabulary — ONE table for BOTH
+// elements, and shared on purpose (#1905).
+//
+// The two charts are drawn one above the other over the same instants, so a
+// reader compares them by eye; two windows would let the aggregate show a month
+// while the panel below it showed a year, with nothing on screen saying they
+// disagreed. The run strip's separate Span vocabulary was exactly that failure
+// and went with the strip. 30 days is the floor: anything shorter has too few
+// spans per bucket for a percentile to mean anything.
 var autonomyWindowSpecs = map[string]autonomyWindowSpec{
 	"30d": {86400, 30},     // 30 daily buckets
 	"1y":  {7 * 86400, 52}, // 52 weekly buckets
 }
 
-// isAutonomyChart reports whether a ?chart= value is the Autonomy section's,
-// which resolves its window from ?window= instead of the usual ?range=/?bucket=
-// pair.
-func isAutonomyChart(chart string) bool { return chart == chartAutonomyProjects }
+// isAutonomyChart reports whether a ?chart= value is one of the Autonomy
+// section's two elements — both of which resolve their window from ?window=
+// instead of the usual ?range=/?bucket= pair.
+func isAutonomyChart(chart string) bool {
+	return chart == chartAutonomyProjects || chart == chartAutonomyDuration
+}
 
 // autonomyDefaultWindow is the ?window= value assumed when the client sends
-// none.
+// none. One value, because there is one vocabulary.
 func autonomyDefaultWindow() string { return "30d" }
 
 // resolveAutonomyWindow resolves ?window= into a trailing [start, end) window
@@ -96,9 +109,11 @@ func resolveAutonomyWindow(window string) (bucketSeconds, start, end int64, ok b
 	return spec.bucketSeconds, end - spec.bucketSeconds*spec.buckets, end, true
 }
 
-// autonomyWindowError is the 400 body for an unrecognized ?window=.
-func autonomyWindowError() string {
-	return "invalid window for chart=autonomy_projects: use 30d|1y"
+// autonomyWindowError is the 400 body for an unrecognized ?window=. It names
+// the chart that was asked for rather than the section, so a caller that sent
+// the wrong window to the right chart is told which request failed.
+func autonomyWindowError(chart string) string {
+	return "invalid window for chart=" + chart + ": use 30d|1y"
 }
 
 // historyAutonomyPanelBucket is one time bucket of one project's panel.
@@ -184,7 +199,8 @@ type historyAutonomyPanel struct {
 }
 
 // historyAutonomySummary is the window-wide figure row: the section's two
-// headline numbers across EVERY project, not just the five drawn.
+// headline numbers across EVERY project in the window, including any beyond the
+// panel cap and every one the reader has not selected.
 type historyAutonomySummary struct {
 	// Longest is the longest run anywhere in the window, and LongestProject
 	// names where it happened.
@@ -212,13 +228,19 @@ type historyAutonomyProjectsResponse struct {
 	BucketSeconds int64   `json:"bucket_seconds"`
 	BucketStarts  []int64 `json:"bucket_starts"`
 
-	// Panels are the five most important projects, most autonomous time first.
+	// Panels is EVERY project with a run in the window, most autonomous time
+	// first, up to autonomyPanelCount.
+	//
+	// Every one of them, because the client draws ONE at a time and offers the
+	// rest in a dropdown: a payload that carried only the top five would leave
+	// the picker unable to show a project the summary above it counts.
 	Panels []historyAutonomyPanel `json:"panels"`
-	// PanelLimit is how many panels the daemon draws — on the wire so a client
-	// renders what it was sent rather than re-deciding the number itself.
+	// PanelLimit is the safety cap the daemon applied — on the wire so a client
+	// reports what it was sent rather than re-deciding the number itself.
 	PanelLimit int `json:"panel_limit"`
 	// MoreProjects is how many projects the window holds beyond the panels, all
-	// of them with less autonomous time than every panel above.
+	// of them with less autonomous time than every panel above. 0 on every
+	// machine that stays under the cap, which is every machine seen so far.
 	MoreProjects int `json:"more_projects"`
 
 	Summary historyAutonomySummary `json:"summary"`
@@ -436,10 +458,11 @@ func serveHistoryAutonomyProjectsChart(w http.ResponseWriter, store outbound.Aut
 // nil store and writing a 500 on error. ok is false once it has written a
 // response.
 //
-// DELIBERATELY UNLIMITED. The run strip capped its read at 20 000 rows because
-// it drew one column per run and could not draw more than its own pixel width;
-// the panels reduce every run to two per-bucket figures, and a concurrency peak
-// computed from a clipped span list is simply wrong — silently, and always
+// DELIBERATELY UNLIMITED, and shared by both elements. The run strip capped its
+// read at 20 000 rows because it drew one column per run and could not draw more
+// than its own pixel width; both surviving elements reduce every run to a
+// per-bucket figure. A percentile computed from a clipped span list is wrong,
+// and a concurrency peak computed from one is wrong silently and always
 // downwards. A cap here would be a number nobody could check.
 func readAutonomySpans(w http.ResponseWriter, store outbound.AutonomySpanStore, q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, bool) {
 	if store == nil {
@@ -467,8 +490,8 @@ type autonomyProjectTotals struct {
 }
 
 // buildAutonomyProjectsResponse groups the window's spans by project, ranks the
-// projects by total autonomous time, and reduces the top autonomyPanelCount of
-// them to a panel each.
+// projects by total autonomous time, and reduces each of them — up to the
+// autonomyPanelCount safety cap — to a panel.
 func buildAutonomyProjectsResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyProjectsResponse {
 	n := 0
 	if bucketSeconds > 0 && end > start {
@@ -628,8 +651,9 @@ func autonomyBucketLongest(spans []outbound.AutonomySpan, start, bucketSeconds i
 	return longest, running
 }
 
-// autonomySummaryFrom reduces every project in the window — not just the five
-// drawn — to the section's two headline figures.
+// autonomySummaryFrom reduces every project in the window — including any past
+// the panel cap, and every one the reader is not currently looking at — to the
+// section's two headline figures.
 func autonomySummaryFrom(ranked []string, byProject map[string]*autonomyProjectTotals, start, end int64) historyAutonomySummary {
 	out := historyAutonomySummary{Projects: len(ranked)}
 	for _, project := range ranked {

--- a/core/cmd/irrlichd/history_autonomy_duration.go
+++ b/core/cmd/irrlichd/history_autonomy_duration.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"net/http"
+	"sort"
+
+	"irrlicht/core/pkg/stats"
+	"irrlicht/core/ports/outbound"
+)
+
+// Autonomy, element 1 (#1905) — THE AGGREGATE PERCENTILE CHART, over every
+// project at once: p95 / p50 / p5 of autonomous run duration per time bucket,
+// with the plane between p95 and p5 filled as a band.
+//
+// IT ANSWERS A DIFFERENT QUESTION FROM THE PROJECT PANEL BESIDE IT, which is
+// why both are on screen rather than one replacing the other. This chart asks
+// "is autonomy getting better ACROSS THE MACHINE" — a trend over the whole
+// population of runs, where one project's quiet fortnight cannot move the line
+// much. The panel asks "what did THIS project do", where a single run is the
+// whole story. A maximum answers the second and is useless for the first: the
+// longest run in a bucket is one run, so a per-project maximum charted over all
+// projects is a chart of whichever project had the longest run that day.
+//
+// It was deleted in #1919 and restored here at the maintainer's request. What
+// came back is exactly what went: the three percentiles, the translucent band,
+// ONE hue at three weights, the sample floor and its thin-bucket marking, and
+// the min/max/count figures that stay FIGURES rather than lines. What did NOT
+// come back is chart=autonomy_spans, the per-project run strip and its
+// end-reason colours — that stays deleted.
+//
+// Served from the always-on span log, like everything else in this section.
+const chartAutonomyDuration = "autonomy_duration"
+
+// autonomySampleFloor is the minimum number of spans a bucket needs before its
+// p95 and p5 are percentiles rather than restatements of its own max and min.
+//
+// It bites harder than a p90 would, which is why it exists at all: at n < 20
+// the R-7 p95 of a bucket interpolates within its top pair and the p5 within
+// its bottom pair, so the two outer lines collapse onto the min/max envelope
+// this chart explicitly rejected — three lines drawn from what are really two
+// points. A bucket under the floor is MARKED (see historyAutonomyBucket.Thin)
+// and drawn differently by both clients, never hidden and never smoothed:
+// hiding it would turn a low-activity day into a gap, which reads as "no runs",
+// which is a different and false claim.
+const autonomySampleFloor = 20
+
+// historyAutonomyBucket is one time bucket of the aggregate chart. Buckets with
+// no spans are OMITTED from the response entirely rather than sent with zeros —
+// a day with no runs is a gap, not a run of length zero, and a zero would pull
+// the line to the axis (the same rule appendSparsePoints applies to the cost
+// series). Count is therefore always ≥ 1 on a bucket that is present.
+type historyAutonomyBucket struct {
+	TS    int64   `json:"ts"`
+	P95   float64 `json:"p95"`
+	P50   float64 `json:"p50"`
+	P5    float64 `json:"p5"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
+	Count int     `json:"count"`
+	// Thin marks a bucket below autonomySampleFloor, whose p95/p5 are its own
+	// max/min. Both clients render such buckets visibly differently.
+	Thin bool `json:"thin,omitempty"`
+}
+
+// historyAutonomyDurationSummary is the window-wide figure row under the
+// aggregate chart: the drawn envelope's percentiles plus the true extremes,
+// which are figures and deliberately NOT lines (one overnight run would
+// otherwise redraw the whole Y scale and flatten every other bucket onto the
+// floor — an effect the switch to a LINEAR axis in #1905 makes stronger still,
+// see autonomyYAt on the web and the Y-scale comment on macOS).
+type historyAutonomyDurationSummary struct {
+	P95   float64 `json:"p95"`
+	P50   float64 `json:"p50"`
+	P5    float64 `json:"p5"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
+	Count int     `json:"count"`
+}
+
+// historyAutonomyDurationResponse is the chart=autonomy_duration payload.
+type historyAutonomyDurationResponse struct {
+	Window        string                         `json:"window"`
+	Chart         string                         `json:"chart"`
+	Start         int64                          `json:"start"`
+	End           int64                          `json:"end"`
+	BucketSeconds int64                          `json:"bucket_seconds"`
+	BucketStarts  []int64                        `json:"bucket_starts"`
+	Buckets       []historyAutonomyBucket        `json:"buckets"`
+	Summary       historyAutonomyDurationSummary `json:"summary"`
+	SampleFloor   int                            `json:"sample_floor"`
+	// EarliestSpan is the earliest span on record across the WHOLE log, not
+	// this window — 0 when nothing has ever been recorded. It is what lets both
+	// clients say "collecting since <date>" instead of leaving an empty chart to
+	// be read as "you did nothing" (#1905).
+	EarliestSpan  int64 `json:"earliest_span"`
+	TotalRecorded int   `json:"total_recorded"`
+	// Provenance marks how much of THIS window was reconstructed rather than
+	// measured (#1905 back-fill). Always present, zero-valued when the whole
+	// window was measured live.
+	Provenance historyAutonomyProvenance `json:"provenance"`
+	// Kinds says what this payload is made of, by run kind (#1905 subagents).
+	Kinds historyAutonomyKinds `json:"kinds"`
+	// Measurement says how many of the runs in view have a duration that is a
+	// floor rather than a measurement (#1905 recording).
+	Measurement historyAutonomyMeasurement `json:"measurement"`
+}
+
+// serveHistoryAutonomyDurationChart serves chart=autonomy_duration. A nil store
+// yields an empty-but-valid payload rather than an error, mirroring
+// serveHistoryAgentsChart.
+func serveHistoryAutonomyDurationChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64) {
+	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end})
+	if !ok {
+		return
+	}
+	writeHistoryJSON(w, buildAutonomyDurationResponse(window, bucketSeconds, start, end, res))
+}
+
+// buildAutonomyDurationResponse buckets the window's spans by the bucket their
+// END falls in, and reduces each bucket to its percentile envelope.
+//
+// Every percentile here is computed ONCE, server-side, with the R-7 convention
+// named in stats.Percentile — not because the clients could not divide, but
+// because "the p95" is ambiguous enough that two independent implementations
+// draw two different lines from the same data (#1905 design decision 5).
+//
+// A RUN STILL IN PROGRESS IS NOT A SAMPLE. This is where that is decided (#1905
+// recording), and it is a decision rather than an omission.
+//
+// A run that is three hours in and continuing has a duration of "at least three
+// hours". Folding that into a percentile treats a floor as a measurement, and
+// the error is not random: it always shortens, and it shortens the longest runs
+// hardest, which is the exact bias this whole fix exists to remove. A p95 that
+// counted it would say the top 5% of runs were shorter than they were.
+//
+// It is also the one place the aggregate chart and the project panel beside it
+// disagree on purpose: the panel's figure is a MAXIMUM, and "the longest run
+// already lasted 3h" is a true statement about a maximum, so a running run
+// counts there. The same run is not a percentile sample here. Both surfaces say
+// which they did — response.Measurement carries the count either way.
+//
+// A LOWER-BOUND START is treated differently, and the asymmetry is the point. A
+// run Irrlicht met already in progress has FINISHED: its length is known to
+// within however long it had been going when Irrlicht started watching, which
+// is bounded by the daemon's own uptime. It is a sample, and it is marked.
+// Dropping those would re-create the under-count exactly — every long run that
+// crosses a restart is one of them.
+func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyDurationResponse {
+	n := 0
+	if bucketSeconds > 0 && end > start {
+		n = int((end - start + bucketSeconds - 1) / bucketSeconds)
+	}
+	bucketStarts := make([]int64, n)
+	for i := range bucketStarts {
+		bucketStarts[i] = start + int64(i)*bucketSeconds
+	}
+
+	byBucket := make([][]float64, n)
+	all := make([]float64, 0, len(res.Spans))
+	for _, s := range res.Spans {
+		if s.Running {
+			continue
+		}
+		d := float64(s.Duration())
+		if d <= 0 {
+			continue
+		}
+		all = append(all, d)
+		if n == 0 {
+			continue
+		}
+		idx := int((s.End - start) / bucketSeconds)
+		if idx < 0 || idx >= n {
+			continue
+		}
+		byBucket[idx] = append(byBucket[idx], d)
+	}
+
+	buckets := make([]historyAutonomyBucket, 0, n)
+	for i, samples := range byBucket {
+		// A bucket with no spans is a GAP: omitted, never emitted as a zero.
+		if len(samples) == 0 {
+			continue
+		}
+		buckets = append(buckets, autonomyBucketFrom(bucketStarts[i], samples))
+	}
+
+	return historyAutonomyDurationResponse{
+		Window:        window,
+		Chart:         chartAutonomyDuration,
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  bucketStarts,
+		Buckets:       buckets,
+		Summary:       autonomyDurationSummaryFrom(all),
+		SampleFloor:   autonomySampleFloor,
+		EarliestSpan:  res.EarliestStart,
+		TotalRecorded: res.TotalRecorded,
+		Provenance:    autonomyProvenanceFrom(res.Provenance),
+		Kinds:         autonomyKindsFrom(res.Kinds),
+		Measurement:   autonomyMeasurementFrom(res.Measurement),
+	}
+}
+
+// autonomyBucketFrom reduces one bucket's samples to its envelope. samples is
+// sorted in place, then read five times — one sort per bucket, not per line.
+func autonomyBucketFrom(ts int64, samples []float64) historyAutonomyBucket {
+	sort.Float64s(samples)
+	return historyAutonomyBucket{
+		TS:    ts,
+		P95:   stats.PercentileSorted(samples, 0.95),
+		P50:   stats.PercentileSorted(samples, 0.50),
+		P5:    stats.PercentileSorted(samples, 0.05),
+		Min:   samples[0],
+		Max:   samples[len(samples)-1],
+		Count: len(samples),
+		Thin:  len(samples) < autonomySampleFloor,
+	}
+}
+
+// autonomyDurationSummaryFrom reduces the whole window's samples to the figure
+// row. Named for its chart rather than for the section, because the project
+// panels have a summary of their own (autonomySummaryFrom) that counts a
+// different thing — the two must never be swapped for each other.
+func autonomyDurationSummaryFrom(samples []float64) historyAutonomyDurationSummary {
+	if len(samples) == 0 {
+		return historyAutonomyDurationSummary{}
+	}
+	sort.Float64s(samples)
+	return historyAutonomyDurationSummary{
+		P95:   stats.PercentileSorted(samples, 0.95),
+		P50:   stats.PercentileSorted(samples, 0.50),
+		P5:    stats.PercentileSorted(samples, 0.05),
+		Min:   samples[0],
+		Max:   samples[len(samples)-1],
+		Count: len(samples),
+	}
+}

--- a/core/cmd/irrlichd/history_autonomy_duration_test.go
+++ b/core/cmd/irrlichd/history_autonomy_duration_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Tests for the Autonomy section's AGGREGATE element (chart=autonomy_duration).
+//
+// They came back with the chart in #1905's restore, unchanged in substance from
+// the versions that shipped before #1919 deleted it — the same fixtures, the
+// same committed mutations, the same R-7 arithmetic spelled out. What changed is
+// the file they live in and the summary type's name
+// (historyAutonomyDurationSummary), since the project panels now own the plain
+// one.
+//
+// Everything here except TestAutonomyDuration_RunningRunIsNotAPercentileSample
+// is a LOCK: it pins behaviour that existed before, so it passes by
+// construction against the restored code and cannot have been seen red first.
+// The one thing it can and does show is that the restore is faithful.
+
+// decodeAutonomyDuration issues one request and decodes the aggregate payload.
+func decodeAutonomyDuration(t *testing.T, store outbound.AutonomySpanStore, query string) historyAutonomyDurationResponse {
+	t.Helper()
+	rec := getAutonomy(t, store, query)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s → %d, want 200", query, rec.Code)
+	}
+	var resp historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestAutonomyDuration_WindowShapes(t *testing.T) {
+	for _, tc := range []struct {
+		window        string
+		bucketSeconds int64
+		buckets       int
+	}{
+		{"30d", 86400, 30},
+		{"1y", 7 * 86400, 52},
+	} {
+		resp := decodeAutonomyDuration(t, &fakeAutonomyStore{}, "chart=autonomy_duration&window="+tc.window)
+		if resp.Chart != chartAutonomyDuration {
+			t.Errorf("window=%s chart = %q, want %q", tc.window, resp.Chart, chartAutonomyDuration)
+		}
+		if resp.BucketSeconds != tc.bucketSeconds {
+			t.Errorf("window=%s bucket_seconds = %d, want %d", tc.window, resp.BucketSeconds, tc.bucketSeconds)
+		}
+		if len(resp.BucketStarts) != tc.buckets {
+			t.Errorf("window=%s has %d buckets, want %d", tc.window, len(resp.BucketStarts), tc.buckets)
+		}
+	}
+}
+
+func TestAutonomyDuration_DefaultWindow(t *testing.T) {
+	resp := decodeAutonomyDuration(t, &fakeAutonomyStore{}, "chart=autonomy_duration")
+	if resp.Window != "30d" {
+		t.Errorf("default window = %q, want 30d", resp.Window)
+	}
+}
+
+// --- An empty bucket is a gap, not a zero -----------------------------------
+
+// TestAutonomyDuration_EmptyBucketIsAGapNotAZero pins the honesty rule: a day
+// with no runs must not pull the line to the axis.
+//
+// The committed mutation is denseBuckets below — the "just emit every bucket"
+// build that would draw a zero for every quiet day.
+func TestAutonomyDuration_EmptyBucketIsAGapNotAZero(t *testing.T) {
+	now := time.Now().Unix()
+	// Two spans, both ending today: 29 of the 30 daily buckets are empty.
+	store := &fakeAutonomyStore{
+		spans: []outbound.AutonomySpan{
+			spanEndingAt(now-60, 600, "irrlicht", "ready"),
+			spanEndingAt(now-30, 900, "irrlicht", "waiting"),
+		},
+		earliest: now - 600,
+		total:    2,
+	}
+	resp := decodeAutonomyDuration(t, store, "chart=autonomy_duration&window=30d")
+	if len(resp.BucketStarts) != 30 {
+		t.Fatalf("bucket_starts = %d, want 30 (the axis is still fully drawn)", len(resp.BucketStarts))
+	}
+	for _, b := range resp.Buckets {
+		if b.Count == 0 {
+			t.Fatalf("bucket ts=%d was emitted with count 0 — an empty bucket must be OMITTED "+
+				"(a gap), never sent as a zero that pulls the line to the axis", b.TS)
+		}
+	}
+	if len(resp.Buckets) != 1 {
+		t.Fatalf("got %d non-empty buckets, want 1 (both spans ended today)", len(resp.Buckets))
+	}
+
+	// The MUTATION: a builder that emits a point per bucket regardless. It has
+	// to differ from production here, or this test proves nothing.
+	denseBuckets := len(resp.BucketStarts)
+	if denseBuckets == len(resp.Buckets) {
+		t.Fatalf("the dense mutation (%d points) is indistinguishable from production (%d) on this "+
+			"fixture — it cannot show that empty buckets are dropped", denseBuckets, len(resp.Buckets))
+	}
+}
+
+// --- The sample floor -------------------------------------------------------
+
+// TestAutonomyDuration_SampleFloorMarksThinBuckets pins the floor and the fact
+// that a thin bucket is MARKED rather than hidden or smoothed.
+//
+// Both boundary cases are derived from autonomySampleFloor rather than typed,
+// so moving the constant moves the test with it — and the third assertion is
+// the committed mutation: a build that dropped the floor entirely would report
+// thin=false on the under-floor bucket, which is what the second case catches.
+func TestAutonomyDuration_SampleFloorMarksThinBuckets(t *testing.T) {
+	now := time.Now().Unix()
+	// Put everything in "today" so both cases land in one bucket.
+	build := func(n int) *fakeAutonomyStore {
+		spans := make([]outbound.AutonomySpan, 0, n)
+		for i := 0; i < n; i++ {
+			spans = append(spans, spanEndingAt(now-int64(i)-1, int64(60+i*10), "irrlicht", "ready"))
+		}
+		return &fakeAutonomyStore{spans: spans, earliest: now - 86400, total: n}
+	}
+	for _, tc := range []struct {
+		n        int
+		wantThin bool
+	}{
+		{autonomySampleFloor - 1, true},
+		{autonomySampleFloor, false},
+	} {
+		resp := decodeAutonomyDuration(t, build(tc.n), "chart=autonomy_duration&window=30d")
+		if resp.SampleFloor != autonomySampleFloor {
+			t.Errorf("sample_floor = %d, want %d — clients render the floor, so it travels on the wire",
+				resp.SampleFloor, autonomySampleFloor)
+		}
+		if len(resp.Buckets) == 0 {
+			t.Fatalf("n=%d produced no buckets at all — a thin bucket must be MARKED, never hidden", tc.n)
+		}
+		var thinFound bool
+		var total int
+		for _, b := range resp.Buckets {
+			total += b.Count
+			if b.Thin {
+				thinFound = true
+			}
+		}
+		if total != tc.n {
+			t.Errorf("n=%d: buckets hold %d spans in total, want %d — no sample may be dropped", tc.n, total, tc.n)
+		}
+		if thinFound != tc.wantThin {
+			t.Errorf("n=%d: thin=%v, want %v (floor is %d)", tc.n, thinFound, tc.wantThin, autonomySampleFloor)
+		}
+	}
+}
+
+// TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes states the reason
+// the floor exists, as an executable claim rather than a comment: under the
+// floor the p95 IS the max and the p5 IS the min for a small enough sample, so
+// the outer lines stop being percentiles.
+func TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes(t *testing.T) {
+	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-10, 100, "irrlicht", "ready"),
+		spanEndingAt(now-20, 200, "irrlicht", "ready"),
+		spanEndingAt(now-30, 300, "irrlicht", "waiting"),
+	}
+	resp := decodeAutonomyDuration(t, &fakeAutonomyStore{spans: spans, total: 3, earliest: now - 300},
+		"chart=autonomy_duration&window=30d")
+	if len(resp.Buckets) != 1 {
+		t.Fatalf("want exactly 1 non-empty bucket, got %d", len(resp.Buckets))
+	}
+	b := resp.Buckets[0]
+	if !b.Thin {
+		t.Fatalf("a 3-sample bucket must be thin (floor %d)", autonomySampleFloor)
+	}
+	// R-7 over {100,200,300}: p95 = 200 + 0.9*100 = 290; p5 = 100 + 0.1*100 = 110.
+	if math.Abs(b.P95-290) > 1e-9 || math.Abs(b.P5-110) > 1e-9 {
+		t.Errorf("p95/p5 = %v/%v, want 290/110 (R-7 over 3 samples)", b.P95, b.P5)
+	}
+	if b.Max != 300 || b.Min != 100 {
+		t.Errorf("max/min = %v/%v, want 300/100", b.Max, b.Min)
+	}
+	if b.P95 <= b.Max*0.9 {
+		t.Errorf("p95 %v is not pinned near the max %v — the reason the floor exists has changed", b.P95, b.Max)
+	}
+}
+
+// --- Percentiles are computed daemon-side -----------------------------------
+
+func TestAutonomyDuration_SummaryPercentilesAreServerComputed(t *testing.T) {
+	now := time.Now().Unix()
+	// The same 12-sample fixture stats' own test uses, so a convention change
+	// fails in both places rather than only the one nobody reads.
+	spans := make([]outbound.AutonomySpan, 0, 12)
+	for i := 1; i <= 12; i++ {
+		spans = append(spans, spanEndingAt(now-int64(i), int64(i*100), "irrlicht", "ready"))
+	}
+	resp := decodeAutonomyDuration(t, &fakeAutonomyStore{spans: spans, total: 12, earliest: now - 1200},
+		"chart=autonomy_duration&window=30d")
+	if resp.Summary.Count != 12 {
+		t.Fatalf("summary count = %d, want 12", resp.Summary.Count)
+	}
+	if math.Abs(resp.Summary.P95-1145) > 1e-9 {
+		t.Errorf("summary p95 = %v, want 1145 (R-7 — nearest rank would give 1200)", resp.Summary.P95)
+	}
+	if resp.Summary.Min != 100 || resp.Summary.Max != 1200 {
+		t.Errorf("summary min/max = %v/%v, want 100/1200 — the true extremes stay figures, not lines",
+			resp.Summary.Min, resp.Summary.Max)
+	}
+}
+
+// --- A running run is not a percentile sample -------------------------------
+
+// TestAutonomyDuration_RunningRunIsNotAPercentileSample pins the one place the
+// section's two elements disagree ON PURPOSE, and it is the only test in this
+// file that is not a lock: the panels' figure is a MAXIMUM, where "the longest
+// run already lasted 3h" is true, so a running run counts there; the aggregate
+// chart's figures are PERCENTILES, where folding a floor in always shortens and
+// shortens the longest runs hardest.
+//
+// It went red against the restored chart before the `if s.Running { continue }`
+// guard was carried over with it — with the guard removed, the 3h floor becomes
+// the window's max and the summary count rises to 2.
+func TestAutonomyDuration_RunningRunIsNotAPercentileSample(t *testing.T) {
+	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-100, 600, "irrlicht", "ready"),
+		{Start: now - 3*3600, End: now, Project: "irrlicht", Session: "live",
+			Kind: session.AutonomyKindTopLevel, Running: true},
+	}
+	store := &fakeAutonomyStore{
+		spans: spans, total: 2, earliest: now - 3*3600,
+		measurement: outbound.AutonomySpanMeasurement{Running: 1},
+	}
+	resp := decodeAutonomyDuration(t, store, "chart=autonomy_duration&window=30d")
+
+	if resp.Summary.Count != 1 {
+		t.Errorf("summary count = %d, want 1 — a run still in progress is a FLOOR on its own length, "+
+			"and a percentile computed from floors always shortens", resp.Summary.Count)
+	}
+	if resp.Summary.Max != 600 {
+		t.Errorf("summary max = %v, want 600 — the 3h floor must not pass as a measured extreme",
+			resp.Summary.Max)
+	}
+	// …and it is COUNTED and NAMED rather than quietly dropped: the reader is
+	// told the section is showing fewer samples than runs.
+	if resp.Measurement.Running != 1 {
+		t.Errorf("measurement.running = %d, want 1 — dropping a run silently is what left 5 of a "+
+			"day's 35 runs on the record", resp.Measurement.Running)
+	}
+	// The same run IS the panels' longest, which is the asymmetry this test
+	// exists to state. Asserted here so the two claims cannot drift apart.
+	panels := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+	if got := panelFor(t, panels, "irrlicht").Longest; got != float64(3*3600) {
+		t.Errorf("panel longest = %v, want %d — the panels report a maximum, where a floor is a true "+
+			"statement about the longest run", got, 3*3600)
+	}
+}
+
+// --- Provenance, kinds and measurement ride on BOTH payloads ----------------
+
+// TestAutonomyDuration_CarriesTheSameCensusesAsThePanels pins that the section's
+// two elements cannot disagree about what they counted: one converter each,
+// shared, so a reader comparing the two charts is reading one census.
+func TestAutonomyDuration_CarriesTheSameCensusesAsThePanels(t *testing.T) {
+	now := time.Now().Unix()
+	store := &fakeAutonomyStore{
+		spans:    []outbound.AutonomySpan{spanEndingAt(now-60, 600, "irrlicht", "ready")},
+		earliest: now - 86400,
+		total:    9,
+		provenance: outbound.AutonomySpanProvenance{
+			Reconstructed: 4,
+			CostDerived:   2,
+			EraStarts:     map[string]int64{"cost": now - 80000, "": now - 40000},
+		},
+		kinds:       outbound.AutonomySpanKinds{TopLevel: 5, Subagent: 3, Unknown: 1},
+		measurement: outbound.AutonomySpanMeasurement{Running: 1, LowerBoundStart: 2},
+	}
+	duration := decodeAutonomyDuration(t, store, "chart=autonomy_duration&window=30d")
+	panels := decodeAutonomy(t, store, "chart=autonomy_projects&window=30d")
+
+	if duration.Provenance.Reconstructed != panels.Provenance.Reconstructed ||
+		duration.Provenance.CostDerived != panels.Provenance.CostDerived ||
+		duration.Provenance.LiveSince != panels.Provenance.LiveSince ||
+		len(duration.Provenance.Boundaries) != len(panels.Provenance.Boundaries) {
+		t.Errorf("provenance differs between the elements: %+v vs %+v",
+			duration.Provenance, panels.Provenance)
+	}
+	if duration.Kinds != panels.Kinds {
+		t.Errorf("kinds differ between the elements: %+v vs %+v", duration.Kinds, panels.Kinds)
+	}
+	if duration.Measurement != panels.Measurement {
+		t.Errorf("measurement differs between the elements: %+v vs %+v",
+			duration.Measurement, panels.Measurement)
+	}
+	if duration.EarliestSpan != panels.EarliestSpan || duration.TotalRecorded != panels.TotalRecorded {
+		t.Errorf("the collecting-since figures differ: %d/%d vs %d/%d",
+			duration.EarliestSpan, duration.TotalRecorded, panels.EarliestSpan, panels.TotalRecorded)
+	}
+	if len(duration.Provenance.Boundaries) == 0 {
+		t.Fatal("the fixture produced no source boundary, so this check cannot observe that both " +
+			"elements carry the same one")
+	}
+}
+
+func TestAutonomyDuration_NilStoreServesEmptyButValid(t *testing.T) {
+	rec := getAutonomy(t, nil, "chart="+chartAutonomyDuration)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("no store → %d, want 200", rec.Code)
+	}
+}
+
+func TestAutonomyDuration_StoreErrorIs500(t *testing.T) {
+	store := &fakeAutonomyStore{err: errAutonomyProbe}
+	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("store error → %d, want 500", rec.Code)
+	}
+}
+
+// errAutonomyProbe is the store failure both elements' 500 tests use, named once
+// so neither can drift into asserting a different error's status.
+var errAutonomyProbe = errors.New("disk on fire")

--- a/core/cmd/irrlichd/history_autonomy_endpoint_test.go
+++ b/core/cmd/irrlichd/history_autonomy_endpoint_test.go
@@ -665,3 +665,62 @@ func TestAutonomy_ReadIsUnlimited(t *testing.T) {
 			store.lastQuery.End-store.lastQuery.Start, 52*7*86400)
 	}
 }
+
+// --- A stated figure must be reachable on the axis that states it -----------
+
+// TestAutonomy_PanelLongestIsAlwaysOnItsOwnAxis pins the property whose absence
+// was the aggregate chart's Y-domain defect (#1905): a figure the header states
+// must be a value the plot beside it can actually reach.
+//
+// The panel's line domain is built from its BUCKET longests, and its header
+// states the WINDOW longest. Those are two different reductions of the same
+// spans, and they agree only because every returned span is bucketed: the store
+// selects on `End < q.Start || End >= q.End` (foldSpanRow), so every span it
+// returns has an end inside the window and therefore an index inside [0, n).
+// A span counted towards the header but dropped from every bucket would put the
+// header's figure above the top of its own plot.
+//
+// A LOCK: it passes by construction against the code as written, and it is
+// here so a later change to either reduction — a filter on one side, a clamp on
+// the other — cannot silently break the pair. The mutation below is what such a
+// change looks like.
+func TestAutonomy_PanelLongestIsAlwaysOnItsOwnAxis(t *testing.T) {
+	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-100, 600, "irrlicht", "ready"),
+		spanEndingAt(now-20*86400, 41_940, "irrlicht", "ready"), // the long one, 20 days back
+		spanEndingAt(now-5*86400, 900, "irrlicht", "ready"),
+	}
+	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: len(spans), earliest: now - 30*86400},
+		"chart=autonomy_projects&window=30d")
+	panel := panelFor(t, resp, "irrlicht")
+
+	var acrossBuckets float64
+	for _, b := range panel.Buckets {
+		if b.Longest > acrossBuckets {
+			acrossBuckets = b.Longest
+		}
+	}
+	if acrossBuckets <= 0 {
+		t.Fatal("no bucket carries a longest run, so this check cannot observe the pair it guards")
+	}
+	if panel.Longest != acrossBuckets {
+		t.Errorf("header states longest %v but the highest bucket is %v — the header's figure is not "+
+			"reachable on the plot beside it, which is the aggregate chart's Y-domain defect in the "+
+			"other direction", panel.Longest, acrossBuckets)
+	}
+
+	// The MUTATION: a bucketing pass that drops what falls outside the window
+	// instead of clamping it, while the header keeps counting it. It has to
+	// differ from production here, or this fixture proves nothing.
+	dropped := 0.0
+	for _, s := range spans {
+		if s.End >= now-10*86400 && float64(s.Duration()) > dropped {
+			dropped = float64(s.Duration())
+		}
+	}
+	if dropped == panel.Longest {
+		t.Fatal("the dropping mutation agrees with production on this fixture — it cannot show that " +
+			"every counted run is also bucketed")
+	}
+}

--- a/core/cmd/irrlichd/history_autonomy_endpoint_test.go
+++ b/core/cmd/irrlichd/history_autonomy_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,13 +169,56 @@ func TestAutonomyWindows_AreNotHistoryGranularities(t *testing.T) {
 }
 
 func TestAutonomy_RejectsAnUnknownWindow(t *testing.T) {
-	// The section offers 30d|1y. The run strip's old 8h…12mo vocabulary went
-	// with the strip, so a client still sending one is told rather than
-	// silently served some other window.
-	for _, window := range []string{"8h", "24h", "12mo", "week"} {
-		rec := getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_projects&window="+window)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("window=%s → %d, want 400", window, rec.Code)
+	// The section offers 30d|1y — ONE vocabulary for BOTH elements, so the two
+	// charts drawn one above the other can never show different periods. The run
+	// strip's old 8h…12mo vocabulary went with the strip, so a client still
+	// sending one is told rather than silently served some other window.
+	for _, chart := range []string{chartAutonomyProjects, chartAutonomyDuration} {
+		for _, window := range []string{"8h", "24h", "12mo", "week"} {
+			rec := getAutonomy(t, &fakeAutonomyStore{}, "chart="+chart+"&window="+window)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("chart=%s window=%s → %d, want 400", chart, window, rec.Code)
+			}
+			// The body names the chart that was asked for. A caller that sent
+			// the wrong window to the right chart otherwise cannot tell which
+			// of the section's two requests failed.
+			if body := rec.Body.String(); !strings.Contains(body, chart) {
+				t.Errorf("chart=%s window=%s 400 body %q does not name the chart", chart, window, body)
+			}
+		}
+	}
+}
+
+// TestAutonomy_BothElementsShareOneWindowVocabulary pins the property the
+// section's single Range control depends on: whatever window the aggregate
+// chart accepts, the project panels accept, and they resolve to the SAME
+// period.
+//
+// The committed mutation is splitVocabulary below — the shape the run strip
+// had, where each element owned its own window keys. Two windows under one
+// control is how a reader ends up comparing a month of one chart against a year
+// of the other with nothing on screen saying they disagree.
+func TestAutonomy_BothElementsShareOneWindowVocabulary(t *testing.T) {
+	// The MUTATION: a per-chart window table, the run strip's old shape.
+	splitVocabulary := map[string]map[string]bool{
+		chartAutonomyDuration: {"30d": true, "1y": true},
+		chartAutonomyProjects: {"8h": true, "24h": true, "7d": true},
+	}
+	if splitVocabulary[chartAutonomyDuration]["24h"] == splitVocabulary[chartAutonomyProjects]["24h"] {
+		t.Fatal("the split-vocabulary mutation no longer disagrees with itself, so this fixture cannot " +
+			"show that production shares one table")
+	}
+
+	for window := range autonomyWindowSpecs {
+		durationResp := decodeAutonomyDuration(t, &fakeAutonomyStore{}, "chart="+chartAutonomyDuration+"&window="+window)
+		panelsResp := decodeAutonomy(t, &fakeAutonomyStore{}, "chart="+chartAutonomyProjects+"&window="+window)
+		if durationResp.BucketSeconds != panelsResp.BucketSeconds {
+			t.Errorf("window=%s: aggregate buckets %ds, panels %ds — one Range control moving two "+
+				"different periods", window, durationResp.BucketSeconds, panelsResp.BucketSeconds)
+		}
+		if len(durationResp.BucketStarts) != len(panelsResp.BucketStarts) {
+			t.Errorf("window=%s: aggregate has %d buckets, panels %d",
+				window, len(durationResp.BucketStarts), len(panelsResp.BucketStarts))
 		}
 	}
 }
@@ -408,12 +452,17 @@ func TestAutonomyConcurrency_SplitOnlyWhereKindIsKnown(t *testing.T) {
 	}
 }
 
-// --- Five panels, ranked by total autonomous time ---------------------------
+// --- Every project, ranked by total autonomous time -------------------------
 
-// TestAutonomy_DrawsFivePanelsAndNamesTheRest pins the section's shape: exactly
-// autonomyPanelCount panels, and everything below them named as a count rather
-// than dropped in silence.
-func TestAutonomy_DrawsFivePanelsAndNamesTheRest(t *testing.T) {
+// TestAutonomy_SendsEveryProjectRankedNotJustTheTopFew pins what the dropdown
+// depends on: the payload carries a panel for EVERY project with a run in the
+// window, ranked, not a five-project slice of them.
+//
+// It went red against the shipped build (autonomyPanelCount = 5), which sent
+// five panels and reported the other three as `more_projects` — a picker built
+// on that payload could offer only five of the eight projects its own summary
+// counted, and the three it dropped were unreachable.
+func TestAutonomy_SendsEveryProjectRankedNotJustTheTopFew(t *testing.T) {
 	now := time.Now().Unix()
 	spans := []outbound.AutonomySpan{}
 	// Eight projects, each with a distinct total so the ranking is unambiguous.
@@ -422,27 +471,70 @@ func TestAutonomy_DrawsFivePanelsAndNamesTheRest(t *testing.T) {
 	}
 	resp := decodeAutonomy(t, &fakeAutonomyStore{spans: spans, total: len(spans), earliest: now - 10000},
 		"chart=autonomy_projects&window=30d")
-	if len(resp.Panels) != autonomyPanelCount {
-		t.Fatalf("drew %d panels, want %d", len(resp.Panels), autonomyPanelCount)
+	if len(resp.Panels) != 8 {
+		t.Fatalf("drew %d panels over 8 projects, want 8 — a project the payload omits is one the "+
+			"dropdown cannot offer", len(resp.Panels))
+	}
+	if resp.MoreProjects != 0 {
+		t.Errorf("more_projects = %d, want 0 — nothing was left out", resp.MoreProjects)
 	}
 	if resp.PanelLimit != autonomyPanelCount {
-		t.Errorf("panel_limit = %d, want %d — clients render what they are sent rather than re-deciding "+
-			"the number", resp.PanelLimit, autonomyPanelCount)
-	}
-	if resp.MoreProjects != 3 {
-		t.Errorf("more_projects = %d, want 3 — an omission nothing mentions is indistinguishable from a "+
-			"project that never ran", resp.MoreProjects)
+		t.Errorf("panel_limit = %d, want %d — the cap is on the wire so a client reports what it was "+
+			"sent rather than re-deciding the number", resp.PanelLimit, autonomyPanelCount)
 	}
 	if resp.Summary.Projects != 8 {
-		t.Errorf("summary projects = %d, want 8 (the summary counts every project, not the drawn five)",
-			resp.Summary.Projects)
+		t.Errorf("summary projects = %d, want 8", resp.Summary.Projects)
 	}
-	// p8 has the most seconds, p4 the fifth-most.
-	want := []string{"p8", "p7", "p6", "p5", "p4"}
+	// Ranked, most autonomous time first — the order the client's default
+	// selection (rank 1) and its dropdown both read.
+	want := []string{"p8", "p7", "p6", "p5", "p4", "p3", "p2", "p1"}
 	for i, p := range resp.Panels {
 		if p.Project != want[i] {
 			t.Fatalf("panel %d = %q, want %q (order is most autonomous time first)", i, p.Project, want[i])
 		}
+	}
+}
+
+// TestAutonomy_PanelCapStillBitesAndSaysSo pins the other half: the cap is a
+// SAFETY cap, not a design, and a machine that reaches it is told rather than
+// silently truncated.
+//
+// It runs the builder directly rather than through the handler because the
+// fixture needs autonomyPanelCount+5 projects, and building that many HTTP
+// requests would say nothing extra about the rule under test.
+//
+// The committed mutation is unboundedPanels below — the "just send them all"
+// build, which is what makes a pathological install's payload unbounded.
+func TestAutonomy_PanelCapStillBitesAndSaysSo(t *testing.T) {
+	now := time.Now().Unix()
+	const extra = 5
+	spans := []outbound.AutonomySpan{}
+	// Distinct totals so the rank is total order, and the cap's tail is exactly
+	// the `extra` smallest.
+	for i := 1; i <= autonomyPanelCount+extra; i++ {
+		spans = append(spans, spanEndingAt(now-int64(i), int64(i)*10, fmt.Sprintf("p%04d", i), "ready"))
+	}
+	res := &outbound.AutonomySpanResult{Spans: spans, TotalRecorded: len(spans), EarliestStart: now - 100000}
+	resp := buildAutonomyProjectsResponse("30d", 86400, now-30*86400, now, res)
+
+	if len(resp.Panels) != autonomyPanelCount {
+		t.Fatalf("sent %d panels over %d projects, want the cap of %d",
+			len(resp.Panels), autonomyPanelCount+extra, autonomyPanelCount)
+	}
+	if resp.MoreProjects != extra {
+		t.Errorf("more_projects = %d, want %d — a truncation nothing mentions is indistinguishable "+
+			"from a project that never ran", resp.MoreProjects, extra)
+	}
+	if resp.Summary.Projects != autonomyPanelCount+extra {
+		t.Errorf("summary projects = %d, want %d (the summary counts every project, including the "+
+			"ones past the cap)", resp.Summary.Projects, autonomyPanelCount+extra)
+	}
+
+	// The MUTATION: no cap at all.
+	unboundedPanels := len(spans)
+	if unboundedPanels == len(resp.Panels) {
+		t.Fatal("the uncapped mutation sends the same number of panels production does — this fixture " +
+			"cannot show that the cap bites")
 	}
 }
 
@@ -550,7 +642,7 @@ func TestAutonomy_NilStoreServesEmptyButValid(t *testing.T) {
 }
 
 func TestAutonomy_StoreErrorIs500(t *testing.T) {
-	store := &fakeAutonomyStore{err: fmt.Errorf("disk on fire")}
+	store := &fakeAutonomyStore{err: errAutonomyProbe}
 	rec := getAutonomy(t, store, "chart=autonomy_projects&window=30d")
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("store error → %d, want 500", rec.Code)

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -787,15 +787,30 @@ struct HistoryAutonomyDurationResponse: Codable {
         return bucketStarts.map { byTS[$0] }
     }
 
-    /// The chart's LINEAR Y domain, over the drawn p95s and the true extremes.
+    /// The chart's LINEAR Y domain: the highest p95 it DRAWS, plus a tenth of
+    /// headroom, from zero.
     ///
-    /// Same decision and the same cost as `HistoryAutonomyPanel.yDomain` — see
-    /// there. The summary row under the chart carries p95/p50/p5 and the true
-    /// extremes as FIGURES, which is what keeps them readable when the band
-    /// flattens toward the floor.
+    /// THE DOMAIN FITS WHAT IS DRAWN, and `max` is not drawn. The chart draws
+    /// p95, p50, p5 and the plane between p95 and p5; a bucket's true maximum is
+    /// a FIGURE in the summary row, and it is a figure precisely so it cannot
+    /// redraw the axis — "one four-hour run left going overnight would otherwise
+    /// redraw the whole Y scale and flatten every other bucket into the floor"
+    /// (#1905). Folding it back into the domain re-created exactly that, and the
+    /// first round of this restore shipped it.
+    ///
+    /// MEASURED on the reference machine's live span log (30-day window, 27 of
+    /// 30 buckets with data, 2735 runs): highest p95 1h37m against a highest max
+    /// of 11h39m — a 7.19x inflation that put the tallest p50 at 0.92% of the
+    /// plot height and the median p50 at 0.46%, with 87.4% of the plot empty
+    /// above the band. `testTheDomainFitsWhatIsDrawnNotAnUndrawnOutlier` pins it.
+    ///
+    /// Linear still costs what `HistoryAutonomyPanel.yDomain` says it costs — a
+    /// long p95 flattens the short buckets under it — but that is a cost paid to
+    /// a line the reader can SEE. Paying it to one the chart never draws buys
+    /// nothing.
     var yDomain: ClosedRange<Double> {
-        let values = buckets.flatMap { [$0.p95, $0.max] }.filter { $0 > 0 }
-        let hi = Swift.max(1, values.max() ?? 60)
+        let drawn = buckets.map(\.p95).filter { $0 > 0 }
+        let hi = Swift.max(1, drawn.max() ?? 60)
         return 0...(hi * 1.1)
     }
 }

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -1,29 +1,34 @@
 import Foundation
 
-// Codable mirrors of the daemon's Autonomy payload (#1905) —
-// `chart=autonomy_projects` in core/cmd/irrlichd/history_autonomy.go — plus the
-// Range picker's vocabulary and the pure layout rules the panels draw with.
+// Codable mirrors of the daemon's Autonomy payloads (#1905) —
+// `chart=autonomy_duration` and `chart=autonomy_projects` in
+// core/cmd/irrlichd/history_autonomy*.go — plus the Range picker's vocabulary
+// and the pure layout rules both elements draw with.
 //
-// FIVE PER-PROJECT PANELS, one per project, stacked. Each carries a LINE (the
-// longest run in each time bucket) and, under it, a HISTOGRAM (how many runs
-// were working at the same time in that bucket, derived by the daemon from the
-// spans by overlap).
+// TWO ELEMENTS over one window:
 //
-// WHAT THIS REPLACED. Two payloads and two elements: a p5–p95 band with a p50
-// line, and a per-project run strip coloured by end reason. Both are gone —
-// with the strip's legend, glyphs and collapse ladder, the Span picker that
-// governed its window, and the sample floor that marked buckets whose p95 was
-// really their maximum. A maximum over one run IS that run, so the floor has
-// nothing left to protect.
+//   THE AGGREGATE CHART — p95/p50/p5 of run duration across EVERY project, with
+//   the plane between p95 and p5 filled as a band.
+//   ONE PROJECT PANEL — a LINE (the longest run in each time bucket) and, under
+//   it, a HISTOGRAM (how many runs were working at the same time in that
+//   bucket, derived by the daemon from the spans by overlap). Exactly one is
+//   drawn; a Picker in the panel's own header chooses which.
+//
+// WHAT IS STILL GONE. The per-project run strip, its legend, glyphs and
+// collapse ladder, and the Span picker that governed its window. The section's
+// subject is how LONG a run was, not how it ended.
 
-/// The section's Range picker. Two windows, and 30 days is the floor.
+/// The section's Range picker. Two windows, and 30 days is the floor: anything
+/// shorter has too few spans per bucket for a percentile to mean anything.
 ///
 /// The raw values are WINDOW LENGTHS sent as `?window=`, not the
 /// bucket-width-times-count that `HistoryGranularity`'s same-looking keys mean.
 ///
-/// There is no second picker. `HistoryAutonomySpanWindow` governed the run
-/// strip's own window and went with the strip: one window, one control, and no
-/// pair of textually-overlapping vocabularies for a reader to keep apart.
+/// ONE picker for BOTH elements. They are read together — one above the other,
+/// over the same instants — so two windows would let the chart show a month
+/// while the panel under it showed a year, with nothing on screen saying they
+/// disagreed. `HistoryAutonomySpanWindow` was exactly that and went with the
+/// strip.
 enum HistoryAutonomyRange: String, CaseIterable, Identifiable {
     case days30 = "30d"
     case year = "1y"
@@ -175,19 +180,23 @@ struct HistoryAutonomyBoundary: Codable, Equatable, Identifiable {
     ]
 }
 
-/// Where a source-boundary caption is written, once the stack has five panels.
+/// Where a source-boundary caption is written, given the section's two elements.
 ///
-/// THE RULE READS ONCE ACROSS THE STACK. The dashed rule is drawn through EVERY
-/// panel — it has to be, or it annotates one project's line and leaves the four
-/// below it stepping for no stated reason — but the caption is drawn on the TOP
-/// panel only. Five stacked copies of "← cost log · 60s resolution" down one x
-/// position are five competing captions where the reader needs one, and at 9 pt
-/// in a 380 pt popover they would collide with four project names.
+/// THE RULE READS ONCE ACROSS THE SECTION. The dashed rule is drawn on BOTH
+/// elements — it has to be, or it annotates the aggregate line and leaves the
+/// panel below it stepping for no stated reason — but the caption is written by
+/// the AGGREGATE chart only, which is the top one. Two stacked copies of
+/// "← cost log · 60s resolution" down one x position are two competing captions
+/// where the reader needs one, and at 9 pt in a 380 pt popover the lower one
+/// collides with the panel's own header row.
 enum AutonomyBoundaryCaption {
-    /// The panel index that carries the words.
-    static let panelIndex = 0
+    /// The section's two drawn elements, in the order they appear.
+    enum Element: String, CaseIterable { case aggregate, panel }
 
-    static func isShown(panelIndex: Int) -> Bool { panelIndex == Self.panelIndex }
+    /// The element that carries the words.
+    static let captionedBy = Element.aggregate
+
+    static func isShown(element: Element) -> Bool { element == Self.captionedBy }
 
     /// Which side of its rule the caption hangs off.
     ///
@@ -421,22 +430,37 @@ struct HistoryAutonomySummary: Codable, Equatable {
     }
 }
 
-/// One entry of the panel stack, in draw order — the macOS twin of the web's
-/// `autonomyStackRows`.
+/// Which project the single panel draws — the macOS twin of the web's
+/// `autonomyPanelChoice`.
 ///
-/// The client never re-decides how many panels there are: the daemon computes
-/// five and says how many it left out, so the two surfaces cannot disagree the
-/// way the run strip's twelve-rows-on-web against six-on-macOS did.
-enum AutonomyStackRow: Identifiable, Equatable {
-    case panel(HistoryAutonomyPanel, index: Int)
-    case more(String)
+/// THREE OUTCOMES, and the third is the one that has to be written down rather
+/// than fallen into:
+///
+///   - nothing selected → rank 1, the project with the most autonomous time in
+///     the window. A freshly opened tab needs no stored name.
+///   - the selection is in this range → that panel.
+///   - the selection is NOT in this range → `isMissing`, and the selection is
+///     KEPT. Silently falling back to rank 1 would answer a question the reader
+///     did not ask, and would make a Range change look like a click they never
+///     made; the panel says "no runs for <project> in this range" instead, and
+///     the Picker still carries the name so one Range change back restores it.
+struct AutonomyPanelChoice: Equatable {
+    let panel: HistoryAutonomyPanel?
+    let project: String
 
-    var id: String {
-        switch self {
-        case let .panel(p, _): return "panel-" + p.project
-        case .more: return "more"
-        }
-    }
+    var isMissing: Bool { panel == nil && !project.isEmpty }
+}
+
+/// One entry of the project Picker — the macOS twin of the web's
+/// `autonomyProjectOptions`.
+struct AutonomyProjectOption: Identifiable, Equatable {
+    let project: String
+    /// Whether this range holds no runs for it, in which case the Picker says
+    /// so rather than offering a name that draws nothing with no explanation.
+    let isMissing: Bool
+
+    var id: String { project }
+    var label: String { isMissing ? project + " — no runs in this range" : project }
 }
 
 struct HistoryAutonomyProjectsResponse: Codable {
@@ -447,16 +471,21 @@ struct HistoryAutonomyProjectsResponse: Codable {
     let bucketSeconds: Int64
     let bucketStarts: [Int64]
 
-    /// The five most important projects, most autonomous time first.
+    /// EVERY project with a run in the window, most autonomous time first, up
+    /// to the daemon's safety cap.
     ///
-    /// "Most important" is GREATEST TOTAL AUTONOMOUS TIME in the window, never
-    /// longest single run: one lucky overnight run would otherwise promote a
-    /// project nobody has touched in a month. The daemon ranks them; each panel
-    /// carries `totalSeconds` so the ranking can be checked.
+    /// Every one of them, because exactly ONE is drawn and the rest are offered
+    /// in a Picker: a payload carrying only the top few would leave the Picker
+    /// unable to show a project the summary above it counts.
+    ///
+    /// The rank is GREATEST TOTAL AUTONOMOUS TIME in the window, never longest
+    /// single run: one lucky overnight run would otherwise promote a project
+    /// nobody has touched in a month. The daemon ranks them; each panel carries
+    /// `totalSeconds` so the ranking can be checked.
     let panels: [HistoryAutonomyPanel]
     let panelLimit: Int
-    /// How many projects the window holds beyond the panels, all of them with
-    /// less autonomous time than every panel above.
+    /// How many projects the window holds beyond the cap, all of them with less
+    /// autonomous time than every panel above. 0 on every machine seen so far.
     let moreProjects: Int
 
     let summary: HistoryAutonomySummary
@@ -492,22 +521,41 @@ struct HistoryAutonomyProjectsResponse: Codable {
     var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
     var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
 
-    /// What the stack renders, in order: one entry per panel the daemon sent
-    /// and, when the window holds more projects than those, a final entry
-    /// naming the rest. An omission nothing mentions is indistinguishable from
-    /// a project that never ran.
-    var stackRows: [AutonomyStackRow] {
-        var out: [AutonomyStackRow] = panels.enumerated().map { .panel($1, index: $0) }
-        if let label = overflowLabel { out.append(.more(label)) }
+    /// Which project the panel draws, given the reader's selection (nil = none
+    /// made yet). See `AutonomyPanelChoice` for why an absent selection is kept
+    /// rather than silently replaced.
+    func choice(selected: String?) -> AutonomyPanelChoice {
+        guard let selected, !selected.isEmpty else {
+            return AutonomyPanelChoice(panel: panels.first, project: panels.first?.project ?? "")
+        }
+        if let found = panels.first(where: { $0.project == selected }) {
+            return AutonomyPanelChoice(panel: found, project: selected)
+        }
+        return AutonomyPanelChoice(panel: nil, project: selected)
+    }
+
+    /// The Picker's contents: every project the window holds, ranked, plus the
+    /// selected one when this range does not hold it.
+    ///
+    /// The absent project goes LAST, which is the same rule the rest follow
+    /// rather than an exception to it: the order is most autonomous time first,
+    /// and a project with no runs in this range has none of it.
+    func projectOptions(selected: String?) -> [AutonomyProjectOption] {
+        var out = panels.map { AutonomyProjectOption(project: $0.project, isMissing: false) }
+        if let selected, !selected.isEmpty, !panels.contains(where: { $0.project == selected }) {
+            out.append(AutonomyProjectOption(project: selected, isMissing: true))
+        }
         return out
     }
 
-    /// What the five-panel view left out, and WHY those are the ones missing —
-    /// so the reader knows the section took the tail rather than an arbitrary
-    /// slice. `nil` when every project already has a panel.
+    /// What the daemon's safety cap left out, and WHY those are the ones missing
+    /// — so the reader knows the payload took the tail rather than an arbitrary
+    /// slice. `nil` when the cap left nothing out, which is every machine seen
+    /// so far.
     var overflowLabel: String? {
         guard moreProjects > 0 else { return nil }
-        return "+\(moreProjects) more project\(moreProjects == 1 ? "" : "s"), each with less autonomous time"
+        return "+\(moreProjects) more project\(moreProjects == 1 ? "" : "s") past the payload cap, "
+            + "each with less autonomous time"
     }
 
     /// The source boundaries that fall inside the DRAWN domain, so the panels
@@ -530,30 +578,38 @@ struct HistoryAutonomyProjectsResponse: Codable {
         return Double(boundary.ts - first) / Double(last - first)
     }
 
-    /// The log Y domain SHARED by all five panels, `nil` when nothing in the
-    /// window has a length to plot.
+}
+
+extension HistoryAutonomyPanel {
+    /// This panel's own LINEAR Y domain, `nil` when it has no length to plot.
     ///
-    /// Shared, so the projects are comparable — that is the point of picking
-    /// five. Log, because a project whose best is two minutes would otherwise be
-    /// a flat line under one whose best is eleven hours. Each panel states its
-    /// own longest as a NUMBER in its header, so the exact figure never depends
-    /// on reading the axis.
-    var sharedYDomain: ClosedRange<Double>? {
-        let values = panels.flatMap { $0.buckets.map(\.longest) }.filter { $0 > 0 }
-        guard let smallest = values.min(), let biggest = values.max() else { return nil }
-        // Floored at 1s: a log scale cannot plot 0, and a sub-second span is
-        // not a run.
-        let lo = Swift.max(1, smallest * 0.8)
-        let hi = Swift.max(lo * 2, biggest * 1.25)
-        return lo...hi
+    /// ITS OWN, because exactly one panel is drawn: there is nothing left to be
+    /// comparable WITH, and a domain stretched to fit projects that are not on
+    /// screen would flatten the one that is. (It was shared across five, for
+    /// exactly the reason that no longer applies.)
+    ///
+    /// LINEAR, AND WHAT THAT COSTS. This is the maintainer's explicit call
+    /// (#1905), recorded here so the next reader knows it was a decision and not
+    /// an oversight. On a linear axis one 11-hour run sets the whole domain, and
+    /// the typical 10-minute runs beneath it collapse into the bottom 1.5% of
+    /// the plot — visually indistinguishable from the floor. A log axis kept
+    /// them apart, at the cost of making a doubling look like a small step
+    /// wherever the eye landed. The panel header states the exact longest as a
+    /// NUMBER for exactly this reason, so the figure never depends on reading
+    /// the axis.
+    ///
+    /// ZERO IS THE FLOOR, which the log axis could not offer: a linear axis
+    /// whose origin is not zero exaggerates every difference above it, and there
+    /// is no longer any "a log scale cannot plot 0" reason to lift it.
+    var yDomain: ClosedRange<Double>? {
+        guard let biggest = buckets.map(\.longest).filter({ $0 > 0 }).max() else { return nil }
+        return 0...(biggest * 1.1)
     }
 
-    /// The histogram's SHARED full-height value: the highest peak any panel
-    /// reaches. 0 when nothing overlapped anywhere, in which case no bar is
-    /// drawn at all rather than every bar being drawn full height.
-    var sharedPeakScale: Int {
-        panels.flatMap { $0.buckets.map(\.peak) }.max() ?? 0
-    }
+    /// The histogram's full-height value: this panel's own highest peak. 0 when
+    /// nothing overlapped anywhere in it, in which case no bar is drawn at all
+    /// rather than every bar being drawn full height.
+    var peakScale: Int { buckets.map(\.peak).max() ?? 0 }
 }
 
 /// The contiguous stretches a panel's line may be stroked over — as a pure
@@ -587,5 +643,225 @@ enum AutonomyLineLayout {
         }
         if let from = start { out.append(Segment(from: from, to: points.count - 1)) }
         return out
+    }
+}
+
+// MARK: - The aggregate percentile chart (chart=autonomy_duration)
+
+/// One bucket of the aggregate chart. The daemon OMITS empty buckets, so every
+/// bucket present here has `count >= 1` — a day with no runs is a gap in the
+/// line, never a point on the axis.
+struct HistoryAutonomyBucket: Codable, Identifiable, Equatable {
+    let ts: Int64
+    let p95: Double
+    let p50: Double
+    let p5: Double
+    let min: Double
+    let max: Double
+    let count: Int
+    /// True when the bucket holds fewer than `sampleFloor` spans, so its p95
+    /// IS its max and its p5 IS its min. Rendered visibly differently (dashed
+    /// + faded), never hidden and never smoothed.
+    let thin: Bool
+
+    var id: Int64 { ts }
+
+    enum CodingKeys: String, CodingKey {
+        case ts, p95, p50, p5, min, max, count, thin
+    }
+
+    init(ts: Int64, p95: Double, p50: Double, p5: Double,
+         min: Double, max: Double, count: Int, thin: Bool = false) {
+        self.ts = ts
+        self.p95 = p95
+        self.p50 = p50
+        self.p5 = p5
+        self.min = min
+        self.max = max
+        self.count = count
+        self.thin = thin
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        ts = try c.decode(Int64.self, forKey: .ts)
+        p95 = try c.decode(Double.self, forKey: .p95)
+        p50 = try c.decode(Double.self, forKey: .p50)
+        p5 = try c.decode(Double.self, forKey: .p5)
+        min = try c.decode(Double.self, forKey: .min)
+        max = try c.decode(Double.self, forKey: .max)
+        count = try c.decode(Int.self, forKey: .count)
+        // `thin` is omitempty on the wire: absent means false.
+        thin = try c.decodeIfPresent(Bool.self, forKey: .thin) ?? false
+    }
+}
+
+/// The window-wide figure row under the aggregate chart. The true extremes stay
+/// FIGURES and are deliberately not lines: one four-hour run left going
+/// overnight would otherwise redraw the whole Y scale and flatten every other
+/// bucket — an effect the switch to a LINEAR axis makes stronger still, which is
+/// why these figures matter more now rather than less.
+struct HistoryAutonomySummaryStats: Codable, Equatable {
+    let p95: Double
+    let p50: Double
+    let p5: Double
+    let min: Double
+    let max: Double
+    let count: Int
+
+    init(p95: Double = 0, p50: Double = 0, p5: Double = 0,
+         min: Double = 0, max: Double = 0, count: Int = 0) {
+        self.p95 = p95
+        self.p50 = p50
+        self.p5 = p5
+        self.min = min
+        self.max = max
+        self.count = count
+    }
+}
+
+struct HistoryAutonomyDurationResponse: Codable {
+    let window: String
+    let chart: String
+    let start: Int64
+    let end: Int64
+    let bucketSeconds: Int64
+    let bucketStarts: [Int64]
+    let buckets: [HistoryAutonomyBucket]
+    let summary: HistoryAutonomySummaryStats
+    let sampleFloor: Int
+    /// Earliest span on record across the WHOLE log (0 = nothing ever
+    /// recorded). What lets an empty chart say "collecting since <date>"
+    /// instead of being read as "you did nothing".
+    let earliestSpan: Int64
+    let totalRecorded: Int
+    /// Optional so a payload from a daemon that predates the field decodes
+    /// rather than failing outright.
+    let provenance: HistoryAutonomyProvenance?
+    let kinds: HistoryAutonomyKinds?
+    let measurement: HistoryAutonomyMeasurement?
+
+    enum CodingKeys: String, CodingKey {
+        case window, chart, start, end, buckets, summary, provenance, kinds, measurement
+        case bucketSeconds = "bucket_seconds"
+        case bucketStarts = "bucket_starts"
+        case sampleFloor = "sample_floor"
+        case earliestSpan = "earliest_span"
+        case totalRecorded = "total_recorded"
+    }
+
+    var hasData: Bool { !buckets.isEmpty }
+    var provenanceOrNone: HistoryAutonomyProvenance { provenance ?? .none }
+    var measurementOrNone: HistoryAutonomyMeasurement { measurement ?? .none }
+
+    /// How many buckets in view are below the sample floor — the count the
+    /// thin-bucket sentence states. A fainter plane means nothing on its own.
+    var thinCount: Int { buckets.filter(\.thin).count }
+
+    /// The source boundaries that fall inside the DRAWN domain, so the chart
+    /// marks only what the reader can actually see. Same strictly-inside rule
+    /// as the panel's, and over the same window, so the two elements mark the
+    /// same instant.
+    var visibleBoundaries: [HistoryAutonomyBoundary] {
+        guard let first = bucketStarts.first, let last = bucketStarts.last, last > first else { return [] }
+        return provenanceOrNone.boundaryList.filter { $0.ts > first && $0.ts < last }
+    }
+
+    /// Where in the DRAWN domain a boundary sits, 0…1.
+    func domainFraction(of boundary: HistoryAutonomyBoundary) -> Double {
+        guard let first = bucketStarts.first, let last = bucketStarts.last, last > first else { return 0 }
+        return Double(boundary.ts - first) / Double(last - first)
+    }
+
+    /// The buckets aligned to `bucket_starts`, with `nil` for every bucket the
+    /// daemon OMITTED — the macOS twin of the web's `autonomyChartPoints`.
+    ///
+    /// The nil is the honesty rule, not a convenience: an empty bucket is a
+    /// GAP, and a day with no runs must not pull a line down to the axis or let
+    /// a filled band close over it. Reading `buckets` directly hands Swift
+    /// Charts a dense list in which the gap is simply not there, and it connects
+    /// straight across.
+    var alignedBuckets: [HistoryAutonomyBucket?] {
+        var byTS: [Int64: HistoryAutonomyBucket] = [:]
+        for b in buckets { byTS[b.ts] = b }
+        return bucketStarts.map { byTS[$0] }
+    }
+
+    /// The chart's LINEAR Y domain, over the drawn p95s and the true extremes.
+    ///
+    /// Same decision and the same cost as `HistoryAutonomyPanel.yDomain` — see
+    /// there. The summary row under the chart carries p95/p50/p5 and the true
+    /// extremes as FIGURES, which is what keeps them readable when the band
+    /// flattens toward the floor.
+    var yDomain: ClosedRange<Double> {
+        let values = buckets.flatMap { [$0.p95, $0.max] }.filter { $0 > 0 }
+        let hi = Swift.max(1, values.max() ?? 60)
+        return 0...(hi * 1.1)
+    }
+}
+
+/// The p5–p95 band's geometry, as a pure function so both the gap rule and the
+/// thin-bucket rule are testable without a chart — and so this and the web's
+/// `autonomyBandSegments` fill the same shape.
+///
+/// TWO RULES, both of them honesty rules a smooth fill would otherwise erase:
+///
+///   - **A filled area wants to close across a gap.** The daemon omits empty
+///     buckets; a polygon spanning one paints a plane over days that hold no
+///     runs at all, a stronger false claim than the interpolated line #1905
+///     already refuses. A segment never crosses a `nil`.
+///   - **A thin bucket is not a percentile.** Under `sample_floor`, p95 is that
+///     bucket's longest run and p5 its shortest. The stroke already dashes
+///     across such a bucket; the fill splits at the same place so the thin
+///     stretch can be painted in its own fainter plane.
+enum AutonomyBandLayout {
+    /// One fillable stretch: inclusive indices into the aligned point list, and
+    /// whether it is thin. Adjacent segments SHARE their boundary index, so a
+    /// thin→solid handover leaves no seam. `from == to` is an isolated bucket —
+    /// it has no neighbour to make an area with, and the chart draws its spread
+    /// as a whisker rather than leaving it the one bucket with no visible range.
+    struct Segment: Equatable, Identifiable {
+        let from: Int
+        let to: Int
+        let thin: Bool
+
+        var id: String { "\(from)-\(to)-\(thin)" }
+        var isIsolated: Bool { from == to }
+    }
+
+    static func segments(points: [HistoryAutonomyBucket?]) -> [Segment] {
+        var out: [Segment] = []
+        var i = 0
+        while i < points.count {
+            guard points[i] != nil else { i += 1; continue }
+            var last = i
+            while last + 1 < points.count, points[last + 1] != nil { last += 1 }
+            if last == i {
+                out.append(Segment(from: i, to: i, thin: points[i]?.thin ?? false))
+                i = last + 1
+                continue
+            }
+            // Thinness belongs to the INTERVAL, not the bucket — matching the
+            // stroke, which dashes a segment either of whose ends is thin.
+            var start = i
+            var thin = isThin(points, i) || isThin(points, i + 1)
+            var j = i + 1
+            while j < last {
+                let next = isThin(points, j) || isThin(points, j + 1)
+                if next != thin {
+                    out.append(Segment(from: start, to: j, thin: thin))
+                    start = j
+                    thin = next
+                }
+                j += 1
+            }
+            out.append(Segment(from: start, to: last, thin: thin))
+            i = last + 1
+        }
+        return out
+    }
+
+    private static func isThin(_ points: [HistoryAutonomyBucket?], _ i: Int) -> Bool {
+        points[i]?.thin ?? false
     }
 }

--- a/platforms/macos/Irrlicht/Theme/Tokens.swift
+++ b/platforms/macos/Irrlicht/Theme/Tokens.swift
@@ -67,23 +67,28 @@ enum IrrColors {
     static let readyDim   = ready.opacity(0.12)
     static let errorDim   = error.opacity(0.12)
 
-    // Autonomy panels (#1905) — ONE hue, two weights. The longest-run line is
-    // `working` at full strength; the concurrency histogram under it is the
-    // same hue, quieter, because the bars are a second reading of the same
-    // activity and not a second subject.
+    // Autonomy (#1905) — ONE hue, four weights, across both of the section's
+    // elements. The lines are `working` at full strength; the concurrency
+    // histogram, the p5–p95 plane and its edges are the same hue, quieter,
+    // because they are further readings of the same activity and not further
+    // subjects.
     //
     // `adaptive` rather than `working.opacity(…)` because the alpha itself has
     // to differ per appearance, and a single opacity cannot have two values:
-    // on a dark window a violet bar has to LIGHTEN the surface to register at
+    // on a dark window a violet wash has to LIGHTEN the surface to register at
     // all, while on a light one the same alpha reads as a solid lavender slab
-    // louder than the line above it. Hex is `#AARRGGBB`, so the alpha rides in
-    // the token. Web twin: --autonomy-bar in platforms/web/irrlicht.css, same
-    // alphas.
-    //
-    // The p5–p95 band's three tokens went with the band (#1905 redesign): the
-    // section reports the LONGEST run now, so there is no plane to fill and no
-    // thin-bucket variant to distinguish.
+    // louder than the line it sits behind. Hex is `#AARRGGBB`, so the alpha
+    // rides in the token. Web twins: --autonomy-bar / --autonomy-band /
+    // --autonomy-band-thin / --autonomy-edge in platforms/web/irrlicht.css,
+    // same alphas.
     static let autonomyBar      = Color.adaptive(light: "#618B5CF6", dark: "#738B5CF6")
+    // The band came back with the aggregate percentile chart (#1905 restore).
+    static let autonomyBand     = Color.adaptive(light: "#1C8B5CF6", dark: "#338B5CF6")
+    // Buckets under `sample_floor` keep their own, fainter plane: there p95 IS
+    // the maximum and p5 IS the minimum, so the area is a range rather than a
+    // percentile spread and must not read as one.
+    static let autonomyBandThin = Color.adaptive(light: "#0D8B5CF6", dark: "#148B5CF6")
+    static let autonomyEdge     = Color.adaptive(light: "#618B5CF6", dark: "#738B5CF6")
 
     // Glow halos (--working-glow 0.25, --waiting-glow / --ready-glow 0.20).
     static let workingGlow = working.opacity(0.25)

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -3,24 +3,42 @@ import SwiftUI
 
 // MARK: - Autonomy section (#1905)
 //
-// FIVE PER-PROJECT PANELS, one per project, stacked. Each carries a LINE — the
-// longest run in each time bucket — and, under it, a low HISTOGRAM of how many
-// runs were working at the same time in that bucket.
+// TWO ELEMENTS over one window, sharing one Range control:
 //
-// HOW FIVE PANELS FIT A 380 pt POPOVER. The tab's content is already inside a
-// ScrollView (HistoryView.content), so the stack scrolls rather than compresses:
-// a 58 pt panel (14 pt header + 44 pt plot) times five is 290 pt, and the
-// header, the "+N more" line, the axis, the key and the provenance paragraph
-// follow it. Compressing instead would leave a histogram two points tall — a
-// smear that cannot be read — and the paragraphs that explain the figures are
-// the last thing that may be clipped.
+//   THE AGGREGATE CHART — p95/p50/p5 of autonomous run duration across EVERY
+//   project, with the plane between p95 and p5 filled as a band. "Is autonomy
+//   getting better across the machine."
+//   ONE PROJECT PANEL under it — a LINE of the longest run in each time bucket
+//   and, beneath that, a HISTOGRAM of how many runs were working at the same
+//   time. "What did THIS project do." A Picker in the panel's own header row
+//   chooses which project.
 //
-// Pure inputs (the decoded response), so a snapshot test can host this view
+// WHY BOTH. A maximum over one project is that project's story; a maximum
+// charted across every project is a chart of whoever ran longest that day. A
+// percentile over the whole population is a trend; a percentile over one
+// project's four runs is not a percentile. Neither can stand in for the other.
+//
+// WHY ONE PANEL AND NOT FIVE. In a 380 pt popover five panels squeezed each plot
+// to 32 pt and each histogram to 10 pt, and the reader could still only compare
+// the five the daemon ranked highest. One panel gets 96 pt for its line and 40
+// pt for its bars, and the Picker reaches EVERY project in the window.
+//
+// Pure inputs (the two decoded responses), so a snapshot test can host this view
 // directly with fixture data.
 
 struct HistoryAutonomyContentView: View {
+    let duration: HistoryAutonomyDurationResponse
     let data: HistoryAutonomyProjectsResponse
     let range: HistoryAutonomyRange
+    /// A BINDING, unlike `range`: the project Picker lives in the panel's own
+    /// header row, beside the figures it changes. Range moves BOTH elements and
+    /// belongs to the tab's control row; this moves one of them, and a control's
+    /// place is what says which.
+    ///
+    /// nil is "no choice made yet" → rank 1. The NAME is held, not the rank, so
+    /// the choice survives a Range change rather than silently swapping projects
+    /// whenever a longer window reorders the ranking.
+    @Binding var selectedProject: String?
 
     /// #1659 — every date this view renders takes its zone as an INPUT rather
     /// than reading `NSTimeZone.default`.
@@ -28,7 +46,9 @@ struct HistoryAutonomyContentView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp4) {
-            panelStack
+            aggregateSection
+            Divider()
+            panelSection
             Divider()
             collectionProvenance
         }
@@ -36,43 +56,82 @@ struct HistoryAutonomyContentView: View {
         .padding(.vertical, IrrSpacing.sp3)
     }
 
-    // MARK: The stack
+    // MARK: Element 1 — the aggregate percentile chart
 
-    @ViewBuilder private var panelStack: some View {
+    @ViewBuilder private var aggregateSection: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
             HStack {
-                Text("Longest autonomous run · \(range.label)")
+                Text("Autonomous run duration · \(range.label)")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Text("log scale, shared")
+                Text("all projects · linear scale")
                     .font(.caption2)
                     .foregroundColor(.secondary)
             }
-            if data.hasData {
-                ForEach(data.stackRows) { row in
-                    switch row {
-                    case let .panel(panel, index):
-                        AutonomyPanelView(panel: panel,
-                                          data: data,
-                                          panelIndex: index,
-                                          timeZone: formatTimeZone)
-                    case let .more(label):
-                        overflow(label)
-                    }
-                }
-                stackAxis
-                AutonomyKeyView()
-                concurrencyCaveat
-                summaryRow
+            if duration.hasData {
+                AutonomyDurationChart(data: duration, timeZone: formatTimeZone)
+                    .frame(height: 190)
+                aggregateSummaryRow
+                if duration.thinCount > 0 { thinNote }
             } else {
                 emptyText
             }
         }
     }
 
-    /// "+N more projects" — quieter than a panel and clearly not one: it is a
-    /// statement about the stack, not another entry in it.
+    /// "p95 1h58m · p50 11m · p5 41s · longest 2h14m · shortest 22s · 312 runs"
+    /// — the true extremes are figures here, deliberately not lines on the
+    /// chart, and that matters MORE on a linear axis than it did on a log one.
+    private var aggregateSummaryRow: some View {
+        let s = duration.summary
+        return Text(
+            "p95 \(AutonomyFormat.duration(s.p95)) · p50 \(AutonomyFormat.duration(s.p50)) · "
+            + "p5 \(AutonomyFormat.duration(s.p5)) · longest \(AutonomyFormat.duration(s.max)) · "
+            + "shortest \(AutonomyFormat.duration(s.min)) · \(s.count) runs"
+        )
+        .font(.caption)
+        .monospacedDigit()
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// Thin buckets are MARKED, never hidden and never smoothed — and the
+    /// marking is explained in words, because a fainter plane means nothing on
+    /// its own. Three signals, since a distinction is easy to lose inside a
+    /// smooth band: the plane itself, the edges bounding it, and the points.
+    private var thinNote: some View {
+        Text("\(duration.thinCount) of \(duration.buckets.count) buckets hold fewer than "
+             + "\(duration.sampleFloor) runs (fainter band, dashed edges, hollow points): there, p95 is "
+             + "that bucket's longest run and p5 its shortest — not percentiles.")
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: Element 2 — one project's panel
+
+    @ViewBuilder private var panelSection: some View {
+        VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
+            if data.hasData {
+                AutonomyPanelView(choice: data.choice(selected: selectedProject),
+                                  data: data,
+                                  selectedProject: $selectedProject,
+                                  timeZone: formatTimeZone)
+                if let label = data.overflowLabel { overflow(label) }
+                stackAxis
+                AutonomyKeyView()
+                concurrencyCaveat
+                summaryRow
+            } else {
+                emptyPanelText
+            }
+        }
+    }
+
+    /// "+N more projects" — what the daemon's payload cap left out, which is
+    /// nothing on any machine seen so far. Quieter than the panel and clearly
+    /// not one: it is a statement about the payload, not another entry in it.
     private func overflow(_ text: String) -> some View {
         Text(text)
             .font(.caption2)
@@ -82,9 +141,8 @@ struct HistoryAutonomyContentView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// The window's bounds, ONCE under the whole stack: the five panels share
-    /// one x domain, so five copies would be five statements of one fact. The
-    /// start label coarsens with the window — see AutonomyFormat.axisBound.
+    /// The window's bounds under the panel. The start label coarsens with the
+    /// window — see AutonomyFormat.axisBound.
     private var stackAxis: some View {
         HStack(spacing: IrrSpacing.sp2) {
             Text(AutonomyFormat.axisBound(Date(timeIntervalSince1970: TimeInterval(data.start)),
@@ -121,16 +179,30 @@ struct HistoryAutonomyContentView: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
-    /// An empty stack with axes drawn is not acceptable (#1905): the empty
+    /// An empty chart with axes drawn is not acceptable (#1905): the empty
     /// state says, in words, that the feature collects from the day it ships.
     private var emptyText: some View {
-        Text(data.totalRecorded == 0
+        Text(duration.totalRecorded == 0
              ? "No autonomous runs recorded yet. Irrlicht starts measuring them the first time a session runs after this update — an empty section here means \"nothing recorded\", not \"nothing happened\"."
-             : "No runs in this range. \(data.totalRecorded) runs are on record outside it.")
+             : "No runs in this range. \(duration.totalRecorded) runs are on record outside it.")
             .font(.callout)
             .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
+            .multilineTextAlignment(.center)
+    }
+
+    /// The panel's own empty state, for a window that holds no project at all.
+    /// A project the reader SELECTED that this range does not hold is a
+    /// different case and is answered inside the panel — see AutonomyPanelView.
+    private var emptyPanelText: some View {
+        Text(data.totalRecorded == 0
+             ? "No project has an autonomous run yet — this panel fills in as sessions run."
+             : "No runs in this range for any project.")
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
             .multilineTextAlignment(.center)
     }
 
@@ -174,62 +246,122 @@ struct HistoryAutonomyContentView: View {
 // MARK: - Panel geometry
 
 /// The panel's fixed geometry, in points. Named rather than spread across the
-/// views so the stack's total height is arithmetic a reader can do: five times
-/// (`headerHeight` + `plotHeight` + `barsHeight`) plus the spacing between them.
+/// views so the section's total height is arithmetic a reader can do.
+///
+/// TALLER THAN THE FIVE-PANEL STACK COULD AFFORD, because only one panel is
+/// drawn: the plot went 32 → 96 pt and the histogram 10 → 40 pt. At 10 pt a peak
+/// of 1 and a peak of 15 differed by a few points of ink, which is half of why
+/// "the number of agents running in parallel is not visible"; the other half is
+/// that the gutter beside them carried no scale, which `concurrencyBars` now
+/// labels.
 enum AutonomyPanelMetrics {
-    static let plotHeight: CGFloat = 32
-    static let barsHeight: CGFloat = 10
-    /// The width reserved for the shared axis's duration labels. The stack's
-    /// own x axis is indented by the same amount so its two bounds sit under
-    /// the plot rather than under the labels.
+    static let plotHeight: CGFloat = 96
+    static let barsHeight: CGFloat = 40
+    /// The clearance between the two charts, and it is load-bearing rather than
+    /// cosmetic (#1905, QA-4). Both axes are labelled in the SAME right-hand
+    /// gutter now, and neither knows about the other: the line axis's lowest
+    /// value label sits at the foot of its plot and the histogram's peak label
+    /// at the head of the bar band. Butted together at the 1 pt spacing the
+    /// five-panel stack used — where the bar band carried no labels at all —
+    /// the two overprint. The web build showed exactly that in QA before this
+    /// gap existed; `tickFontSize` is what it has to clear.
+    static let chartGap: CGFloat = 10
+    /// The tick font both axes label in. One value, so the two gutters cannot
+    /// end up at different sizes and read as two columns.
+    static let tickFontSize: CGFloat = 9
+    /// The width reserved for the duration labels. The panel's own x axis is
+    /// indented by the same amount so its two bounds sit under the plot rather
+    /// than under the labels — and the histogram's own axis uses the same
+    /// gutter, so the two read as one column.
     static let labelGutter: CGFloat = 46
 }
 
 // MARK: - One project's panel
 
 private struct AutonomyPanelView: View {
-    let panel: HistoryAutonomyPanel
+    let choice: AutonomyPanelChoice
     let data: HistoryAutonomyProjectsResponse
-    /// Which panel of the stack this is — the caption rule reads it, and
-    /// nothing else does.
-    let panelIndex: Int
+    @Binding var selectedProject: String?
     let timeZone: TimeZone
 
-    private var points: [HistoryAutonomyPanelBucket?] { panel.alignedBuckets(data.bucketStarts) }
+    private var points: [HistoryAutonomyPanelBucket?] {
+        choice.panel?.alignedBuckets(data.bucketStarts) ?? []
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
-            HStack(spacing: IrrSpacing.sp2) {
-                Text(panel.project)
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: IrrSpacing.sp2)
-                // The panel's OWN figures, so the exact longest never depends
-                // on reading a shared axis, and the concurrency split is
-                // legible rather than buried.
-                Text(panel.headline)
-                    .font(.caption2)
-                    .monospacedDigit()
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
+            header
+            if let panel = choice.panel {
+                longestRunChart(panel)
+                // See AutonomyPanelMetrics.chartGap: the two axes share one
+                // gutter, and butted together their innermost labels overprint.
+                concurrencyBars(panel).padding(.top, AutonomyPanelMetrics.chartGap)
+            } else {
+                missingProjectNote
             }
-            longestRunChart
-            concurrencyBars
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(panel.project): \(panel.headline), \(panel.runs) runs")
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(choice.panel.map { "\($0.project): \($0.headline), \($0.runs) runs" }
+                            ?? AutonomyFormat.emptyProjectNote(choice.project))
     }
 
-    /// The longest-run line, on the SHARED log domain.
+    /// The panel's own header row: the project Picker, and that project's two
+    /// figures. The Picker sits HERE rather than in the tab's control row
+    /// because it moves one element where Range moves both — a control's place
+    /// is what says which.
+    private var header: some View {
+        HStack(spacing: IrrSpacing.sp2) {
+            Picker("Project", selection: projectBinding) {
+                ForEach(data.projectOptions(selected: selectedProject)) { option in
+                    Text(option.label).tag(option.project)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .controlSize(.small)
+            .font(.caption2)
+            .frame(maxWidth: 190, alignment: .leading)
+            Spacer(minLength: IrrSpacing.sp2)
+            // The panel's OWN figures, so the exact longest never depends on
+            // reading the axis, and the concurrency split is legible rather
+            // than buried.
+            Text(choice.panel?.headline ?? "")
+                .font(.caption2)
+                .monospacedDigit()
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    /// The Picker writes a NAME, never nil: once the reader has chosen, the
+    /// choice is theirs to keep across a Range change.
+    private var projectBinding: Binding<String> {
+        Binding(get: { choice.project }, set: { selectedProject = $0 })
+    }
+
+    /// A SENTENCE, not an empty frame. An empty plot with axes on it is the
+    /// same picture a failed request draws, and the reader cannot tell which
+    /// they are looking at. Its height matches the plot's, so switching to a
+    /// project this range does not hold does not make the section jump.
+    private var missingProjectNote: some View {
+        Text(AutonomyFormat.emptyProjectNote(choice.project))
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity,
+                   minHeight: AutonomyPanelMetrics.plotHeight + AutonomyPanelMetrics.barsHeight,
+                   alignment: .center)
+            .multilineTextAlignment(.center)
+    }
+
+    /// The longest-run line, on THIS PROJECT'S OWN linear domain.
     ///
     /// `run` is the series key on purpose: it names the CONTIGUOUS STRETCH a
     /// point belongs to, and Swift Charts connects points that share it. Without
     /// that key the line is drawn through every bucket the daemon sent — which
     /// silently bridges the omitted ones, exactly the interpolation
     /// `alignedBuckets` exists to refuse.
-    @ViewBuilder private var longestRunChart: some View {
-        let domain = data.sharedYDomain ?? 1...60
+    @ViewBuilder private func longestRunChart(_ panel: HistoryAutonomyPanel) -> some View {
+        let domain = panel.yDomain ?? 0...60
         Chart {
             // The source-change markers first, so they sit UNDER the line: the
             // marker explains the data, it is not part of it.
@@ -246,7 +378,9 @@ private struct AutonomyPanelView: View {
                     .annotation(position: .top,
                                 alignment: captionAlignment(for: boundary),
                                 spacing: 2) {
-                        if AutonomyBoundaryCaption.isShown(panelIndex: panelIndex) {
+                        // Drawn on this element, captioned on the other: see
+                        // AutonomyBoundaryCaption.
+                        if AutonomyBoundaryCaption.isShown(element: .panel) {
                             Text(boundary.label)
                                 .font(.system(size: 9))
                                 .foregroundColor(.secondary)
@@ -255,7 +389,7 @@ private struct AutonomyPanelView: View {
                         }
                     }
             }
-            ForEach(lineData()) { d in
+            ForEach(lineData(panel)) { d in
                 LineMark(
                     x: .value("Date", d.date),
                     y: .value("Longest", d.value),
@@ -267,28 +401,32 @@ private struct AutonomyPanelView: View {
             }
             // An isolated bucket has no neighbour to draw a segment to, and
             // would otherwise be the one bucket that vanishes.
-            ForEach(lineData().filter(\.isolated)) { d in
+            ForEach(lineData(panel).filter(\.isolated)) { d in
                 PointMark(x: .value("Date", d.date), y: .value("Longest", d.value))
                     .symbolSize(14)
                     .foregroundStyle(AutonomyPalette.lineColor)
             }
             // A bucket whose longest run has not ended is hollow: its length is
             // a floor, and the header says "still going" beside it.
-            ForEach(lineData().filter(\.running)) { d in
+            ForEach(lineData(panel).filter(\.running)) { d in
                 PointMark(x: .value("Date", d.date), y: .value("Longest", d.value))
                     .symbol(.circle)
                     .symbolSize(30)
                     .foregroundStyle(AutonomyPalette.lineColor.opacity(0.5))
             }
         }
-        .chartYScale(domain: domain, type: .log)
+        // LINEAR, and what that costs is stated where the domain is chosen —
+        // see HistoryAutonomyPanel.yDomain. This is the maintainer's explicit
+        // call (#1905); there is no toggle and no log path kept behind a flag.
+        .chartYScale(domain: domain)
         .chartXScale(domain: xDomain)
         .chartYAxis {
             AxisMarks(values: .automatic(desiredCount: 3)) { value in
                 AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
                 AxisValueLabel {
                     if let v = value.as(Double.self) {
-                        Text(AutonomyFormat.duration(v)).font(.system(size: 9))
+                        Text(AutonomyFormat.duration(v))
+                            .font(.system(size: AutonomyPanelMetrics.tickFontSize))
                     }
                 }
             }
@@ -297,16 +435,28 @@ private struct AutonomyPanelView: View {
         .frame(height: AutonomyPanelMetrics.plotHeight)
     }
 
-    /// The concurrency histogram: one low bar per bucket, scaled against the
-    /// stack's SHARED peak so the five panels are comparable.
+    /// The concurrency histogram: one bar per bucket, scaled against THIS
+    /// panel's own peak.
     ///
     /// A BUCKET WITH NO ONE WORKING DRAWS NOTHING — not a zero-height bar, and
     /// not a hairline on the baseline. A mark on the axis reads as a measured
     /// zero, which is a different and false claim from "no runs here".
-    @ViewBuilder private var concurrencyBars: some View {
-        let scale = data.sharedPeakScale
+    ///
+    /// THE BAND'S OWN Y AXIS IS LABELLED (#1905). It used to be a deliberately
+    /// BLANK gutter — `AxisMarks(values: [0])` with a spacer string — kept only
+    /// so the bars stayed in register with the plot above. That is what "the
+    /// number of agents running in parallel is not visible" was about: the bars
+    /// carried the only figure on the panel with no scale of any kind. Two
+    /// labels now, the band's full-height value and 0, in the same gutter and at
+    /// the same 9 pt the line chart uses, so the two axes read as one column.
+    /// Two is what the axis actually means — a bar's height is its peak as a
+    /// fraction of the highest peak, so the top and the floor are the only two
+    /// exact readings, and a ladder of intermediate ticks in a 40 pt band would
+    /// be four numbers ten points apart.
+    @ViewBuilder private func concurrencyBars(_ panel: HistoryAutonomyPanel) -> some View {
+        let scale = panel.peakScale
         Chart {
-            ForEach(barData()) { d in
+            ForEach(barData(panel)) { d in
                 BarMark(
                     x: .value("Date", d.date),
                     y: .value("At once", d.peak)
@@ -318,11 +468,14 @@ private struct AutonomyPanelView: View {
         .chartXScale(domain: xDomain)
         .chartXAxis(.hidden)
         .chartYAxis {
-            // The gutter is kept — an empty label of the same width — so the
-            // bars line up under the plot above rather than starting further
-            // left, which would put the histogram out of register with the line
-            // it belongs to.
-            AxisMarks(values: [0]) { _ in AxisValueLabel { Text("     ").font(.system(size: 9)) } }
+            AxisMarks(values: AutonomyBarAxis.values(peak: scale)) { value in
+                AxisValueLabel {
+                    if let v = value.as(Int.self) {
+                        Text(AutonomyBarAxis.label(v))
+                            .font(.system(size: AutonomyPanelMetrics.tickFontSize))
+                    }
+                }
+            }
         }
         .frame(height: AutonomyPanelMetrics.barsHeight)
     }
@@ -358,7 +511,7 @@ private struct AutonomyPanelView: View {
 
     /// The line, split into one series per contiguous stretch so the stroke
     /// BREAKS at every gap instead of being drawn through it.
-    private func lineData() -> [Datum] {
+    private func lineData(_ panel: HistoryAutonomyPanel) -> [Datum] {
         var out: [Datum] = []
         for segment in AutonomyLineLayout.segments(points: points) {
             for i in segment.from...segment.to {
@@ -366,9 +519,7 @@ private struct AutonomyPanelView: View {
                 out.append(Datum(id: "\(panel.project)-\(b.ts)",
                                  date: date(at: i),
                                  run: "\(panel.project)#\(segment.id)",
-                                 // A log scale cannot plot 0, and a span shorter
-                                 // than a second is not a run.
-                                 value: Swift.max(1, b.longest),
+                                 value: b.longest,
                                  running: b.running,
                                  isolated: segment.isIsolated))
             }
@@ -376,7 +527,7 @@ private struct AutonomyPanelView: View {
         return out
     }
 
-    private func barData() -> [BarDatum] {
+    private func barData(_ panel: HistoryAutonomyPanel) -> [BarDatum] {
         points.enumerated().compactMap { i, b in
             guard let b, b.hasBar, i < data.bucketStarts.count else { return nil }
             return BarDatum(id: "bar-\(panel.project)-\(b.ts)", date: date(at: i), peak: b.peak)
@@ -394,11 +545,234 @@ private struct AutonomyPanelView: View {
     }
 }
 
+// MARK: - The aggregate percentile chart
+
+/// p95/p50/p5 across every project, with the plane between p95 and p5 filled.
+///
+/// Restored in #1905 after #1919 deleted it. What came back is what went: three
+/// lines in ONE hue at three weights, the translucent band, the thin-bucket
+/// marking, and the boundary rule with its caption. What did NOT come back is
+/// the log scale — see the Y-scale comment below.
+private struct AutonomyDurationChart: View {
+    let data: HistoryAutonomyDurationResponse
+    let timeZone: TimeZone
+
+    /// One drawn point.
+    ///
+    /// `series` names which of the three lines it belongs to and is what the
+    /// colour scale reads. `run` is a different key on purpose: it names the
+    /// CONTIGUOUS STRETCH the point belongs to, and Swift Charts connects points
+    /// that share it. Without that second key a line is drawn through every
+    /// bucket the daemon sent — which silently bridges the omitted ones, exactly
+    /// the interpolation `alignedBuckets` exists to refuse.
+    private struct Datum: Identifiable {
+        let id: String
+        let date: Date
+        let series: String
+        let run: String
+        let value: Double
+        let thin: Bool
+    }
+
+    /// One stretch of the band: the plane between p5 and p95 over a run of
+    /// consecutive buckets, or (when `isolated`) a single bucket's spread.
+    private struct BandDatum: Identifiable {
+        let id: String
+        let date: Date
+        let run: String
+        let low: Double
+        let high: Double
+        let thin: Bool
+    }
+
+    private func date(at index: Int) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(data.bucketStarts[index]))
+    }
+
+    private var points: [HistoryAutonomyBucket?] { data.alignedBuckets }
+    private var segments: [AutonomyBandLayout.Segment] {
+        AutonomyBandLayout.segments(points: points)
+    }
+
+    /// The three lines, split into one series per contiguous stretch so the
+    /// stroke BREAKS at every omitted bucket instead of being drawn through it.
+    private func lineData(_ segments: [AutonomyBandLayout.Segment]) -> [Datum] {
+        var out: [Datum] = []
+        for segment in segments where !segment.isIsolated {
+            for i in segment.from...segment.to {
+                guard let b = points[i] else { continue }
+                for key in AutonomyPalette.seriesOrder {
+                    let v: Double
+                    switch key {
+                    case "p95": v = b.p95
+                    case "p5": v = b.p5
+                    default: v = b.p50
+                    }
+                    out.append(Datum(id: "\(key)-\(segment.id)-\(b.ts)",
+                                     date: date(at: i),
+                                     series: key,
+                                     run: "\(key)#\(segment.id)",
+                                     value: v,
+                                     thin: segment.thin))
+                }
+            }
+        }
+        return out
+    }
+
+    private func bandData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
+        var out: [BandDatum] = []
+        for segment in segments where !segment.isIsolated {
+            for i in segment.from...segment.to {
+                guard let b = points[i] else { continue }
+                out.append(BandDatum(id: "band-\(segment.id)-\(b.ts)",
+                                     date: date(at: i),
+                                     run: segment.id,
+                                     low: b.p5,
+                                     high: b.p95,
+                                     thin: segment.thin))
+            }
+        }
+        return out
+    }
+
+    /// Buckets with no neighbour to make an area with. Drawn as a whisker
+    /// rather than dropped: a lone bucket is exactly where a reader most needs
+    /// to see how wide the range was, and it would otherwise be the only one
+    /// whose spread is invisible.
+    private func whiskerData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
+        segments.filter(\.isIsolated).compactMap { segment in
+            guard let b = points[segment.from] else { return nil }
+            return BandDatum(id: "whisker-\(segment.id)", date: date(at: segment.from), run: segment.id,
+                             low: b.p5, high: b.p95, thin: segment.thin)
+        }
+    }
+
+    var body: some View {
+        let segments = self.segments
+        let lines = lineData(segments)
+        Chart {
+            // FIRST in the builder, so the plane and the rules sit UNDER the
+            // lines. The band is context; the p50 line is the headline, and it
+            // is the last ink down so nothing crosses over it.
+            ForEach(bandData(segments)) { d in
+                AreaMark(
+                    x: .value("Date", d.date),
+                    yStart: .value("p5", d.low),
+                    yEnd: .value("p95", d.high),
+                    series: .value("Band", d.run)
+                )
+                .foregroundStyle(d.thin ? AutonomyPalette.bandThin : AutonomyPalette.band)
+                .interpolationMethod(.monotone)
+            }
+            ForEach(whiskerData(segments)) { d in
+                RuleMark(
+                    x: .value("Date", d.date),
+                    yStart: .value("p5", d.low),
+                    yEnd: .value("p95", d.high)
+                )
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: d.thin ? [3, 3] : []))
+                .foregroundStyle(AutonomyPalette.edge)
+            }
+            // The source-change markers: the marker explains the data, it is
+            // not part of it, so it sits under the curves too.
+            //
+            // A LONG-DASHED 1.5 pt rule, deliberately unlike the axis gridlines
+            // below (solid hairlines): before, both were thin dashes in a muted
+            // colour and the one line on the chart that carries an explanation
+            // was indistinguishable from furniture.
+            ForEach(data.visibleBoundaries) { boundary in
+                RuleMark(x: .value("Source change", boundary.date))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [6, 3]))
+                    .foregroundStyle(Color.secondary.opacity(0.75))
+                    .annotation(position: .top,
+                                alignment: captionAlignment(for: boundary),
+                                spacing: 2) {
+                        // This element writes the words; the panel below draws
+                        // the same rule uncaptioned. See AutonomyBoundaryCaption.
+                        if AutonomyBoundaryCaption.isShown(element: .aggregate) {
+                            Text(boundary.label)
+                                .font(.system(size: 9))
+                                .foregroundColor(.secondary)
+                                .opacity(0.9)
+                                .fixedSize()
+                        }
+                    }
+            }
+            ForEach(lines) { d in
+                LineMark(
+                    x: .value("Date", d.date),
+                    y: .value("Duration", d.value),
+                    series: .value("Run", d.run)
+                )
+                .foregroundStyle(AutonomyPalette.lineColor)
+                .interpolationMethod(.monotone)
+                .lineStyle(StrokeStyle(lineWidth: AutonomyPalette.lineWidth(AutonomyPalette.role(of: d.series)),
+                                       dash: d.thin ? [3, 3] : []))
+                .opacity(AutonomyPalette.opacity(AutonomyPalette.role(of: d.series), thin: d.thin))
+            }
+            // Thin buckets are marked rather than hidden: a hollow point on
+            // every line at that bucket, so a low-sample day is visibly
+            // different from a well-sampled one without being dropped. Inside a
+            // smooth band this is the third signal, alongside the fainter plane
+            // and the dashed edges.
+            ForEach(lines.filter(\.thin)) { d in
+                PointMark(
+                    x: .value("Date", d.date),
+                    y: .value("Duration", d.value)
+                )
+                .symbol(.circle)
+                .symbolSize(28)
+                .foregroundStyle(AutonomyPalette.lineColor)
+                .opacity(0.45)
+            }
+        }
+        .chartLegend(.hidden)
+        // LINEAR, and what that costs is stated where the domain is chosen —
+        // see HistoryAutonomyDurationResponse.yDomain. This is the maintainer's
+        // explicit call (#1905): no toggle, and no log path behind a flag.
+        .chartYScale(domain: data.yDomain)
+        .chartYAxis {
+            AxisMarks { value in
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                AxisValueLabel {
+                    if let v = value.as(Double.self) {
+                        Text(AutonomyFormat.duration(v))
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                // Solid hairlines. Dashed x gridlines read as several source
+                // markers and made the real one impossible to find.
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                AxisValueLabel {
+                    if let d = value.as(Date.self) {
+                        Text(AutonomyFormat.axisDate(d, timeZone: timeZone))
+                    }
+                }
+            }
+        }
+    }
+
+    /// Which side of its rule a boundary caption hangs off — see
+    /// `AutonomyBoundaryCaption`. `.trailing` puts the caption's trailing edge
+    /// on the rule (text extends left), `.leading` its leading edge (text
+    /// extends right).
+    private func captionAlignment(for boundary: HistoryAutonomyBoundary) -> Alignment {
+        AutonomyBoundaryCaption.side(fraction: data.domainFraction(of: boundary)) == .left
+            ? .trailing
+            : .leading
+    }
+}
+
 // MARK: - The stack's key
 
-/// Two entries, because a panel draws two things: a line and a row of bars.
-/// Each swatch takes the SHAPE of what it stands for — a pair of identically
-/// coloured dots would be a key that says the same thing twice.
+/// Four entries, because the section draws four marks: the aggregate chart's
+/// p50 line and p5–p95 plane, and the panel's longest-run line and concurrency
+/// bars. Each swatch takes the SHAPE of what it stands for — four identically
+/// coloured dots would be a key that says the same thing four times.
 private struct AutonomyKeyView: View {
     var body: some View {
         HStack(spacing: IrrSpacing.sp3) {
@@ -416,10 +790,16 @@ private struct AutonomyKeyView: View {
 
     @ViewBuilder private func swatch(_ entry: AutonomyKeyEntry) -> some View {
         switch entry.kind {
-        case .line:
+        case .p50, .line:
             Capsule()
                 .fill(entry.color)
                 .frame(width: 16, height: 2)
+        case .band:
+            (entry.fill ?? Color.clear)
+                .frame(width: 16, height: 9)
+                .overlay(alignment: .top) { entry.color.frame(height: 1) }
+                .overlay(alignment: .bottom) { entry.color.frame(height: 1) }
+                .clipShape(RoundedRectangle(cornerRadius: 1))
         case .bars:
             HStack(alignment: .bottom, spacing: 2) {
                 entry.color.frame(width: 3, height: 4)
@@ -436,37 +816,92 @@ private struct AutonomyKeyView: View {
 /// One entry of the stack's key. `kind` names the MARK it stands for, so a key
 /// entry cannot be given a colour for something the panels do not draw.
 struct AutonomyKeyEntry: Identifiable, Equatable {
-    enum Kind: String { case line, bars }
+    enum Kind: String { case p50, band, line, bars }
 
     let kind: Kind
     let label: String
     let color: Color
+    /// The band's plane. nil for every entry that is a stroke and has no area.
+    let fill: Color?
+
+    init(kind: Kind, label: String, color: Color, fill: Color? = nil) {
+        self.kind = kind
+        self.label = label
+        self.color = color
+        self.fill = fill
+    }
 
     var id: String { kind.rawValue }
 }
 
+/// The concurrency histogram's own y axis (#1905), as a pure function so what
+/// it draws is testable without a chart.
+///
+/// TWO VALUES: the band's full-height peak and 0. That is what the axis actually
+/// means — a bar's height is its peak as a fraction of the highest peak, so the
+/// top and the floor are the only two exact readings — and a ladder in a 40 pt
+/// band would be four numbers ten points apart.
+///
+/// EMPTY when nothing overlapped anywhere in the panel: with no bar drawn, an
+/// axis labelled 0 to 0 would be furniture claiming a measurement. This is the
+/// twin of the web's `autonomyBarAxisLabels`.
+enum AutonomyBarAxis {
+    static func values(peak: Int) -> [Int] {
+        guard peak > 0 else { return [] }
+        return [0, peak]
+    }
+
+    static func label(_ v: Int) -> String { String(v) }
+}
+
 enum AutonomyPalette {
-    /// ONE HUE, TWO WEIGHTS. The longest-run line is `working` at full
-    /// strength; the concurrency histogram under it is the same hue, quieter,
-    /// because the bars are a second reading of the same activity and not a
-    /// second subject. `barsAreTheLineHue` in the tests pins that.
+    /// ONE HUE, FOUR WEIGHTS. Both lines are `working` at full strength; the
+    /// band, its edges and the concurrency histogram are the same hue, quieter,
+    /// because they are further readings of the same activity and not further
+    /// subjects. `marksAreOneHue` in the tests pins that.
     ///
-    /// What went: a colour per percentile. The first round drew p95 green, p50
-    /// purple and p5 orange — three equally loud curves and a legend that had to
-    /// be decoded before the chart said anything.
+    /// What never came back: a colour per percentile. The first round drew p95
+    /// green, p50 purple and p5 orange — three equally loud curves and a legend
+    /// that had to be decoded before the chart said anything.
     static var lineColor: Color { IrrColors.working }
     static var bars: Color { IrrColors.autonomyBar }
+    static var band: Color { IrrColors.autonomyBand }
+    static var bandThin: Color { IrrColors.autonomyBandThin }
+    static var edge: Color { IrrColors.autonomyEdge }
 
-    /// The stack's key: exactly two entries, because a panel draws exactly two
-    /// things.
+    /// The three drawn percentile lines, in draw order, and what each is FOR.
+    /// The colours no longer separate them, so the roles do — and the chart
+    /// reads its stroke weights from here rather than from a literal beside each
+    /// mark. Mirrors the web's AUTONOMY_SERIES.
+    static let seriesOrder = ["p95", "p50", "p5"]
+    enum Role { case line, edge }
+    static let seriesRoles: [String: Role] = ["p95": .edge, "p50": .line, "p5": .edge]
+    static func role(of key: String) -> Role { seriesRoles[key] ?? .line }
+
+    /// Stroke weight per role. The line carries the chart; the edges are
+    /// present enough to bound the plane and quiet enough not to compete.
+    static func lineWidth(_ role: Role) -> CGFloat { role == .line ? 1.8 : 1 }
+    static func opacity(_ role: Role, thin: Bool) -> Double {
+        switch (role, thin) {
+        case (.line, false): return 1
+        case (.line, true): return 0.6
+        case (.edge, false): return 0.5
+        case (.edge, true): return 0.32
+        }
+    }
+
+    /// The section's key: exactly four entries, because it draws exactly four
+    /// marks, in the order they appear on screen.
     ///
-    /// SAME TWO STRINGS AS THE WEB's side-panel key (AUTONOMY_KEY in
+    /// SAME FOUR STRINGS AS THE WEB's side-panel key (AUTONOMY_KEY in
     /// platforms/web/historyTab.js), and pinned against it by `the two surfaces
     /// name the key the same way` — two clients must not explain one chart
     /// differently. That panel is 260 pt where this popover is 380, so the
     /// length that fits THERE is the length both carry.
     static var keyEntries: [AutonomyKeyEntry] {
         [
+            AutonomyKeyEntry(kind: .p50, label: "p50 · the typical run", color: lineColor),
+            AutonomyKeyEntry(kind: .band, label: "p5–p95 · the usual spread", color: edge, fill: band),
             AutonomyKeyEntry(kind: .line, label: "longest run in a bucket", color: lineColor),
             AutonomyKeyEntry(kind: .bars, label: "working at once (peak)", color: bars),
         ]
@@ -506,6 +941,14 @@ enum AutonomyFormat {
         guard peak > 0 else { return "" }
         guard splitKnown else { return "\(peak) at once" }
         return "\(peak) at once (\(top) + \(sub) sub)"
+    }
+
+    /// What the panel draws instead of an empty frame when the selected project
+    /// has no runs in this range. Same wording as the web's
+    /// `autonomyEmptyProjectNote` — two clients must not explain one state
+    /// differently.
+    static func emptyProjectNote(_ project: String) -> String {
+        "no runs for \(project.isEmpty ? "this project" : project) in this range"
     }
 
     /// The caveat beside the `at once` figure, and it is not optional: without

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -92,11 +92,17 @@ struct HistoryView: View {
     // daemon's own chart=="state" special-case in resolveHistoryQuery).
     @State private var stateGranularity: HistoryGranularity = .hr24
 
-    // Autonomy (#1905) — ONE picker. The tab is a single element now (five
-    // per-project panels), so it has a single window: Range, sent as ?window=,
-    // whose keys are window LENGTHS (unlike stateGranularity's same-looking
-    // keys, which are bucket widths). The strip's Span went with the strip.
+    // Autonomy (#1905) — ONE window picker for BOTH elements. Range is sent as
+    // ?window= by each of the two requests, and its keys are window LENGTHS
+    // (unlike stateGranularity's same-looking keys, which are bucket widths).
+    // The strip's Span went with the strip.
     @State private var autonomyRange: HistoryAutonomyRange = .days30
+    // …and which project the single panel draws. nil = "no choice made yet" →
+    // rank 1. It is NOT part of queryKey: the payload already carries every
+    // project, so changing it is a repaint rather than a refetch — and holding
+    // the NAME rather than the rank is what makes the choice survive a Range
+    // change instead of silently swapping projects when the ranking reorders.
+    @State private var autonomyProject: String?
     // There is no section-wide run-scope state any more (#1905 recording): the
     // section counts every run, subagent runs included, so there is nothing to
     // hold and nothing for the query key below to vary on.
@@ -112,8 +118,9 @@ struct HistoryView: View {
     @State private var yieldResponse: HistoryYieldResponse?
     @State private var doraResponse: HistoryDoraResponse?
     @State private var stateResponse: HistoryStateResponse?
-    // Autonomy has its own payload shape and its own window, so it keeps its
-    // own slot rather than sharing the single-chart one above.
+    // Autonomy fetches BOTH elements for one tab render, so it keeps two
+    // responses rather than sharing the single-chart slot above.
+    @State private var autonomyDuration: HistoryAutonomyDurationResponse?
     @State private var autonomyProjects: HistoryAutonomyProjectsResponse?
     @State private var loadFailed = false
 
@@ -319,13 +326,17 @@ struct HistoryView: View {
         .font(.caption)
     }
 
-    /// Autonomy tab (#1905): Range, and only Range. It governs all five
-    /// panels, which are the first thing under this row.
+    /// Autonomy tab (#1905): Range, and only Range. It governs BOTH elements,
+    /// which are the first thing under this row.
     ///
     /// Span — the run strip's window — used to sit here beside it, two controls
     /// above two elements with nothing on screen saying which moved which, and
     /// two vocabularies that overlap textually (`30d` was a Range value AND a
     /// Span value). The strip is gone and Span went with it.
+    ///
+    /// The project picker is NOT here either, for the same reason spelled the
+    /// other way round: it moves ONE element, so it lives in that element's own
+    /// header row. A control's place is what says what it moves.
     ///
     /// It is not the shared `range`: the section answers a different question
     /// over a different window, and uses no Group or drilldown at all.
@@ -477,10 +488,12 @@ struct HistoryView: View {
         }
     }
 
-    /// Autonomy tab (#1905): the five per-project panels.
+    /// Autonomy tab (#1905): both elements, always together — the aggregate
+    /// percentile chart above, one project panel below.
     @ViewBuilder private var autonomyContent: some View {
-        if let d = autonomyProjects {
-            HistoryAutonomyContentView(data: d, range: autonomyRange)
+        if let duration = autonomyDuration, let d = autonomyProjects {
+            HistoryAutonomyContentView(duration: duration, data: d, range: autonomyRange,
+                                       selectedProject: $autonomyProject)
         } else if loadFailed {
             loadFailedText
         } else {
@@ -618,22 +631,28 @@ struct HistoryView: View {
         }
     }
 
-    /// Autonomy (#1905) has its own window and its own payload shape, so it
-    /// cannot be folded into the shared single-chart fetch above.
+    /// Autonomy (#1905) fetches BOTH elements — the tab shows them together
+    /// over the same window, and neither can be folded into the shared
+    /// single-chart fetch above. A failure in either marks the tab failed
+    /// rather than showing one element beside a frame that never resolves.
     private func fetchAutonomy() async {
         loadFailed = false
-        let d: HistoryAutonomyProjectsResponse? =
-            await fetchAutonomyPart(chart: "autonomy_projects", window: autonomyRange.rawValue)
+        async let duration: HistoryAutonomyDurationResponse? =
+            fetchAutonomyPart(chart: "autonomy_duration", window: autonomyRange.rawValue)
+        async let projects: HistoryAutonomyProjectsResponse? =
+            fetchAutonomyPart(chart: "autonomy_projects", window: autonomyRange.rawValue)
+        let (dur, d) = await (duration, projects)
         if Task.isCancelled { return }
-        guard let d else {
+        guard let dur, let d else {
             loadFailed = true
             return
         }
+        autonomyDuration = dur
         autonomyProjects = d
     }
 
-    /// The Autonomy request. Returns nil on any failure — the caller decides
-    /// what that means rather than the fetch guessing.
+    /// One Autonomy request. Returns nil on any failure — the caller decides
+    /// what an incomplete pair means, rather than each half guessing.
     private func fetchAutonomyPart<T: Decodable>(chart: String, window: String) async -> T? {
         var comps = URLComponents(string: "\(DaemonEndpoint.httpBase)/api/v1/history")
         // The chart and its window, and nothing else (#1905 recording). Every

--- a/platforms/macos/Tests/HistoryAutonomyDurationTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyDurationTests.swift
@@ -1,0 +1,272 @@
+import SwiftUI
+import XCTest
+
+@testable import Irrlicht
+
+/// The Autonomy section's AGGREGATE element (chart=autonomy_duration), restored
+/// in #1905 after #1919 deleted it.
+///
+/// Everything here except `testTheAggregateAxisIsLinearAndStartsAtZero` is a
+/// LOCK: it pins behaviour that existed before, so it passes by construction
+/// against the restored code and cannot have been seen red first. What it CAN
+/// show is that the restore is faithful — the gap rule, the thin-bucket split
+/// and the shared seam all behave as they did.
+final class HistoryAutonomyDurationTests: XCTestCase {
+
+    // MARK: Decoding
+
+    func testDurationResponseDecodesIncludingOmittedThin() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1,2],
+         "buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":100,"count":30},
+                    {"ts":2,"p95":9,"p50":5,"p5":1,"min":1,"max":9,"count":3,"thin":true}],
+         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
+         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(r.buckets.count, 2)
+        XCTAssertFalse(r.buckets[0].thin, "`thin` is omitempty on the wire — absent must decode as false")
+        XCTAssertTrue(r.buckets[1].thin)
+        XCTAssertEqual(r.thinCount, 1)
+        XCTAssertEqual(r.sampleFloor, 20)
+        XCTAssertEqual(r.earliestSpan, 1_700_000_000)
+        XCTAssertEqual(r.totalRecorded, 33)
+        XCTAssertTrue(r.hasData)
+        XCTAssertEqual(r.summary.p95, 100)
+        XCTAssertEqual(r.summary.count, 33)
+    }
+
+    func testEmptyBucketListIsNoData() throws {
+        let json = """
+        {"window":"1y","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":604800,
+         "bucket_starts":[1,2,3],"buckets":[],
+         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
+         "sample_floor":20,"earliest_span":0,"total_recorded":0}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertFalse(r.hasData, "a fully-drawn axis with no buckets is still \"no data\"")
+        XCTAssertFalse(r.bucketStarts.isEmpty, "the axis is still sent, so the chart can say what window it is")
+        XCTAssertEqual(r.thinCount, 0)
+    }
+
+    /// Provenance, kinds and measurement are optional so a payload from a daemon
+    /// that predates them decodes rather than failing outright — and absent
+    /// means SAY NOTHING, which is not the same claim as "there were none".
+    func testAPayloadWithoutTheCensusesStillDecodes() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"buckets":[{"ts":1,"p95":9,"p50":5,"p5":1,"min":1,"max":9,"count":2}],
+         "summary":{"p95":9,"p50":5,"p5":1,"min":1,"max":9,"count":2},
+         "sample_floor":20,"earliest_span":0,"total_recorded":2}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertNil(r.kinds)
+        XCTAssertEqual(r.provenanceOrNone, .none)
+        XCTAssertEqual(r.measurementOrNone, .none)
+    }
+
+    // MARK: The LINEAR axis (#1905)
+
+    /// The maintainer's explicit call. The committed mutation is `logLower` —
+    /// the log domain's floor of 1s, which exists only because a log scale
+    /// cannot plot 0.
+    func testTheAggregateAxisIsLinearAndStartsAtZero() throws {
+        let d = try duration(starts: [1, 2], present: [1, 2])
+        XCTAssertEqual(d.yDomain.lowerBound, 0,
+                       "a linear axis whose origin is not zero exaggerates every difference above it")
+        // The drawn p95 is 90 and the true max 90, so the domain is 90 * 1.1.
+        XCTAssertEqual(d.yDomain.upperBound, 99, accuracy: 0.001)
+
+        let logLower = Swift.max(1.0, 10.0 * 0.8)
+        XCTAssertNotEqual(logLower, d.yDomain.lowerBound,
+                          "the log domain's 1s floor has no reason to exist on a linear axis")
+    }
+
+    /// The domain covers the TRUE max as well as the drawn p95, so the figure
+    /// row's "longest" is never a number above the top of its own chart.
+    func testTheDomainCoversTheTrueExtreme() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],
+         "buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":41940,"count":30}],
+         "summary":{"p95":100,"p50":50,"p5":10,"min":10,"max":41940,"count":30},
+         "sample_floor":20,"earliest_span":0,"total_recorded":30}
+        """
+        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertGreaterThanOrEqual(d.yDomain.upperBound, 41_940)
+    }
+
+    /// What linear COSTS, recorded rather than hidden: with one 11h39m run in
+    /// the window, a typical 10m run sits in the bottom ~1.5% of the plot. The
+    /// figure row under the chart carries p95/p50/p5 and the extremes as
+    /// NUMBERS for exactly this reason.
+    func testTheCostOfALinearAxisIsRecorded() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],
+         "buckets":[{"ts":1,"p95":1200,"p50":600,"p5":60,"min":60,"max":41940,"count":30}],
+         "summary":{"p95":1200,"p50":600,"p5":60,"min":60,"max":41940,"count":30},
+         "sample_floor":20,"earliest_span":0,"total_recorded":30}
+        """
+        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertLessThan(600 / d.yDomain.upperBound, 0.02)
+    }
+
+    func testAnEmptyWindowStillHasAPlottableDomain() throws {
+        let d = try duration(starts: [1, 2], present: [])
+        XCTAssertGreaterThan(d.yDomain.upperBound, d.yDomain.lowerBound,
+                             "a zero-width domain would make Swift Charts draw nothing at all")
+    }
+
+    // MARK: The band's geometry
+
+    /// The daemon OMITS empty buckets, and reading `buckets` directly hands
+    /// Swift Charts a dense list in which the gap simply is not there — so it
+    /// connects straight across. `alignedBuckets` is what puts the hole back.
+    func testAlignedBucketsPutTheGapBack() throws {
+        let d = try duration(starts: [100, 200, 300, 400], present: [100, 400])
+        let aligned = d.alignedBuckets
+        XCTAssertEqual(aligned.count, 4)
+        XCTAssertNotNil(aligned[0])
+        XCTAssertNil(aligned[1], "an omitted bucket is a GAP, not a zero")
+        XCTAssertNil(aligned[2])
+        XCTAssertNotNil(aligned[3])
+    }
+
+    /// A LINE drawn across a gap interpolates; a FILLED AREA drawn across one
+    /// paints a whole plane over days that hold no runs at all.
+    func testABandSegmentNeverSpansAnEmptyBucket() throws {
+        let d = try duration(starts: [100, 200, 300, 400, 500], present: [100, 200, 400, 500])
+        let points = d.alignedBuckets
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments.map { [$0.from, $0.to] }, [[0, 1], [3, 4]])
+        // Stated as the property, not just the shape.
+        for segment in segments {
+            for i in segment.from...segment.to {
+                XCTAssertNotNil(points[i], "segment \(segment.id) covers an omitted bucket")
+            }
+        }
+    }
+
+    /// THE COMMITTED MUTATION: the "one polygon over everything present" build —
+    /// the shape a fill takes by default, and the shape that silently claims the
+    /// gap. It answers identically for a gapped range and an unbroken one;
+    /// production must not.
+    func testProductionTellsAGappedRangeFromAnUnbrokenOne() throws {
+        let gapped = try duration(starts: [1, 2, 3], present: [1, 3]).alignedBuckets
+        let whole = try duration(starts: [1, 2, 3], present: [1, 2, 3]).alignedBuckets
+
+        let bridging: ([HistoryAutonomyBucket?]) -> [AutonomyBandLayout.Segment] = {
+            [AutonomyBandLayout.Segment(from: 0, to: $0.count - 1, thin: false)]
+        }
+        XCTAssertEqual(bridging(gapped), bridging(whole))
+
+        XCTAssertEqual(AutonomyBandLayout.segments(points: whole),
+                       [AutonomyBandLayout.Segment(from: 0, to: 2, thin: false)])
+        XCTAssertNotEqual(AutonomyBandLayout.segments(points: gapped),
+                          AutonomyBandLayout.segments(points: whole))
+        // Two isolated buckets — a bridging build would have drawn one plane
+        // straight over the empty day between them.
+        XCTAssertEqual(AutonomyBandLayout.segments(points: gapped),
+                       [AutonomyBandLayout.Segment(from: 0, to: 0, thin: false),
+                        AutonomyBandLayout.Segment(from: 2, to: 2, thin: false)])
+    }
+
+    /// A thin bucket's p95 IS its maximum and its p5 IS its minimum. Inside one
+    /// smooth plane that distinction disappears, so the plane splits there and
+    /// the thin stretch is filled from its own fainter token.
+    func testAThinStretchIsItsOwnSegmentAndTheSeamIsShared() {
+        let points: [HistoryAutonomyBucket?] = [
+            bucket(1), bucket(2), bucket(3, thin: true), bucket(4), bucket(5),
+        ]
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments, [
+            AutonomyBandLayout.Segment(from: 0, to: 1, thin: false),
+            AutonomyBandLayout.Segment(from: 1, to: 3, thin: true),
+            AutonomyBandLayout.Segment(from: 3, to: 4, thin: false),
+        ])
+        // Adjacent segments SHARE their boundary index — a seam would show as a
+        // hairline crack down the band.
+        for i in 1..<segments.count {
+            XCTAssertEqual(segments[i].from, segments[i - 1].to)
+        }
+    }
+
+    /// The stroke dashes a segment either of whose ends is thin; the fill has to
+    /// split on the same rule, or the dashes and the plane disagree about where
+    /// the thin stretch is.
+    func testThinnessBelongsToTheIntervalNotTheBucket() {
+        let segments = AutonomyBandLayout.segments(points: [bucket(1), bucket(2, thin: true), bucket(3)])
+        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 0, to: 2, thin: true)])
+    }
+
+    /// A lone bucket has no neighbour to make an area with. Reported as a
+    /// zero-width segment so the chart can draw its spread as a whisker rather
+    /// than leaving the one bucket that most needs a range with none.
+    func testAnIsolatedBucketIsAZeroWidthSegment() throws {
+        let points = try duration(starts: [1, 2, 3], present: [2]).alignedBuckets
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 1, to: 1, thin: false)])
+        XCTAssertTrue(segments[0].isIsolated)
+    }
+
+    func testAnEmptyAxisProducesNoSegments() {
+        XCTAssertTrue(AutonomyBandLayout.segments(points: []).isEmpty)
+        XCTAssertTrue(AutonomyBandLayout.segments(points: [nil, nil]).isEmpty)
+    }
+
+    // MARK: The boundary rule lands on the same instant as the panel's
+
+    /// The two elements share one window, so a boundary is at the same fraction
+    /// of each — which is what lets one caption on the top element explain a
+    /// rule drawn on both.
+    func testBoundaryFractionMatchesThePanelsForTheSameWindow() throws {
+        let starts: [Int64] = [0, 100, 200, 300, 400]
+        let boundary = HistoryAutonomyBoundary(ts: 200, from: "cost", to: "log")
+        let d = try duration(starts: starts, present: [0, 400],
+                             boundaries: [["ts": 200, "from": "cost", "to": "log"]])
+        XCTAssertEqual(d.visibleBoundaries.map(\.ts), [200])
+        XCTAssertEqual(d.domainFraction(of: boundary), 0.5, accuracy: 0.0001)
+    }
+
+    /// STRICTLY inside: a rule on the first or last bucket marks nothing and
+    /// reads as a chart border.
+    func testABoundaryOnTheAxisItselfIsNotDrawn() throws {
+        let d = try duration(starts: [0, 100, 200], present: [0],
+                             boundaries: [["ts": 0, "from": "cost", "to": "log"],
+                                          ["ts": 200, "from": "log", "to": "live"]])
+        XCTAssertTrue(d.visibleBoundaries.isEmpty)
+    }
+
+    // MARK: Fixtures
+
+    private func bucket(_ ts: Int64, thin: Bool = false) -> HistoryAutonomyBucket {
+        HistoryAutonomyBucket(ts: ts, p95: 90, p50: 50, p5: 10,
+                              min: 10, max: 90, count: thin ? 3 : 30, thin: thin)
+    }
+
+    /// A decoded response over `starts`, carrying a bucket for each ts in
+    /// `present`. Built through the DECODER rather than a memberwise init, so a
+    /// wire-shape change fails here too rather than only in the decode tests.
+    private func duration(starts: [Int64],
+                          present: [Int64],
+                          boundaries: [[String: Any]] = []) throws -> HistoryAutonomyDurationResponse {
+        let buckets = present.map { ts in
+            "{\"ts\":\(ts),\"p95\":90,\"p50\":50,\"p5\":10,\"min\":10,\"max\":90,\"count\":30}"
+        }.joined(separator: ",")
+        let rules = boundaries.map { b in
+            "{\"ts\":\(b["ts"] ?? 0),\"from\":\"\(b["from"] ?? "")\",\"to\":\"\(b["to"] ?? "")\"}"
+        }.joined(separator: ",")
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":\(starts.first ?? 0),
+         "end":\(starts.last ?? 0),"bucket_seconds":86400,
+         "bucket_starts":[\(starts.map(String.init).joined(separator: ","))],
+         "buckets":[\(buckets)],
+         "summary":{"p95":90,"p50":50,"p5":10,"min":10,"max":90,"count":\(present.count * 30)},
+         "sample_floor":20,"earliest_span":1700000000,"total_recorded":\(present.count * 30),
+         "provenance":{"reconstructed":0,"cost_derived":0,"live_since":0,"boundaries":[\(rules)]}}
+        """
+        return try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+    }
+}

--- a/platforms/macos/Tests/HistoryAutonomyDurationTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyDurationTests.swift
@@ -83,34 +83,88 @@ final class HistoryAutonomyDurationTests: XCTestCase {
                           "the log domain's 1s floor has no reason to exist on a linear axis")
     }
 
-    /// The domain covers the TRUE max as well as the drawn p95, so the figure
-    /// row's "longest" is never a number above the top of its own chart.
-    func testTheDomainCoversTheTrueExtreme() throws {
+    /// THE DEFECT: the domain was `max(p95, max)`, and `max` is a value the
+    /// chart does not draw. It draws p95, p50, p5 and the plane between p95 and
+    /// p5; the true extremes are FIGURES in the summary row, which is the whole
+    /// reason #1905 made them figures — "one four-hour run left going overnight
+    /// would otherwise redraw the whole Y scale and flatten every other bucket
+    /// into the floor".
+    ///
+    /// Measured on the reference machine's live span log (30-day window, 27 of
+    /// 30 buckets with data, 2735 runs): highest p95 1h37m against a highest max
+    /// of 11h39m — a 7.19x inflation that put the tallest p50 at 0.92% of the
+    /// plot height and the median p50 at 0.46%, i.e. on the axis, with 87.4% of
+    /// the plot empty above the band.
+    ///
+    /// The committed mutation is `scaledToMax` below: the domain that shipped.
+    func testTheDomainFitsWhatIsDrawnNotAnUndrawnOutlier() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1,2],
+         "buckets":[{"ts":1,"p95":5820,"p50":424,"p5":60,"min":60,"max":41940,"count":300},
+                    {"ts":2,"p95":3000,"p50":210,"p5":30,"min":30,"max":4000,"count":120}],
+         "summary":{"p95":5820,"p50":424,"p5":60,"min":30,"max":41940,"count":420},
+         "sample_floor":20,"earliest_span":0,"total_recorded":420}
+        """
+        let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+
+        // The top tracks the highest DRAWN p95.
+        XCTAssertEqual(d.yDomain.upperBound, 5820 * 1.1, accuracy: 0.001)
+
+        // …and the p50 line stays legible rather than collapsing onto the axis.
+        let tallestP50 = d.buckets.map(\.p50).max() ?? 0
+        XCTAssertGreaterThan(tallestP50 / d.yDomain.upperBound, 0.05)
+
+        // THE MUTATION: the shipped domain, scaled to the undrawn max.
+        let scaledToMax = (d.buckets.flatMap { [$0.p95, $0.max] }.max() ?? 0) * 1.1
+        XCTAssertGreaterThan(scaledToMax, d.yDomain.upperBound * 5,
+                             "the mutation is indistinguishable from production on this fixture")
+        XCTAssertLessThan(tallestP50 / scaledToMax, 0.01)
+    }
+
+    /// Dropping `max` from the AXIS must not drop it from the section: the
+    /// figure row under the chart still states the true extremes, which is
+    /// where the ticket wanted them.
+    func testTheExtremesKeepTheirPlaceAsFigures() throws {
         let json = """
         {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
          "bucket_starts":[1],
-         "buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":41940,"count":30}],
-         "summary":{"p95":100,"p50":50,"p5":10,"min":10,"max":41940,"count":30},
-         "sample_floor":20,"earliest_span":0,"total_recorded":30}
+         "buckets":[{"ts":1,"p95":5820,"p50":424,"p5":60,"min":60,"max":41940,"count":300}],
+         "summary":{"p95":5820,"p50":424,"p5":60,"min":6,"max":41940,"count":420},
+         "sample_floor":20,"earliest_span":0,"total_recorded":420}
         """
         let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
-        XCTAssertGreaterThanOrEqual(d.yDomain.upperBound, 41_940)
+        XCTAssertEqual(d.summary.max, 41_940, "the outlier is still reported, as a number")
+        XCTAssertEqual(d.summary.min, 6)
+        XCTAssertEqual(AutonomyFormat.duration(d.summary.max), "11h39m")
+        XCTAssertGreaterThan(d.summary.max, d.yDomain.upperBound,
+                             "a figure above the top of its own chart is exactly the point: it is a "
+                             + "number, not a line")
     }
 
-    /// What linear COSTS, recorded rather than hidden: with one 11h39m run in
-    /// the window, a typical 10m run sits in the bottom ~1.5% of the plot. The
-    /// figure row under the chart carries p95/p50/p5 and the extremes as
-    /// NUMBERS for exactly this reason.
+    /// What linear COSTS, recorded rather than hidden: one day whose p95 really
+    /// was 11h39m sets the domain, and a typical day's 10m p50 then sits in the
+    /// bottom ~1.5% of the plot. The figure row under the chart carries
+    /// p95/p50/p5 and the extremes as NUMBERS for exactly this reason.
+    ///
+    /// The long value here is a p95, not a `max`, because the axis reads only
+    /// what it draws — see `testTheDomainFitsWhatIsDrawnNotAnUndrawnOutlier`.
+    /// The cost is real either way; what changed is that it is now paid to a
+    /// line the reader can see.
     func testTheCostOfALinearAxisIsRecorded() throws {
         let json = """
         {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
-         "bucket_starts":[1],
-         "buckets":[{"ts":1,"p95":1200,"p50":600,"p5":60,"min":60,"max":41940,"count":30}],
-         "summary":{"p95":1200,"p50":600,"p5":60,"min":60,"max":41940,"count":30},
-         "sample_floor":20,"earliest_span":0,"total_recorded":30}
+         "bucket_starts":[1,2],
+         "buckets":[{"ts":1,"p95":41940,"p50":9000,"p5":600,"min":600,"max":43000,"count":30},
+                    {"ts":2,"p95":1200,"p50":600,"p5":60,"min":60,"max":1500,"count":30}],
+         "summary":{"p95":41940,"p50":600,"p5":60,"min":60,"max":43000,"count":60},
+         "sample_floor":20,"earliest_span":0,"total_recorded":60}
         """
         let d = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
-        XCTAssertLessThan(600 / d.yDomain.upperBound, 0.02)
+        XCTAssertEqual(d.yDomain.upperBound, 41_940 * 1.1, accuracy: 0.001)
+        XCTAssertLessThan(600 / d.yDomain.upperBound, 0.02,
+                          "the quiet day's typical run is flattened toward the floor — the cost of a "
+                          + "linear axis, paid to a p95 the chart actually draws")
     }
 
     func testAnEmptyWindowStillHasAPlottableDomain() throws {

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -139,53 +139,116 @@ final class HistoryAutonomyTests: XCTestCase {
         XCTAssertTrue(segments[0].isIsolated, "it has no neighbour to draw a segment to, so it is drawn as a point")
     }
 
-    // MARK: The shared log axis
+    // MARK: The panel's own LINEAR axis
 
-    /// Shared, so the projects are comparable — that is the point of picking
-    /// five. Log, because a project whose best is two minutes would otherwise
-    /// be a flat line under one whose best is eleven hours.
-    func testTheYDomainSpansEveryPanel() throws {
+    /// ITS OWN, because exactly one panel is drawn: there is nothing left to be
+    /// comparable WITH, and a domain stretched to fit projects that are not on
+    /// screen would flatten the one that is.
+    ///
+    /// The committed mutation is `sharedUpper` — the shared domain the
+    /// five-panel stack used. Under it `small`'s 120s is plotted against
+    /// `big`'s 11h39m and is a flat line on the floor.
+    func testTheYDomainIsTheDrawnPanelsOwn() throws {
         let d = try response(bucketStarts: [0],
                              panels: [("big", [(0, 41_940.0, 5)]), ("small", [(0, 120.0, 1)])])
-        let domain = try XCTUnwrap(d.sharedYDomain)
-        XCTAssertLessThanOrEqual(domain.lowerBound, 120)
-        XCTAssertGreaterThanOrEqual(domain.upperBound, 41_940)
+        let own = try XCTUnwrap(d.panels[1].yDomain)
+        XCTAssertEqual(own.upperBound, 120 * 1.1, accuracy: 0.001)
+
+        let sharedUpper = d.panels.compactMap { $0.buckets.map(\.longest).max() }.max() ?? 0
+        XCTAssertGreaterThan(sharedUpper, own.upperBound,
+                             "a shared domain would put the small project's whole plot on the floor")
     }
 
-    /// The committed mutation: a per-panel domain. Under it `small`'s own 120s
-    /// would sit at the top of its plot while `big`'s 120s sat near the bottom,
-    /// and the five panels would not be comparable at all.
-    func testProductionTellsASharedDomainFromAPerPanelOne() throws {
-        // `small` FIRST on purpose: a mutation that reads only the first panel
-        // would then produce the per-panel domain here, and this goes red too
-        // rather than leaving one assertion to carry the whole rule.
-        let d = try response(bucketStarts: [0],
-                             panels: [("small", [(0, 120.0, 1)]), ("big", [(0, 41_940.0, 5)])])
-        let shared = try XCTUnwrap(d.sharedYDomain)
-        let onlySmall = try response(bucketStarts: [0], panels: [("small", [(0, 120.0, 1)])])
-        let perPanel = try XCTUnwrap(onlySmall.sharedYDomain)
-        XCTAssertNotEqual(shared.upperBound, perPanel.upperBound,
-                          "a per-panel domain would put the small project's own maximum at the top of " +
-                          "its plot, and the five panels would not be comparable")
-        XCTAssertGreaterThan(shared.upperBound, perPanel.upperBound)
+    /// LINEAR, not logarithmic. The maintainer's explicit call (#1905), and the
+    /// committed mutation is the log mapping that shipped before: halfway up a
+    /// LINEAR plot is half the domain, where on a log plot it is the geometric
+    /// mean.
+    func testTheAxisIsLinearAndStartsAtZero() throws {
+        let d = try response(bucketStarts: [0], panels: [("p", [(0, 100.0, 1)])])
+        let domain = try XCTUnwrap(d.panels[0].yDomain)
+        XCTAssertEqual(domain.lowerBound, 0,
+                       "a linear axis whose origin is not zero exaggerates every difference above it")
+        XCTAssertEqual(domain.upperBound, 110, accuracy: 0.001)
+
+        // The MUTATION: the log domain, floored at 1s because a log scale
+        // cannot plot 0. Its lower bound is not zero, which is the difference.
+        let logLower = Swift.max(1, 100.0 * 0.8)
+        XCTAssertNotEqual(logLower, domain.lowerBound)
     }
 
-    func testAnEmptyWindowHasNoDomainRatherThanAFabricatedOne() throws {
+    /// What linear COSTS, recorded rather than hidden: a project whose longest
+    /// day is 11h39m plots its typical 10m runs in the bottom ~1.5% of the plot.
+    /// The panel header states the exact longest as a NUMBER for this reason.
+    func testTheCostOfALinearAxisIsRecorded() throws {
+        let d = try response(bucketStarts: [0], panels: [("big", [(0, 41_940.0, 5)])])
+        let domain = try XCTUnwrap(d.panels[0].yDomain)
+        let fraction = 600 / domain.upperBound
+        XCTAssertLessThan(fraction, 0.02, "10m of an 11h39m domain is under 2% of the plot height")
+    }
+
+    func testAnEmptyPanelHasNoDomainRatherThanAFabricatedOne() throws {
         let none = try response(bucketStarts: [0], panels: [])
-        XCTAssertNil(none.sharedYDomain)
-        // …and a window whose only bucket has a bar but no finished run.
+        XCTAssertTrue(none.panels.isEmpty)
+        // …and a panel whose only bucket has a bar but no finished run.
         let barsOnly = try response(bucketStarts: [0], panels: [("p", [(0, 0.0, 2)])])
-        XCTAssertNil(barsOnly.sharedYDomain)
-        XCTAssertEqual(barsOnly.sharedPeakScale, 2)
+        XCTAssertNil(barsOnly.panels[0].yDomain)
+        XCTAssertEqual(barsOnly.panels[0].peakScale, 2)
     }
 
-    func testThePeakScaleIsSharedToo() throws {
+    func testThePeakScaleIsThePanelsOwn() throws {
         let d = try response(bucketStarts: [0],
                              panels: [("a", [(0, 60.0, 5)]), ("b", [(0, 60.0, 2)])])
-        XCTAssertEqual(d.sharedPeakScale, 5)
+        XCTAssertEqual(d.panels[0].peakScale, 5)
+        XCTAssertEqual(d.panels[1].peakScale, 2, "the drawn panel's own peak, not the other's")
         let flat = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 0)])])
-        XCTAssertEqual(flat.sharedPeakScale, 0,
+        XCTAssertEqual(flat.panels[0].peakScale, 0,
                        "nothing overlapped anywhere, so no bar is drawn rather than every bar full height")
+    }
+
+    // MARK: The histogram labels its own y axis (#1905)
+
+    /// "On the bar chart below the number of agents running in parallel is not
+    /// visible." The gutter beside the bars was deliberately BLANK — an
+    /// `AxisMarks(values: [0])` carrying a spacer string, kept only so the bars
+    /// stayed in register with the plot above.
+    ///
+    /// The committed mutation is `blankGutter` below: what shipped.
+    func testTheHistogramAxisIsLabelledAtItsPeakAndZero() {
+        XCTAssertEqual(AutonomyBarAxis.values(peak: 15), [0, 15])
+        XCTAssertEqual(AutonomyBarAxis.label(15), "15")
+        XCTAssertEqual(AutonomyBarAxis.label(0), "0")
+
+        let blankGutter: [Int] = []
+        XCTAssertNotEqual(AutonomyBarAxis.values(peak: 15), blankGutter,
+                          "the shipped gutter carried no scale at all, which is the defect")
+    }
+
+    /// An axis labelled 0 to 0 would be furniture claiming a measurement.
+    func testAPanelNobodyOverlappedInGetsNoHistogramAxis() {
+        XCTAssertEqual(AutonomyBarAxis.values(peak: 0), [])
+        XCTAssertEqual(AutonomyBarAxis.values(peak: -1), [])
+    }
+
+    /// QA-4 (#1905). Both axes are labelled in the SAME right-hand gutter now,
+    /// and neither knows about the other: the line axis's lowest label sits at
+    /// the foot of its plot and the histogram's peak label at the head of the
+    /// bar band. The web build showed the consequence in a browser — "0s" and
+    /// "15" overprinted into a smudge at the 3 pt gap the five-panel stack used,
+    /// where the bar band carried no labels at all.
+    ///
+    /// The committed mutation is `beforeTheGap` below: butted together, the two
+    /// labels' 9 pt boxes intersect.
+    func testTheTwoAxesClearEachOtherInTheSharedGutter() {
+        let font = AutonomyPanelMetrics.tickFontSize
+        let gap = AutonomyPanelMetrics.chartGap
+        // Each label is drawn centred on its own line, so half a glyph hangs
+        // off each side; clearing one whole font is what keeps them apart.
+        XCTAssertGreaterThanOrEqual(gap, font,
+                                    "the line axis's floor label and the histogram's peak label overprint")
+
+        let beforeTheGap: CGFloat = 1
+        XCTAssertLessThan(beforeTheGap, font,
+                          "the shipped spacing did not overprint, so this check cannot show the fix")
     }
 
     // MARK: The concurrency figure, and the split it may not invent
@@ -235,65 +298,117 @@ final class HistoryAutonomyTests: XCTestCase {
         XCTAssertEqual(HistoryAutonomyPanel(project: "p", longest: 600).headline, "longest 10m")
     }
 
-    // MARK: The stack, and what it left out
+    // MARK: One panel at a time, and the picker that chooses it (#1905)
 
-    func testTheStackDrawsThePanelsItWasSentAndNamesTheRest() throws {
+    func testNothingSelectedDrawsRankOne() throws {
         let d = try response(bucketStarts: [0],
-                             panels: (0..<5).map { ("p\($0)", [(Int64(0), 60.0, 1)]) },
-                             moreProjects: 7)
-        let rows = d.stackRows
-        XCTAssertEqual(rows.count, 6)
-        guard case let .more(label) = rows[5] else {
-            return XCTFail("the last stack row must be the overflow line, got \(rows[5])")
-        }
-        XCTAssertEqual(label, "+7 more projects, each with less autonomous time")
+                             panels: [("irrlicht", [(0, 600.0, 2)]), ("articles", [(0, 300.0, 1)])])
+        let choice = d.choice(selected: nil)
+        XCTAssertEqual(choice.project, "irrlicht")
+        XCTAssertEqual(choice.panel?.project, "irrlicht")
+        XCTAssertFalse(choice.isMissing)
     }
 
-    func testTheStackSaysNothingWhenEveryProjectHasAPanel() throws {
+    func testASelectionThisRangeHoldsDrawsThatProject() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: [("irrlicht", [(0, 600.0, 2)]), ("articles", [(0, 300.0, 1)])])
+        let choice = d.choice(selected: "articles")
+        XCTAssertEqual(choice.panel?.project, "articles")
+        XCTAssertFalse(choice.isMissing)
+    }
+
+    /// The committed mutation is `silentFallback` — `first(where:) ?? first`,
+    /// the silent fall back to rank 1. Under it a Range change looks like a
+    /// click the reader never made, and the project they were looking at is
+    /// gone with nothing on screen saying where it went.
+    func testASelectionThisRangeDoesNotHoldIsKeptAndMarked() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: [("irrlicht", [(0, 600.0, 2)]), ("articles", [(0, 300.0, 1)])])
+        let silentFallback = d.panels.first { $0.project == "besenkammer" } ?? d.panels[0]
+        XCTAssertEqual(silentFallback.project, "irrlicht")
+
+        let choice = d.choice(selected: "besenkammer")
+        XCTAssertEqual(choice.project, "besenkammer")
+        XCTAssertNil(choice.panel)
+        XCTAssertTrue(choice.isMissing)
+        XCTAssertEqual(AutonomyFormat.emptyProjectNote("besenkammer"),
+                       "no runs for besenkammer in this range")
+    }
+
+    func testAnEmptyWindowChoosesNothingRatherThanInventingAProject() throws {
+        let d = try response(bucketStarts: [0], panels: [])
+        XCTAssertNil(d.choice(selected: nil).panel)
+        XCTAssertEqual(d.choice(selected: nil).project, "")
+        XCTAssertTrue(d.projectOptions(selected: nil).isEmpty)
+    }
+
+    /// The committed mutation: a client that re-decides the list itself. Two
+    /// surfaces doing that is exactly how the run strip ended up drawing twelve
+    /// rows on the web against six here, from one ranked list — and a picker
+    /// that caps its own list drops projects the summary beside it still counts.
+    func testThePickerOffersWhatItWasSentNeverItsOwnSlice() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: (0..<40).map { ("p\($0)", [(Int64(0), 60.0, 1)]) },
+                             moreProjects: 0)
+        let clientCap = Array(d.panels.prefix(5))
+        XCTAssertEqual(clientCap.count, 5)
+        XCTAssertEqual(d.projectOptions(selected: nil).count, d.panels.count)
+        XCTAssertEqual(d.projectOptions(selected: nil).count, 40)
+    }
+
+    /// Last by the SAME rule the rest follow — the order is most autonomous
+    /// time first, and a project with no runs in this range has none of it.
+    func testAnAbsentSelectionStaysInThePickerLastAndLabelled() throws {
+        let d = try response(bucketStarts: [0],
+                             panels: [("irrlicht", [(0, 600.0, 2)]), ("articles", [(0, 300.0, 1)])])
+        let options = d.projectOptions(selected: "besenkammer")
+        XCTAssertEqual(options.map(\.project), ["irrlicht", "articles", "besenkammer"])
+        XCTAssertTrue(options[2].isMissing)
+        XCTAssertTrue(options[2].label.contains("no runs in this range"), "got: \(options[2].label)")
+        XCTAssertEqual(options[0].label, "irrlicht", "a present project is named plainly")
+    }
+
+    // MARK: What the payload cap left out
+
+    func testTheOverflowLineNamesWhatTheCapLeftOut() throws {
+        let d = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 1)])], moreProjects: 7)
+        let label = try XCTUnwrap(d.overflowLabel)
+        XCTAssertTrue(label.hasPrefix("+7 more projects past the payload cap"), "got: \(label)")
+        XCTAssertTrue(label.contains("less autonomous time"), "got: \(label)")
+    }
+
+    func testNothingIsSaidWhenTheCapLeftNothingOut() throws {
         let d = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 1)])], moreProjects: 0)
         XCTAssertNil(d.overflowLabel)
-        XCTAssertEqual(d.stackRows.count, 1)
     }
 
     func testOneHiddenProjectIsSingular() throws {
         let d = try response(bucketStarts: [0], panels: [("a", [(0, 60.0, 1)])], moreProjects: 1)
-        XCTAssertEqual(try XCTUnwrap(d.overflowLabel),
-                       "+1 more project, each with less autonomous time")
+        XCTAssertTrue(try XCTUnwrap(d.overflowLabel).hasPrefix("+1 more project past"))
     }
 
-    /// The committed mutation: a client that re-decides the panel count itself.
-    /// Two surfaces doing that is exactly how the run strip ended up drawing
-    /// twelve rows on the web against six here, from one ranked list.
-    func testTheClientRendersWhatItWasSentNeverItsOwnCount() throws {
-        let d = try response(bucketStarts: [0],
-                             panels: (0..<5).map { ("p\($0)", [(Int64(0), 60.0, 1)]) },
-                             moreProjects: 7)
-        let clientCap = Array(d.panels.prefix(3))
-        XCTAssertEqual(clientCap.count, 3)
-        let drawn = d.stackRows.filter { if case .panel = $0 { return true } else { return false } }
-        XCTAssertEqual(drawn.count, d.panels.count)
-        XCTAssertEqual(drawn.count, 5)
-    }
+    // MARK: The boundary caption reads once across the section
 
-    // MARK: The boundary caption reads once across the stack
-
-    /// The rule runs through all five panels — it has to, or it annotates one
-    /// project's line and leaves the four below it stepping for no stated
-    /// reason — but the caption is drawn on exactly one.
-    func testTheCaptionIsWrittenOnceNotOncePerPanel() {
-        let carrying = (0..<5).filter { AutonomyBoundaryCaption.isShown(panelIndex: $0) }
+    /// The rule is drawn on BOTH elements — it has to be, or it annotates the
+    /// aggregate line and leaves the panel below it stepping for no stated
+    /// reason — but the caption is written by exactly one.
+    func testTheCaptionIsWrittenOnceNotOncePerElement() {
+        let carrying = AutonomyBoundaryCaption.Element.allCases
+            .filter { AutonomyBoundaryCaption.isShown(element: $0) }
         XCTAssertEqual(carrying.count, 1)
-        XCTAssertEqual(carrying, [AutonomyBoundaryCaption.panelIndex])
-        XCTAssertTrue(AutonomyBoundaryCaption.isShown(panelIndex: 0))
-        XCTAssertFalse(AutonomyBoundaryCaption.isShown(panelIndex: 4))
+        XCTAssertEqual(carrying, [AutonomyBoundaryCaption.captionedBy])
+        XCTAssertTrue(AutonomyBoundaryCaption.isShown(element: .aggregate),
+                      "the top element carries the words")
+        XCTAssertFalse(AutonomyBoundaryCaption.isShown(element: .panel))
     }
 
-    /// The committed mutation: captioning every panel. It passes "a caption is
-    /// drawn" and fails the thing that matters, which is that there is one.
-    func testProductionTellsOneCaptionFromFive() {
-        let captionEverywhere: (Int) -> Bool = { _ in true }
-        XCTAssertEqual((0..<5).filter(captionEverywhere).count, 5)
-        XCTAssertEqual((0..<5).filter { AutonomyBoundaryCaption.isShown(panelIndex: $0) }.count, 1)
+    /// The committed mutation: captioning every element. It passes "a caption
+    /// is drawn" and fails the thing that matters, which is that there is one.
+    func testProductionTellsOneCaptionFromTwo() {
+        let captionEverywhere: (AutonomyBoundaryCaption.Element) -> Bool = { _ in true }
+        XCTAssertEqual(AutonomyBoundaryCaption.Element.allCases.filter(captionEverywhere).count, 2)
+        XCTAssertEqual(AutonomyBoundaryCaption.Element.allCases
+            .filter { AutonomyBoundaryCaption.isShown(element: $0) }.count, 1)
     }
 
     /// The caption hangs off whichever side of its rule has room. Pinned to the
@@ -331,37 +446,55 @@ final class HistoryAutonomyTests: XCTestCase {
 
     // MARK: The palette and the key
 
-    /// ONE HUE, TWO WEIGHTS: the bars are the line's hue, quieter. What went is
-    /// a colour per percentile — three equally loud curves and a legend that
-    /// had to be decoded before the chart said anything.
+    /// ONE HUE, FOUR WEIGHTS: every quieter mark is the line's hue at a lower
+    /// alpha. What never came back is a colour per percentile — three equally
+    /// loud curves and a legend that had to be decoded before the chart said
+    /// anything.
     @MainActor
-    func testBarsAreTheLineHue() {
+    func testMarksAreOneHue() {
         for appearance in [NSAppearance(named: .aqua)!, NSAppearance(named: .darkAqua)!] {
             let line = rgb(AutonomyPalette.lineColor, appearance)
-            let bars = rgb(AutonomyPalette.bars, appearance)
-            XCTAssertEqual(line.r, bars.r, accuracy: 0.02, "\(appearance.name.rawValue): red")
-            XCTAssertEqual(line.g, bars.g, accuracy: 0.02, "\(appearance.name.rawValue): green")
-            XCTAssertEqual(line.b, bars.b, accuracy: 0.02, "\(appearance.name.rawValue): blue")
-            XCTAssertLessThan(bars.a, line.a,
-                              "\(appearance.name.rawValue): a histogram at the line's full strength " +
-                              "competes with the line above it")
+            for (name, color) in [("bars", AutonomyPalette.bars),
+                                  ("band", AutonomyPalette.band),
+                                  ("bandThin", AutonomyPalette.bandThin),
+                                  ("edge", AutonomyPalette.edge)] {
+                let mark = rgb(color, appearance)
+                let where_ = "\(appearance.name.rawValue)/\(name)"
+                XCTAssertEqual(line.r, mark.r, accuracy: 0.02, "\(where_): red")
+                XCTAssertEqual(line.g, mark.g, accuracy: 0.02, "\(where_): green")
+                XCTAssertEqual(line.b, mark.b, accuracy: 0.02, "\(where_): blue")
+                XCTAssertLessThan(mark.a, line.a,
+                                  "\(where_): a second reading at the line's full strength competes " +
+                                  "with the line it belongs to")
+            }
         }
     }
 
-    func testTheKeyHasTwoEntriesOnePerMark() {
-        let entries = AutonomyPalette.keyEntries
-        XCTAssertEqual(entries.map(\.kind), [.line, .bars])
-        XCTAssertEqual(entries.map(\.id), ["line", "bars"])
+    /// The thin plane must be FAINTER than the ordinary one, or the marking
+    /// that says "these are not percentiles" says nothing at all.
+    @MainActor
+    func testTheThinPlaneIsFainterThanTheOrdinaryOne() {
+        for appearance in [NSAppearance(named: .aqua)!, NSAppearance(named: .darkAqua)!] {
+            XCTAssertLessThan(rgb(AutonomyPalette.bandThin, appearance).a,
+                              rgb(AutonomyPalette.band, appearance).a,
+                              "\(appearance.name.rawValue): a thin bucket's plane is not distinguishable")
+        }
     }
 
-    /// The p50/band key went with the percentiles: a key naming something the
-    /// panels do not draw would promise a distinction that no longer exists.
-    func testTheKeyExplainsItselfInWordsAndNamesNoPercentile() {
+    func testTheKeyHasFourEntriesOnePerMark() {
+        let entries = AutonomyPalette.keyEntries
+        XCTAssertEqual(entries.map(\.kind), [.p50, .band, .line, .bars])
+        XCTAssertEqual(entries.map(\.id), ["p50", "band", "line", "bars"])
+        // Only the band has an area; every other mark is a stroke.
+        XCTAssertEqual(entries.filter { $0.fill != nil }.map(\.kind), [.band])
+    }
+
+    /// Both elements' marks are named. A key that covered only one of them
+    /// would leave half the section's ink unexplained.
+    func testTheKeyExplainsBothElementsInWords() {
         let labels = AutonomyPalette.keyEntries.map(\.label).joined(separator: " ")
-        XCTAssertTrue(labels.contains("longest run"), "got: \(labels)")
-        XCTAssertTrue(labels.contains("at once"), "got: \(labels)")
-        for gone in ["p50", "p95", "spread", "typical"] {
-            XCTAssertFalse(labels.contains(gone), "\(gone) survives in the key: \(labels)")
+        for named in ["p50", "p5–p95", "spread", "longest run", "at once"] {
+            XCTAssertTrue(labels.contains(named), "\(named) is missing from the key: \(labels)")
         }
     }
 

--- a/platforms/web/autonomyLayout.test.js
+++ b/platforms/web/autonomyLayout.test.js
@@ -34,6 +34,7 @@ import {
   autonomyPanelRows,
   autonomyDuration,
   autonomyYDomain,
+  autonomyBarAxisLabels,
   autonomyTickValues,
   autonomyTickPlacement,
   autonomyBarRect,
@@ -109,9 +110,21 @@ describe('the Autonomy section offers exactly one window control', () => {
     expect(follows(row, layout), 'the panels must follow their Range picker').toBe(true);
   });
 
-  test('the panels live inside the chart card, beside the side panel', () => {
-    // Not a full-width block below it, which is where the run strip lived when
-    // it was a SECOND element. There is one element now.
+  // The project picker is NOT a second window control, and this is where that
+  // distinction is made concrete: Range moves BOTH elements and lives in the
+  // tab's control row; the project picker moves ONE and lives in that panel's
+  // own header row. A control's place is what says which.
+  test('the project picker is built into the panel, never into the control row', () => {
+    const d = doc();
+    expect(d.querySelector('#history-autonomy-range-row select')).toBeNull();
+    expect(js).toContain("sel.className = 'history-autonomy-project'");
+    // …and it is appended to the panel HEAD, beside the figures it changes.
+    const build = /function buildAutonomyPanel\([\s\S]*?\n}/.exec(js);
+    expect(build, 'fail-loud: buildAutonomyPanel not found in historyTab.js').not.toBeNull();
+    expect(build[0]).toContain('head.appendChild(buildAutonomyProjectSelect(');
+  });
+
+  test('the panel lives inside the chart card, beside the side panel', () => {
     const d = doc();
     const panels = d.querySelector('#history-autonomy-panels');
     const wrap = d.querySelector('#history-chart-wrap');
@@ -211,11 +224,14 @@ describe('the key rows fit the panel they are rendered in', () => {
   const geometry = panelGeometry();
   const width = (text) => text.length * geometry.fontSize * MONO_ADVANCE_EM;
   const unstyled = { getPropertyValue: () => '' };
-  const summary = { longest: 41_940, peak: 5, runs: 312, projects: 12 };
-  const keyRows = () => autonomyPanelRows(summary, unstyled).filter((r) => r.kind);
+  const payload = {
+    duration: { summary: { p95: 7080, p50: 660, p5: 41, min: 6, max: 41_940, count: 312 } },
+    projects: { summary: { longest: 41_940, peak: 5, runs: 312, projects: 12 } },
+  };
+  const keyRows = () => autonomyPanelRows(payload, unstyled).filter((r) => r.kind);
 
   test('the panel is wide enough for every key label on one line', () => {
-    expect(keyRows()).toHaveLength(2);
+    expect(keyRows()).toHaveLength(4);
     for (const row of keyRows()) {
       expect(width(row.label), `"${row.label}" (${row.label.length} chars) overruns the `
         + `${geometry.labelLine}px a key row's label gets`).toBeLessThan(geometry.labelLine);
@@ -285,15 +301,19 @@ describe('nothing in the panel truncates a key label or splits a figure', () => 
   // every one of them is asserting about markup nothing renders.
   test('the panel actually marks its key rows', () => {
     const list = new JSDOM('<ul id="l"></ul>').window.document.getElementById('l');
-    for (const row of autonomyPanelRows({ longest: 60, peak: 1, runs: 5, projects: 2 },
-      { getPropertyValue: () => '' })) {
+    const rows = autonomyPanelRows({
+      duration: { summary: { p50: 60, p5: 6, p95: 90 } },
+      projects: { summary: { longest: 60, peak: 1, runs: 5, projects: 2 } },
+    }, { getPropertyValue: () => '' });
+    for (const row of rows) {
       const li = list.ownerDocument.createElement('li');
       if (row.kind) li.className = 'autonomy-key';
       list.appendChild(li);
     }
-    // Two key rows, two unswatched figures — the same split
+    // Four key rows, two unswatched figures — the same split
     // renderAutonomySidePanel makes.
-    expect(list.querySelectorAll('li.autonomy-key')).toHaveLength(2);
+    expect(list.querySelectorAll('li.autonomy-key')).toHaveLength(4);
+    expect(rows).toHaveLength(6);
     expect(js).toMatch(/li\.className\s*=\s*'autonomy-key'/);
   });
 });
@@ -307,11 +327,11 @@ describe('the two surfaces name the key the same way', () => {
     join(WEB_DIR, '..', 'macos', 'Irrlicht', 'Views', 'HistoryAutonomyView.swift'), 'utf8',
   );
 
-  test('AutonomyPalette.keyEntries carries the web’s two labels verbatim', () => {
+  test('AutonomyPalette.keyEntries carries the web’s four labels verbatim', () => {
     const entries = /static var keyEntries: \[AutonomyKeyEntry\] \{([\s\S]*?)\n    \}/.exec(swift);
     expect(entries, 'fail-loud: no AutonomyPalette.keyEntries found in HistoryAutonomyView.swift').not.toBeNull();
     const labels = [...entries[1].matchAll(/label: "([^"]+)"/g)].map((m) => m[1]);
-    expect(labels, 'fail-loud: parsed no labels out of keyEntries').toHaveLength(2);
+    expect(labels, 'fail-loud: parsed no labels out of keyEntries').toHaveLength(4);
     const web = autonomyPanelRows(undefined, { getPropertyValue: () => '' })
       .filter((r) => r.kind)
       .map((r) => r.label);
@@ -336,9 +356,9 @@ describe('QA-1: a panel header and the topmost y tick never share a line', () =>
   // the RIGHT gutter (which frees the header row's column), and the canvas
   // gained a top inset (which keeps the topmost label inside the canvas).
   const width = 420;
-  const domain = autonomyYDomain([
+  const domain = autonomyYDomain(
     { buckets: [{ ts: 0, longest: 52_440, peak: 3 }, { ts: 1, longest: 120, peak: 1 }] },
-  ]);
+  );
 
   test('every tick label is drawn in a gutter to the right of the plot', () => {
     // Two claims, and the second is the one that distinguishes a real gutter
@@ -402,24 +422,38 @@ describe('QA-1: a panel header and the topmost y tick never share a line', () =>
 });
 
 describe('QA-2: the axis and the “+N more” line are inside the rendered card', () => {
-  // THE DEFECT: the stack sat in a fixed-height card with its own scrollbar, so
-  // five panels were compressed AND clipped at once — the x axis was cut off at
-  // the bottom edge — while ~250px of page sat empty below the card.
-  const PANELS = 5;
+  // THE DEFECT: the content sat in a fixed-height card with its own scrollbar,
+  // so it was compressed AND clipped at once — the x axis was cut off at the
+  // bottom edge — while ~250px of page sat empty below the card.
+  //
+  // The card holds MORE now, not less: the aggregate chart's canvas AND the
+  // project panel under it. One panel instead of five, but a taller one, and a
+  // 220px canvas above it.
 
-  // The stack's intrinsic height, from the same stylesheet and constants the
+  // The section's intrinsic height, from the same stylesheet and constants the
   // renderer uses. Throws rather than defaulting: a rule this cannot read is
   // one whose value nothing below can be trusted to have computed.
   function stackHeight() {
     const panel = ruleBody('.history-autonomy-panel');
     const head = ruleBody('.history-autonomy-panel-head');
+    const canvas = px(ruleBody('.history-chart-wrap.autonomy #history-chart'), 'height',
+      '.history-chart-wrap.autonomy #history-chart');
     const perPanel = AUTONOMY_PANEL_CANVAS_H
       + px(head, 'line-height', '.history-autonomy-panel-head')
       + px(panel, 'margin-bottom', '.history-autonomy-panel');
     const axis = px(ruleBody('.history-autonomy-axis'), 'font-size', '.history-autonomy-axis');
     const more = px(ruleBody('.history-autonomy-more'), 'font-size', '.history-autonomy-more');
-    return PANELS * perPanel + axis + more;
+    return canvas + perPanel + axis + more;
   }
+
+  // The aggregate chart is drawn on the shared canvas, so the canvas must NOT
+  // be hidden for this section — and inside an auto-height card its own
+  // `height: 100%` resolves to nothing, which is why it is given a px height.
+  test('the shared canvas keeps its place, with a height an auto card cannot supply', () => {
+    expect(js).toMatch(/canvas\.hidden = isState;/);
+    expect(px(ruleBody('.history-chart-wrap.autonomy #history-chart'), 'height',
+      '.history-chart-wrap.autonomy #history-chart')).toBeGreaterThan(100);
+  });
 
   test('the card releases its fixed height for this chart', () => {
     const body = ruleBody('.history-chart-wrap.autonomy');
@@ -430,7 +464,7 @@ describe('QA-2: the axis and the “+N more” line are inside the rendered card
     expect(body).not.toMatch(/max-height/);
   });
 
-  test('the stack does not scroll inside the card', () => {
+  test('the section does not scroll inside the card', () => {
     const body = ruleBody('.history-autonomy-panels');
     expect(body).not.toMatch(/overflow:\s*auto/);
     expect(body).not.toMatch(/overflow:\s*scroll/);
@@ -448,23 +482,23 @@ describe('QA-2: the axis and the “+N more” line are inside the rendered card
   // THE COMMITTED MUTATION: the fixed-height card. The stack is taller than it,
   // which is the whole reason the height had to go — and the two rows a
   // scrollbar cut off first are the last two in the stack.
-  test('the stack is taller than the fixed card it used to be clipped by', () => {
+  test('the section is taller than the fixed card it used to be clipped by', () => {
     const fixedCard = px(ruleBody('.history-chart-wrap'), 'height', '.history-chart-wrap')
       - 2 * px(ruleBody('.history-chart-wrap'), 'padding', '.history-chart-wrap');
-    expect(stackHeight(), `five panels need ${stackHeight()}px; the fixed card offered ${fixedCard}px`)
+    expect(stackHeight(), `the two elements need ${stackHeight()}px; the fixed card offered ${fixedCard}px`)
       .toBeGreaterThan(fixedCard);
   });
 
-  test('the min-height floor cannot clip the stack', () => {
+  test('the min-height floor cannot clip the section', () => {
     const floor = px(ruleBody('.history-chart-wrap.autonomy'), 'min-height', '.history-chart-wrap.autonomy');
     expect(floor).toBeLessThan(stackHeight());
   });
 
-  test('the axis is the last thing in the stack, so nothing can hide behind it', () => {
+  test('the axis is the last thing rendered, so nothing can hide behind it', () => {
     // Order matters for the clipping claim: the axis and the "+N more" line are
-    // appended after every panel, so a ceiling takes them first.
-    const render = /function renderAutonomyPanels\(\)[\s\S]*?\n}/.exec(js);
-    expect(render, 'fail-loud: renderAutonomyPanels not found in historyTab.js').not.toBeNull();
+    // appended after the panel, so a ceiling takes them first.
+    const render = /function renderAutonomyPanel\(\)[\s\S]*?\n}/.exec(js);
+    expect(render, 'fail-loud: renderAutonomyPanel not found in historyTab.js').not.toBeNull();
     expect(render[0].indexOf('history-autonomy-more'))
       .toBeLessThan(render[0].indexOf('buildAutonomyAxis(data)'));
   });
@@ -481,11 +515,41 @@ describe('QA-3: the concurrency bars share a baseline', () => {
     expect([...bottoms][0]).toBe(autonomyBaselineY());
   });
 
-  test('the baseline sits directly beneath the plot, at the foot of the panel', () => {
-    expect(autonomyBaselineY()).toBe(AUTONOMY_PANEL_CANVAS_H);
+  test('the baseline sits directly beneath the plot, clear of the canvas foot', () => {
+    // NOT the canvas's own bottom edge any more: the histogram labels its own
+    // baseline `0`, drawn centred on it, so padB is what keeps the lower half
+    // of that glyph inside the canvas.
+    expect(autonomyBaselineY()).toBe(AUTONOMY_PANEL_CANVAS_H - AUTONOMY_PANEL.padB);
+    expect(AUTONOMY_PANEL.padB * 2).toBeGreaterThanOrEqual(AUTONOMY_PANEL.tickFont);
     // …and immediately under the line plot, not floating below it.
     expect(autonomyBaselineY() - AUTONOMY_PANEL.barsH)
       .toBe(AUTONOMY_PANEL.padT + AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap);
+  });
+
+  // #1905: "on the bar chart below, the number of agents running in parallel is
+  // not visible". The bars carried the only figure on the panel with no scale
+  // of any kind — the gutter beside them was deliberately blank on both
+  // surfaces. It is labelled now, in the LINE chart's own gutter and font, so
+  // the two axes read as one column rather than as two competing ones.
+  test('the histogram’s own axis shares the line chart’s gutter and tick font', () => {
+    const draw = /function drawAutonomyBars\([\s\S]*?\n}/.exec(js);
+    expect(draw, 'fail-loud: drawAutonomyBars not found in historyTab.js').not.toBeNull();
+    expect(draw[0]).toContain('AUTONOMY_PANEL.tickFont');
+    expect(draw[0]).toContain('w - padR + AUTONOMY_PANEL.tickGap');
+    expect(draw[0]).toContain('autonomyBarAxisLabels(peakMax)');
+    // The same x the LINE chart's ticks are placed at, so one gutter serves
+    // both axes.
+    const at = autonomyTickPlacement(1, { lo: 0, hi: 2 }, 420);
+    expect(at.x).toBe(420 - AUTONOMY_PANEL.padR + AUTONOMY_PANEL.tickGap);
+  });
+
+  test('the axis goes red against the blank gutter that shipped', () => {
+    // THE COMMITTED MUTATION: `AxisMarks(values: [0]) { AxisValueLabel { Text("     ") } }`
+    // on macOS, and nothing at all on web — a gutter kept for alignment and
+    // left deliberately empty.
+    const blankGutter = [];
+    expect(autonomyBarAxisLabels(15)).not.toEqual(blankGutter);
+    expect(autonomyBarAxisLabels(15).map((l) => l.text)).toEqual(['15', '0']);
   });
 
   test('a bar of 1 and a bar of 15 are visibly different heights', () => {

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -12,21 +12,25 @@ const HISTORY_COLORS = [
 ];
 const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
 export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', state: 'Activity', yield: 'Yield', dora: 'DORA', autonomy: 'Autonomy' };
-// Autonomy (#1905). `autonomy` is a CLIENT-SIDE pseudo-chart name for the
-// daemon's chart=autonomy_projects: FIVE PER-PROJECT PANELS, one per project,
-// stacked, each carrying a longest-run line and a concurrency histogram under
-// it. One request, one payload — the section used to fan out into two charts
-// (a percentile band and a per-project run strip) and both are gone.
+// Autonomy (#1905). `autonomy` is a CLIENT-SIDE pseudo-chart name that fans out
+// into the daemon's TWO real charts, both over the same window:
+//
+//   chart=autonomy_duration - the AGGREGATE percentile chart across every
+//   project (p95/p50/p5, with the plane between p95 and p5 filled), drawn on
+//   the shared canvas.
+//   chart=autonomy_projects - the per-project panels, of which exactly ONE is
+//   drawn at a time, picked from a dropdown in its own header row.
+//
+// ONE Range control moves both, because they are read together: two windows
+// would let the chart show a month while the panel under it showed a year, with
+// nothing on screen saying they disagreed. The run strip's separate Span picker
+// was exactly that and went with the strip (chart=autonomy_spans stays deleted).
 //
 // WINDOW LENGTHS, not bucket widths. These keys overlap GRANULARITY_LABELS'
 // textually and mean something else entirely: there a key names a bucket width
 // that is multiplied by a count (so '24h' resolves to a THIRTY-DAY window),
 // here a key IS the window. The two tables must never be merged - see
 // autonomy window vocabularies in irrlicht.history.autonomy.test.js.
-//
-// There is no Span control any more. It governed the run strip's own window,
-// and it went with the strip: one window, one control, and no pair of
-// textually-overlapping vocabularies for a reader to keep apart.
 export const AUTONOMY_RANGE_LABELS = { '30d': '30 days', '1y': 'Year' };
 // Granularity steps for chart=state's activity matrix (issue #981) — each
 // picks both the server's bucket width and the matrix's visible column
@@ -66,13 +70,21 @@ const historyState = {
   // granularity is chart=state's own zoom-level axis (#981) — independent of
   // range, which every other chart uses instead.
   granularity: '24h',
-  // Autonomy (#1905): its own window, which is not `range`. One key now, not
-  // two - the run strip's Span went with the strip.
+  // Autonomy (#1905): its own window, which is not `range`. ONE key, shared by
+  // both of the section's elements.
   autonomyRange: '30d',
+  // Which project the single panel draws. null means "whatever the daemon ranks
+  // first", so a fresh tab needs no stored name; once the reader picks one, the
+  // NAME is held rather than the rank, and it SURVIVES a Range change. Holding
+  // a rank instead would silently swap the project under the reader whenever a
+  // longer window reordered the ranking.
+  autonomyProject: null,
   // There is no run-scope key here (#1905 recording): the section counts every
   // run, subagent runs included, because Irrlicht recorded them. What each run
   // WAS still matters - the `kind` field is what splits a concurrency peak into
   // sessions and subagents - but which runs are counted is not a choice.
+  //
+  // Holds BOTH payloads: { duration, projects }.
   autonomyData: null,
   filters: { provider: [], token_type: [], project: [] },
   known: { provider: [], project: [] },
@@ -254,10 +266,12 @@ function setHistoryFilterParams(p, state) {
   }
 }
 
-// autonomyQuery builds the Autonomy request: one chart, one window.
-export function autonomyQuery(state = historyState) {
+// autonomyQuery builds one of the two Autonomy requests. `element` picks which
+// chart; both send the SAME window, which is what makes one Range control
+// honest.
+export function autonomyQuery(element, state = historyState) {
   const p = new URLSearchParams();
-  p.set('chart', 'autonomy_projects');
+  p.set('chart', element === 'projects' ? 'autonomy_projects' : 'autonomy_duration');
   p.set('window', state.autonomyRange);
   // No run-scope parameter (#1905 recording). Every run counts, so there is
   // nothing to ask for - and sending the retired one would leave an OLD daemon
@@ -281,18 +295,23 @@ export function historyQuery(state = historyState) {
   return p.toString();
 }
 
-// fetchAutonomy fetches the section's single payload.
+// fetchAutonomy fetches BOTH elements. Either failing marks the whole section
+// unloaded rather than drawing one chart beside an empty frame that never
+// resolves - the two are read together, so half of them is not a partial answer
+// but a misleading one.
 function fetchAutonomy() {
   const seq = ++historyFetchSeq;
-  return fetch('/api/v1/history?' + autonomyQuery())
+  const get = (element) => fetch('/api/v1/history?' + autonomyQuery(element))
     .then(r => (r.ok ? r.json() : null))
-    .catch(() => null)
-    .then(data => {
-      if (seq !== historyFetchSeq) return; // superseded by a newer request
-      historyState.autonomyData = data || null;
-      historyState.data = historyState.autonomyData;
-      renderHistory();
-    });
+    .catch(() => null);
+  return Promise.all([get('duration'), get('projects')]).then(([duration, projects]) => {
+    if (seq !== historyFetchSeq) return; // superseded by a newer request
+    historyState.autonomyData = (duration && projects) ? { duration, projects } : null;
+    // `data` drives the shared empty/export paths, and the aggregate chart is
+    // what the shared canvas draws, so it is the one that goes there.
+    historyState.data = historyState.autonomyData ? duration : null;
+    renderHistory();
+  });
 }
 
 function fetchHistory() {
@@ -378,7 +397,8 @@ function paintActiveHistoryChart() {
       renderStatePanel();
       break;
     case 'autonomy':
-      renderAutonomyPanels();
+      paintAutonomyChart();
+      renderAutonomyPanel();
       renderAutonomySidePanel();
       break;
     default:
@@ -415,19 +435,19 @@ function syncHistoryMatrixVisibility(isState) {
   const canvas = document.getElementById('history-chart');
   const matrixScroll = document.getElementById('history-matrix-scroll');
   const isAutonomy = historyState.chart === 'autonomy';
-  // Autonomy joins chart=state in replacing the shared canvas with its own DOM
-  // block inside the SAME card, rather than taking a full-width strip below it:
-  // the section is now one element, so it belongs where every other chart is
-  // drawn, with the side panel keeping its place beside it.
-  if (canvas) canvas.hidden = isState || isAutonomy;
+  // Autonomy KEEPS the shared canvas — that is where its aggregate percentile
+  // chart is drawn — and adds its project panel underneath, inside the same
+  // card. Only chart=state replaces the canvas outright.
+  if (canvas) canvas.hidden = isState;
   if (matrixScroll) matrixScroll.hidden = !isState;
   const panels = document.getElementById('history-autonomy-panels');
   if (panels) panels.hidden = !isAutonomy;
-  // The card GROWS for the panel stack rather than scrolling inside its own
-  // fixed height (QA-2). Five panels do not fit 360px at a readable height, and
-  // the two things an inner scrollbar cut off first were the x axis and the
-  // "+N more" line — the row that says what the view left out. The class is
-  // scoped to this chart, so every other chart keeps its fixed-height card.
+  // The card GROWS for the two elements rather than scrolling inside its own
+  // fixed height (QA-2, #1919). The rows an inner scrollbar cut off first were
+  // the x axis and the "+N more" line — the row that says what the view left
+  // out. The class is scoped to this chart, so every other chart keeps its
+  // fixed-height card; it also gives the canvas an explicit height, which a
+  // percentage cannot supply inside an auto-height parent.
   const wrap = document.getElementById('history-chart-wrap');
   if (wrap) wrap.classList.toggle('autonomy', isAutonomy);
 }
@@ -725,33 +745,44 @@ function paintHistoryChart() {
 
 // --- Autonomy (#1905) ---
 //
-// FIVE PER-PROJECT PANELS over the always-on span log, stacked inside the
-// shared chart card. Every panel carries the same two things:
+// TWO ELEMENTS over the always-on span log, one above the other inside the
+// shared chart card, sharing one Range control:
 //
-//   A LINE — the longest run in each time bucket. Only `working` matters to
-//   this section now, so how a run ended is recorded and never drawn.
-//   A HISTOGRAM under it — how many runs were working AT THE SAME TIME in that
-//   bucket, derived by the daemon from the spans by overlap.
+//   THE AGGREGATE CHART, on the shared canvas — p95/p50/p5 of run duration
+//   across EVERY project, with the plane between p95 and p5 filled as a band.
+//   "Is autonomy getting better across the machine."
+//   ONE PROJECT PANEL below it — the longest run in each time bucket as a line,
+//   and how many runs were working at the same time under it as a histogram.
+//   "What did THIS project do." The project is picked from a dropdown in the
+//   panel's own header row.
 //
-// WHAT THIS REPLACED. The section used to be two elements: a p5–p95 band with a
-// p50 line, and a per-project run strip coloured by end reason. Both are gone,
-// along with the strip's legend and glyphs, the Span picker that governed its
-// window, and the sample floor that marked buckets whose p95 was really their
-// maximum. A maximum over one run IS that run, so the floor has nothing left to
-// protect and is not carried over as decoration.
+// WHY BOTH. A maximum over one project is that project's story; a maximum
+// charted across every project is a chart of whoever ran longest that day. A
+// percentile over the whole population is a trend; a percentile over one
+// project's four runs is not a percentile. Neither figure can stand in for the
+// other, which is why #1919's five-panels-only build lost something real and
+// this restores it.
 //
-// SHARED LOG Y ACROSS THE FIVE PANELS. Shared, because comparing the projects is
-// the point of picking five; log, because a project whose best day is two
-// minutes would otherwise be a flat line under one whose best is eleven hours.
-// Each panel states its own longest as a NUMBER in its header, so the exact
-// figure never depends on reading the axis.
+// WHY ONE PANEL AND NOT FIVE. Five panels squeezed each plot to 40px, and the
+// reader could still only compare the five the daemon happened to rank highest.
+// One panel gets 110px for its line and 44px for its bars, and the dropdown
+// reaches EVERY project the window holds.
+//
+// LINEAR Y ON BOTH, and the cost is stated where each domain is chosen
+// (autonomyYDomain, autonomyAggregateDomain) rather than left for the next
+// reader to rediscover.
+//
+// The panel's scales are THAT PROJECT'S OWN. They were shared across the five
+// so the five were comparable; with one panel drawn there is nothing to share
+// with, and a domain stretched to fit projects that are not on screen would
+// flatten the one that is.
 
 // autonomyEverRecorded reports whether the span log holds anything at all,
 // anywhere — the fact that separates "no runs in this range" from "this
 // feature has not collected anything yet". Both are empty views; only one of
 // them means the user did nothing.
 export function autonomyEverRecorded(state = historyState) {
-  return (Number(state.autonomyData?.total_recorded) || 0) > 0;
+  return (Number(state.autonomyData?.projects?.total_recorded) || 0) > 0;
 }
 
 // autonomyDuration formats a run length: "41s", "11m", "1h58m", "2d3h".
@@ -882,9 +913,9 @@ export const AUTONOMY_CONCURRENCY_CAVEAT =
 //
 // Resolution is the whole point (#1905 back-fill, QA-2). The cost log writes at
 // most every 60s and only when a value changed, so it cannot see a run shorter
-// than that; the event log records one-second runs. Across that boundary every
-// panel's line steps at the same instant, and five simultaneous steps read as
-// five findings when they are one change of INSTRUMENT.
+// than that; the event log records one-second runs. Across that boundary both
+// elements step at the same instant, and two simultaneous steps read as two
+// findings when they are one change of INSTRUMENT.
 const AUTONOMY_ERA_LABELS = {
   cost: 'cost log · 60s resolution',
   log: 'event log · rebuilt',
@@ -908,7 +939,8 @@ export function autonomyBoundaryLabel(boundary) {
 // a machine that was never back-filled, and most ranges on one that was.
 //
 // Pure, so both halves of the rule — draws one when it should, draws nothing
-// when it should not — are testable without a canvas.
+// when it should not — are testable without a canvas. Both elements read it,
+// and both share a window, so the rule lands at the same instant in each.
 export function autonomyVisibleBoundaries(data) {
   const starts = data?.bucket_starts || [];
   if (starts.length < 2) return [];
@@ -924,47 +956,82 @@ export function autonomyVisibleBoundaries(data) {
   return out;
 }
 
-// autonomyBoundaryCaptionShown decides which panel carries a boundary's words.
+// AUTONOMY_BOUNDARY_CAPTION_ON names which of the section's two elements writes
+// a boundary's words.
 //
-// THE RULE READS ONCE ACROSS THE STACK. The dashed rule is drawn through EVERY
-// panel — it has to be, or it would annotate one project's line and leave the
-// four below it stepping for no stated reason — but the caption is drawn on the
-// TOP panel only. Five copies of "← cost log · 60s resolution" stacked down one
-// x position is five competing captions where the reader needs one, and at 9px
-// they would collide with four project names.
-export const AUTONOMY_BOUNDARY_CAPTION_PANEL = 0;
-export function autonomyBoundaryCaptionShown(panelIndex) {
-  return panelIndex === AUTONOMY_BOUNDARY_CAPTION_PANEL;
+// THE RULE READS ONCE ACROSS THE SECTION. The dashed rule is drawn on BOTH
+// elements — it has to be, or it would annotate the aggregate line and leave the
+// panel below it stepping for no stated reason — but the caption is drawn on the
+// AGGREGATE chart only, which is the top one. Two copies of "← cost log · 60s
+// resolution" down one x position are two competing captions where the reader
+// needs one, and at 9px the lower one would collide with the panel's header.
+export const AUTONOMY_BOUNDARY_CAPTION_ON = 'aggregate';
+export function autonomyBoundaryCaptionShown(element) {
+  return element === AUTONOMY_BOUNDARY_CAPTION_ON;
 }
 
-// autonomyMoreProjectsLabel names what the five panels left out, or '' when
-// nothing was left out.
+// autonomyMoreProjectsLabel names what the daemon's safety cap left out, or ''
+// when nothing was left out — which is every machine seen so far, since the cap
+// is 200 and the busiest one on record holds 93 projects in a year.
 //
 // It says WHY those projects are the ones missing — they have less autonomous
-// time — so the reader knows the section took the tail rather than an arbitrary
+// time — so the reader knows the payload took the tail rather than an arbitrary
 // slice. An omission nothing mentions is indistinguishable from a project that
 // never ran.
 export function autonomyMoreProjectsLabel(data) {
   const more = Number(data?.more_projects) || 0;
   if (more <= 0) return '';
-  return '+' + more + ' more project' + (more === 1 ? '' : 's') + ', each with less autonomous time';
+  return '+' + more + ' more project' + (more === 1 ? '' : 's') + ' past the payload cap, '
+    + 'each with less autonomous time';
 }
 
-// autonomyStackRows is what the stack renders, in order: one entry per panel
-// the daemon sent, and — when the window holds more projects than those — a
-// final `more` entry naming the rest.
+// autonomyPanelChoice resolves which project the single panel draws.
 //
-// PURE, and the render loop's only source of truth about what appears, so
-// "exactly the panels the daemon sent, and the overflow line beside them" is
-// one assertion rather than a DOM crawl. The client never re-decides how many
-// panels there are: the daemon computes five and says how many it left out, so
-// the two surfaces cannot disagree the way the run strip's twelve-versus-six
-// row caps did.
-export function autonomyStackRows(data) {
-  const rows = (data?.panels || []).map(panel => ({ kind: 'panel', panel }));
-  const more = autonomyMoreProjectsLabel(data);
-  if (more) rows.push({ kind: 'more', label: more });
-  return rows;
+// THREE OUTCOMES, and the third is the one that has to be written down rather
+// than fallen into:
+//
+//   - nothing selected → rank 1, the project with the most autonomous time in
+//     the window. A fresh tab needs no stored name.
+//   - the selection is in this range → that panel.
+//   - the selection is NOT in this range → `missing`, and the selection is
+//     KEPT. Silently falling back to rank 1 would answer a question the reader
+//     did not ask, and would make a Range change look like a click they never
+//     made; the panel says "no runs for <project> in this range" instead, and
+//     the dropdown still carries the name so one Range change back restores it.
+export function autonomyPanelChoice(data, selected) {
+  const panels = data?.panels || [];
+  if (!selected) {
+    return { panel: panels[0] || null, project: panels[0]?.project || '', missing: false };
+  }
+  const found = panels.find(p => p.project === selected);
+  if (found) return { panel: found, project: selected, missing: false };
+  return { panel: null, project: selected, missing: true };
+}
+
+// autonomyProjectOptions is the dropdown's contents: every project the window
+// holds, ranked, plus the selected one when this range does not hold it.
+//
+// The absent project goes LAST and says so, which is the same rule the rest of
+// the list follows rather than an exception to it: the order is most autonomous
+// time first, and a project with no runs in this range has none of it. Its label
+// carries the reason, so a reader who opens the dropdown is not left wondering
+// why one entry draws nothing.
+export function autonomyProjectOptions(data, selected) {
+  const out = (data?.panels || []).map(p => ({ value: p.project, label: p.project, missing: false }));
+  if (selected && !out.some(o => o.value === selected)) {
+    out.push({ value: selected, label: selected + ' — no runs in this range', missing: true });
+  }
+  return out;
+}
+
+// autonomyEmptyProjectNote is what the panel draws instead of an empty frame
+// when the selected project has nothing in this range.
+//
+// A SENTENCE, not a blank plot. An empty plot with axes on it is the same
+// picture a broken request would draw, and the reader cannot tell which they are
+// looking at.
+export function autonomyEmptyProjectNote(project) {
+  return 'no runs for ' + (project || 'this project') + ' in this range';
 }
 
 // autonomyConcurrencyLabel renders one "at once" figure, with its split only
@@ -1007,6 +1074,17 @@ export function autonomyPanelPoints(panel, bucketStarts) {
   return (bucketStarts || []).map(ts => byTs.get(ts) || null);
 }
 
+// autonomyChartPoints does the same for the AGGREGATE chart's buckets. Same
+// rule, same reason, a different payload — one helper each rather than one
+// helper branching on shape, so neither can silently start reading the other's
+// fields.
+export function autonomyChartPoints(duration) {
+  const starts = duration?.bucket_starts || [];
+  const byTs = new Map();
+  for (const b of (duration?.buckets || [])) byTs.set(b.ts, b);
+  return starts.map(ts => byTs.get(ts) || null);
+}
+
 // autonomyLineSegments returns the index ranges the line may be stroked over.
 //
 // TWO KINDS OF GAP, and they are not the same gap. A bucket can be absent
@@ -1030,40 +1108,52 @@ export function autonomyLineSegments(points) {
   return out;
 }
 
-// autonomyYDomain is the log Y domain SHARED by all five panels. null when
-// nothing in the window has a length to plot, which is the empty state.
+// autonomyYDomain is the panel's LINEAR Y domain — that project's own, since
+// exactly one panel is drawn. null when nothing in the window has a length to
+// plot, which is the empty state.
 //
-// Shared, so the panels are comparable — that is the point of picking five.
-// Floored at 1s: a log scale cannot plot 0, and a sub-second span is not a run.
-export function autonomyYDomain(panels) {
-  const values = [];
-  for (const panel of (panels || [])) {
-    for (const b of (panel?.buckets || [])) {
-      const v = Number(b.longest) || 0;
-      if (v > 0) values.push(v);
-    }
-  }
+// LINEAR, AND WHAT THAT COSTS. This is the maintainer's explicit call (#1905),
+// recorded here so the next reader knows it was a decision and not an oversight.
+// On a linear axis one 11-hour run sets the whole domain, and the typical
+// 10-minute runs beneath it collapse into the bottom 1.5% of the plot — visually
+// indistinguishable from the floor. A log axis kept them apart, at the cost of
+// making a doubling look like a small step wherever the eye landed. The panel
+// header states the exact longest as a NUMBER for exactly this reason, so the
+// figure never depends on reading the axis.
+//
+// ZERO IS THE FLOOR, which the log axis could not offer: a linear axis whose
+// origin is not zero exaggerates every difference above it, and there is no
+// longer any "a log scale cannot plot 0" reason to lift it.
+export function autonomyYDomain(panel) {
+  const values = (panel?.buckets || []).map(b => Number(b.longest) || 0).filter(v => v > 0);
   if (!values.length) return null;
-  const lo = Math.max(1, Math.min(...values) * 0.8);
-  const hi = Math.max(lo * 2, Math.max(...values) * 1.25);
-  return { lo, hi };
+  return { lo: 0, hi: Math.max(...values) * 1.1 };
 }
 
-// autonomyPeakScale is the histogram's SHARED full-height value: the highest
-// peak any panel reaches. 0 when nothing overlapped anywhere, in which case no
-// bar is drawn at all rather than every bar being drawn full height.
-export function autonomyPeakScale(panels) {
+// autonomyAggregateDomain is the aggregate chart's LINEAR Y domain, taken from
+// the drawn p95s. Same decision and the same cost as autonomyYDomain above; the
+// summary row under the chart carries p95/p50/p5 and the true extremes as
+// FIGURES, which is what keeps them readable when the band flattens.
+export function autonomyAggregateDomain(points) {
+  const drawn = (points || []).filter(Boolean);
+  if (!drawn.length) return null;
+  const hi = Math.max(...drawn.map(b => Math.max(Number(b.p95) || 0, Number(b.max) || 0, 1)));
+  return { lo: 0, hi: hi * 1.1 };
+}
+
+// autonomyPeakScale is the histogram's full-height value: the panel's own
+// highest peak. 0 when nothing overlapped anywhere in it, in which case no bar
+// is drawn at all rather than every bar being drawn full height.
+export function autonomyPeakScale(panel) {
   let max = 0;
-  for (const panel of (panels || [])) {
-    for (const b of (panel?.buckets || [])) {
-      const v = Number(b.peak) || 0;
-      if (v > max) max = v;
-    }
+  for (const b of (panel?.buckets || [])) {
+    const v = Number(b.peak) || 0;
+    if (v > max) max = v;
   }
   return max;
 }
 
-// autonomyAxisLabel formats one of the stack's two x bounds, coarsening with
+// autonomyAxisLabel formats one of the section's x bounds, coarsening with
 // the window the way stateBucketLabel does for the activity matrix.
 export function autonomyAxisLabel(ts, windowSeconds) {
   const d = new Date((Number(ts) || 0) * 1000);
@@ -1078,12 +1168,13 @@ export function autonomyAxisLabel(ts, windowSeconds) {
 // daemon has been up all day.
 //
 // Two kinds, two sentences, because they are two different limits and a reader
-// who conflated them would misread the panels in opposite directions:
+// who conflated them would misread the section in opposite directions:
 //
 //   - STILL RUNNING. The run has not ended, so its length is how long it has
-//     lasted SO FAR. It COUNTS towards the longest — the section reports a
-//     maximum, and "already lasted 3h" is true — and the panel that shows it
-//     says "still going" rather than presenting a floor as final.
+//     lasted SO FAR. It COUNTS towards the panel's longest — that figure is a
+//     maximum, and "already lasted 3h" is true — and is deliberately NOT a
+//     sample for the aggregate chart's percentiles, where a floor always
+//     shortens and shortens the longest runs hardest.
 //   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its start
 //     is where Irrlicht began watching rather than where the run began; a
 //     restart re-discovers every live session this way. Dropping those is what
@@ -1097,7 +1188,8 @@ export function autonomyMeasurementNote(payload) {
     parts.push(running + ' run' + (running === 1 ? ' is' : 's are') + ' still going: '
       + (running === 1 ? 'its length is' : 'their lengths are') + ' how long '
       + (running === 1 ? 'it has' : 'they have') + ' lasted SO FAR. '
-      + (running === 1 ? 'It counts' : 'They count') + ' towards the longest run, marked "still going".');
+      + (running === 1 ? 'It counts' : 'They count') + ' towards the longest run, marked "still going", '
+      + 'and ' + (running === 1 ? 'is' : 'are') + ' left out of the percentiles above.');
   }
   if (lowerBound > 0) {
     parts.push(lowerBound + ' run' + (lowerBound === 1 ? '' : 's') + ' already going when Irrlicht '
@@ -1108,8 +1200,21 @@ export function autonomyMeasurementNote(payload) {
   return parts.join(' ');
 }
 
-// The side panel's key: exactly two entries, because a panel draws exactly two
-// things — a line and a row of bars.
+// autonomyThinNote explains the aggregate chart's thin-bucket marking, in
+// words, because a fainter plane means nothing on its own. '' when every bucket
+// in view clears the floor.
+export function autonomyThinNote(duration) {
+  const buckets = duration?.buckets || [];
+  const thin = buckets.filter(b => b?.thin).length;
+  if (thin <= 0) return '';
+  return thin + ' of ' + buckets.length + ' buckets hold fewer than ' + (Number(duration?.sample_floor) || 0)
+    + ' runs (fainter band, dashed edges, hollow points): there p95 is that bucket’s longest run and '
+    + 'p5 its shortest — not percentiles.';
+}
+
+// The side panel's key: FOUR entries, because the section draws four marks —
+// the aggregate chart's p50 line and p5–p95 plane, and the panel's longest-run
+// line and concurrency bars.
 //
 // LENGTH IS A CONSTRAINT HERE, not a style preference. This panel is
 // `flex: 0 0 260px` with 16px padding, so a key row's label gets 204px once its
@@ -1118,17 +1223,19 @@ export function autonomyMeasurementNote(payload) {
 // `autonomyLayout.test.js` computes that budget from the stylesheet and fails
 // one that is too long.
 //
-// Both strings are duplicated in AutonomyPalette.keyEntries on macOS, and `the
-// two surfaces name the key the same way` reads this table against that one —
-// two clients must not explain one chart differently.
+// All four strings are duplicated in AutonomyPalette.keyEntries on macOS, and
+// `the two surfaces name the key the same way` reads this table against that one
+// — two clients must not explain one chart differently.
 const AUTONOMY_KEY = [
+  ['p50', 'p50 · the typical run'],
+  ['band', 'p5–p95 · the usual spread'],
   ['line', 'longest run in a bucket'],
   ['bars', 'working at once (peak)'],
 ];
 
-// autonomyKeyColor resolves one key entry's colour against the live theme,
+// autonomyKeyColor resolves one mark's colour against the live theme,
 // falling back to the literal when the custom property is unset (an unstyled
-// document, or a test's stub). '' for a name the key has no mark for.
+// document, or a test's stub). '' for a name the section has no mark for.
 export function autonomyKeyColor(kind, cs) {
   const token = AUTONOMY_MARK_TOKENS[kind];
   if (!token) return '';
@@ -1136,29 +1243,298 @@ export function autonomyKeyColor(kind, cs) {
   return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
 }
 
-// The two marks' colours. ONE HUE: the bars are the line's hue at a lower
-// alpha, because they are a second reading of the same activity and not a
-// second subject. `the bars are the line hue, not a second colour` pins that.
+// Every mark's colour. ONE HUE throughout: the band, its edges and the bars are
+// all the line's hue at lower alphas, because they are further readings of the
+// same activity and not further subjects. `the marks are one hue, not four
+// colours` pins that.
 export const AUTONOMY_MARK_TOKENS = {
+  p50: ['--working', '#8B5CF6'],
+  band: ['--autonomy-band', 'rgba(139, 92, 246, 0.20)'],
+  bandThin: ['--autonomy-band-thin', 'rgba(139, 92, 246, 0.08)'],
+  edge: ['--autonomy-edge', 'rgba(139, 92, 246, 0.45)'],
   line: ['--working', '#8B5CF6'],
   bars: ['--autonomy-bar', 'rgba(139, 92, 246, 0.45)'],
 };
 
 // autonomyKeyEntries is the key the side panel draws, resolved through the same
-// call the canvas painter makes so a swatch cannot disagree with the ink.
+// calls the canvas painters make so a swatch cannot disagree with the ink.
+// `fill` is '' for everything but the band: a line has no area.
 export function autonomyKeyEntries(cs) {
-  return AUTONOMY_KEY.map(([kind, label]) => ({ kind, label, color: autonomyKeyColor(kind, cs) }));
+  return AUTONOMY_KEY.map(([kind, label]) => ({
+    kind,
+    label,
+    color: autonomyKeyColor(kind === 'band' ? 'edge' : kind, cs),
+    fill: kind === 'band' ? autonomyKeyColor('band', cs) : '',
+  }));
 }
 
-// --- Rendering --------------------------------------------------------------
+// Per-role stroke weights for the aggregate chart. The p50 line carries the
+// chart: full alpha, the heavier stroke. The two edges are present enough to
+// bound the plane and quiet enough not to compete with it.
+const AUTONOMY_ROLE_STYLE = {
+  line: { width: 1.8, alpha: 1, thinAlpha: 0.6, marker: 2.6 },
+  edge: { width: 1, alpha: 0.5, thinAlpha: 0.32, marker: 2 },
+};
+
+// The three drawn percentile lines, in draw order: series key, then the ROLE it
+// plays. ONE HUE, THREE WEIGHTS — the chart says one thing (here is the typical
+// run, here is the spread around it), and a hue per percentile would make p95
+// and p5 read as two independent measurements rather than the boundary of one
+// range.
+export const AUTONOMY_SERIES = [
+  ['p95', 'edge'],
+  ['p50', 'line'],
+  ['p5', 'edge'],
+];
+
+// autonomySeriesRole reports whether a key is the headline `line` or one of the
+// band's `edge`s. '' for anything the chart does not draw.
+export function autonomySeriesRole(key) {
+  const row = AUTONOMY_SERIES.find(([k]) => k === key);
+  return row ? row[1] : '';
+}
+
+// autonomyBandSegments splits the gap-aligned point list into the areas the
+// band may actually be filled over.
+//
+// TWO RULES, both of them honesty rules the smooth shape would otherwise
+// erase, and both of them the reason this is a pure function rather than a
+// loop inside the painter:
+//
+//   - A FILLED AREA WANTS TO CLOSE ACROSS A GAP. The daemon omits empty
+//     buckets and the line breaks there (autonomyChartPoints); a polygon
+//     spanning the gap would draw a plane over days that hold no runs at all,
+//     which is a stronger false claim than the interpolated line #1905 already
+//     refuses. A segment therefore never crosses a null.
+//   - A THIN BUCKET IS NOT A PERCENTILE. Under sample_floor, p95 is that
+//     bucket's longest run and p5 its shortest. The stroke already dashes
+//     across such a bucket; the fill splits at the same place so the thin
+//     stretch can be painted in its own fainter plane.
+//
+// Returns index ranges into `points`, inclusive at both ends. Adjacent
+// segments SHARE their boundary index, so a thin→solid handover has no seam.
+// `from === to` is an isolated bucket: it has no neighbour to make an area
+// with, and the painter draws its spread as a whisker instead.
+export function autonomyBandSegments(points) {
+  const out = [];
+  const n = (points || []).length;
+  let i = 0;
+  while (i < n) {
+    if (!points[i]) { i++; continue; }
+    let last = i;
+    while (last + 1 < n && points[last + 1]) last++;
+    if (last === i) {
+      out.push({ from: i, to: i, thin: !!points[i].thin });
+      i = last + 1;
+      continue;
+    }
+    // Thinness belongs to the INTERVAL, not the bucket — matching
+    // drawAutonomySeries, which dashes a segment either of whose ends is thin.
+    let start = i;
+    let thin = !!(points[i].thin || points[i + 1].thin);
+    for (let j = i + 1; j < last; j++) {
+      const next = !!(points[j].thin || points[j + 1].thin);
+      if (next !== thin) {
+        out.push({ from: start, to: j, thin });
+        start = j;
+        thin = next;
+      }
+    }
+    out.push({ from: start, to: last, thin });
+    i = last + 1;
+  }
+  return out;
+}
+
+// --- Rendering: the aggregate chart -----------------------------------------
+
+// AUTONOMY_CHART is the aggregate chart's plot inset, in CSS pixels.
+export const AUTONOMY_CHART = { padL: 52, padR: 12, padT: 12, padB: 22 };
+
+function paintAutonomyChart() {
+  const canvas = document.getElementById('history-chart');
+  const wrap = document.getElementById('history-chart-wrap');
+  if (!canvas || !wrap) return;
+  const duration = historyState.autonomyData?.duration;
+  const { ctx, w, h } = setupHistoryCanvas(canvas, wrap);
+  const points = autonomyChartPoints(duration);
+  const domain = autonomyAggregateDomain(points);
+  wrap.classList.toggle('empty', !domain);
+  if (!domain) return;
+
+  const cs = getComputedStyle(document.documentElement);
+  const muted = (cs.getPropertyValue('--muted') || '#888').trim();
+  const gridColor = 'rgba(128,140,170,0.18)';
+
+  const { padL, padR, padT, padB } = AUTONOMY_CHART;
+  const plotW = Math.max(1, w - padL - padR);
+  const plotH = Math.max(1, h - padT - padB);
+  const n = Math.max(1, points.length);
+  const xAt = (i) => (n <= 1 ? padL : padL + plotW * (i / (n - 1)));
+  const yAt = (v) => padT + autonomyLinearY(v, domain, plotH);
+
+  // Draw order IS the visual hierarchy, cheapest thing first:
+  //
+  //   gridlines → band → boundary rules → edges → p50 → axis labels
+  //
+  // The band goes over the gridlines rather than under them. A gridline is
+  // furniture; drawn on top of the plane it would cut the band into slices
+  // that read as structure in the data, which is the one thing a soft fill
+  // must never do. Over it, the fill's own translucency dims each gridline
+  // where it crosses — the line stays legible, and stays furniture.
+  drawAutonomyChartGridlines(ctx, { domain, yAt, padL, padR, w, muted, gridColor });
+  drawAutonomyBand(ctx, {
+    points,
+    segments: autonomyBandSegments(points),
+    xAt,
+    yAt,
+    fill: autonomyKeyColor('band', cs),
+    fillThin: autonomyKeyColor('bandThin', cs),
+    edge: autonomyKeyColor('edge', cs),
+  });
+  // Under the lines, deliberately: the marker explains the data, it is not
+  // part of it, and a rule drawn over a curve competes with what it annotates.
+  drawAutonomyBoundaries(ctx, {
+    boundaries: autonomyVisibleBoundaries(duration),
+    padL, plotW, top: padT, height: plotH, muted, element: 'aggregate',
+  });
+  // Edges before the line, whatever order the table lists them in: the
+  // headline curve is the last ink down, so nothing crosses over it.
+  for (const role of ['edge', 'line']) {
+    for (const [key, seriesRole] of AUTONOMY_SERIES) {
+      if (seriesRole !== role) continue;
+      drawAutonomySeries(ctx, { points, key, role, color: autonomyKeyColor('p50', cs), xAt, yAt });
+    }
+  }
+  drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB });
+}
+
+// drawAutonomyBand fills the plane between p5 and p95 — the spread around the
+// typical run — one polygon per autonomyBandSegments entry.
+//
+// It fills SEGMENT BY SEGMENT rather than as one path so the two rules that
+// function encodes survive the paint: a gap leaves real empty canvas (no
+// plane over days with no runs), and a thin stretch is filled from the
+// fainter token, so a range that is not a percentile spread does not look
+// like one.
+function drawAutonomyBand(ctx, { points, segments, xAt, yAt, fill, fillThin, edge }) {
+  ctx.save();
+  for (const seg of segments) {
+    if (seg.from === seg.to) {
+      // An isolated bucket has no neighbour to make an area with. Drawn as a
+      // whisker rather than dropped, or it would be the one bucket whose
+      // spread is invisible — and a lone bucket is exactly where the reader
+      // most needs to see how wide the range was.
+      const only = points[seg.from];
+      ctx.setLineDash(seg.thin ? [3, 3] : []);
+      ctx.strokeStyle = edge;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(xAt(seg.from), yAt(only.p95));
+      ctx.lineTo(xAt(seg.from), yAt(only.p5));
+      ctx.stroke();
+      continue;
+    }
+    ctx.beginPath();
+    for (let i = seg.from; i <= seg.to; i++) {
+      const x = xAt(i), y = yAt(points[i].p95);
+      if (i === seg.from) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    for (let i = seg.to; i >= seg.from; i--) ctx.lineTo(xAt(i), yAt(points[i].p5));
+    ctx.closePath();
+    ctx.fillStyle = seg.thin ? fillThin : fill;
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+// drawAutonomySeries strokes one percentile line, breaking at every omitted
+// bucket and DASHING any segment that touches a thin bucket — so a bucket
+// under the sample floor is visibly different rather than hidden or smoothed.
+//
+// `role` decides the weight, not the colour: all three lines are one hue, and
+// what separates the headline p50 from the band's two edges is stroke width
+// and alpha (AUTONOMY_ROLE_STYLE).
+function drawAutonomySeries(ctx, { points, key, role, color, xAt, yAt }) {
+  const style = AUTONOMY_ROLE_STYLE[role] || AUTONOMY_ROLE_STYLE.line;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = style.width;
+  for (let i = 1; i < points.length; i++) {
+    const a = points[i - 1], b = points[i];
+    if (!a || !b) continue; // a gap is a gap: never interpolate across it
+    const thin = a.thin || b.thin;
+    ctx.save();
+    ctx.setLineDash(thin ? [3, 3] : []);
+    ctx.globalAlpha = thin ? style.thinAlpha : style.alpha;
+    ctx.beginPath();
+    ctx.moveTo(xAt(i - 1), yAt(a[key]));
+    ctx.lineTo(xAt(i), yAt(b[key]));
+    ctx.stroke();
+    ctx.restore();
+  }
+  // Hollow markers on thin buckets, and a solid dot on an isolated bucket that
+  // has no neighbour to draw a segment to (which would otherwise vanish).
+  for (let i = 0; i < points.length; i++) {
+    const b = points[i];
+    if (!b) continue;
+    const isolated = !points[i - 1] && !points[i + 1];
+    if (!b.thin && !isolated) continue;
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(xAt(i), yAt(b[key]), style.marker, 0, Math.PI * 2);
+    if (b.thin) {
+      ctx.strokeStyle = color;
+      ctx.globalAlpha = style.alpha * 0.8;
+      ctx.stroke();
+    } else {
+      ctx.fillStyle = color;
+      ctx.globalAlpha = style.alpha;
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+}
+
+// drawAutonomyChartGridlines draws the aggregate chart's linear Y gridlines,
+// labelled in the same duration units the summary row uses, so an axis tick and
+// a headline figure can never be read in different units.
+function drawAutonomyChartGridlines(ctx, { domain, yAt, padL, padR, w, muted, gridColor }) {
+  ctx.strokeStyle = gridColor;
+  ctx.fillStyle = muted;
+  ctx.font = '10px ui-monospace, monospace';
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  for (const v of autonomyTickValues(domain, 4)) {
+    const y = yAt(v);
+    ctx.beginPath();
+    ctx.moveTo(padL, y);
+    ctx.lineTo(w - padR, y);
+    ctx.stroke();
+    ctx.fillText(autonomyDuration(v), padL - 6, y);
+  }
+}
+
+function drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB }) {
+  ctx.fillStyle = muted;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  const starts = duration?.bucket_starts || [];
+  if (!starts.length) return;
+  const labels = Math.min(5, starts.length);
+  for (let i = 0; i < labels; i++) {
+    const c = Math.round(i * (starts.length - 1) / Math.max(1, labels - 1));
+    ctx.fillText(histAxisLabel(starts[c], duration.bucket_seconds), xAt(c), h - padB + 5);
+  }
+}
+
+// --- Rendering: the project panel -------------------------------------------
 
 // Panel geometry, in CSS pixels. The line plot and the histogram share one
-// canvas per panel so their x axes cannot drift apart and one boundary rule can
-// run through both.
+// canvas so their x axes cannot drift apart and one boundary rule can run
+// through both.
 //
-// TICK LABELS ON THE RIGHT, and the top inset that goes with them. Both are
-// QA fixes and both are copied from macOS, so the two surfaces read as one
-// design (QA-1):
+// TICK LABELS ON THE RIGHT, and the insets that go with them. Both are QA fixes
+// carried over from #1919 (QA-1):
 //
 //   - On the LEFT, the y-axis gutter sat directly under the panel header's
 //     project name, and the header row and the axis column were one column of
@@ -1166,65 +1542,75 @@ export function autonomyKeyEntries(cs) {
 //   - `padT` is what stops the TOPMOST label being sliced. A label is drawn
 //     centred on its gridline; the top gridline is at the plot's own top edge,
 //     so without an inset half the glyph falls outside the canvas and reads as
-//     text cut off by the panel above. The inset has to be at least half the
+//     text cut off by the element above. The inset has to be at least half the
 //     tick font — `autonomyTickPlacement` computes that and a test asserts it.
+//   - `padB` is the same rule at the other end, and it is NEW: the histogram
+//     labels its own baseline `0` now, drawn centred on the baseline, so
+//     without an inset half of that glyph would fall off the bottom.
+//   - `gap` is the same rule a THIRD time, and it is what QA caught: the line
+//     axis's lowest label sits at the foot of the line plot, and the histogram's
+//     peak label at the head of the bar band. Both are in the same right-hand
+//     gutter, both drawn centred on their own line. At the 3px gap the
+//     five-panel stack used — where the bar band carried NO labels at all —
+//     "0s" and "15" overprinted into an unreadable smudge. The gap has to clear
+//     one whole tick font, and `autonomyGutterLabels` is where that is asserted.
+//
+// The plot is TALLER than the 40px five stacked panels could afford, because
+// only one is drawn: 110px for the line, 44px for the bars.
 export const AUTONOMY_PANEL = {
-  padL: 4,      // a hair of left margin; the labels are on the RIGHT now
-  padR: 46,     // the shared y axis's label gutter
+  padL: 4,      // a hair of left margin; the labels are on the RIGHT
+  padR: 46,     // the y axes' label gutter, shared by the line and the bars
   padT: 6,      // clearance for the topmost tick label's upper half
-  lineH: 40,    // the longest-run plot
-  gap: 3,
-  barsH: 18,    // the concurrency histogram
-  tickFont: 9,  // px, the y-axis tick label
+  lineH: 110,   // the longest-run plot
+  gap: 14,      // clearance between the two axes' innermost labels
+  barsH: 44,    // the concurrency histogram
+  padB: 5,      // clearance for the baseline label's lower half
+  tickFont: 9,  // px, the y-axis tick label — the SAME font on both axes
   tickGap: 5,   // px between the plot's right edge and its labels
 };
 export const AUTONOMY_PANEL_CANVAS_H =
-  AUTONOMY_PANEL.padT + AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap + AUTONOMY_PANEL.barsH;
+  AUTONOMY_PANEL.padT + AUTONOMY_PANEL.lineH + AUTONOMY_PANEL.gap
+  + AUTONOMY_PANEL.barsH + AUTONOMY_PANEL.padB;
 
 // AUTONOMY_BAR_MIN_H is the floor on a drawn bar (QA-3). A bucket where one
-// agent worked is a real reading and must be visible; at `barsH * 1/15` it was
-// a single device pixel and read as grit. The floor applies only to a bar that
-// is drawn at all — a bucket with nobody working still draws NOTHING.
+// agent worked is a real reading and must be visible; at a fraction of the band
+// it was a single device pixel and read as grit. The floor applies only to a bar
+// that is drawn at all — a bucket with nobody working still draws NOTHING.
 export const AUTONOMY_BAR_MIN_H = 2;
 
-// renderAutonomyPanels draws the stack: five project panels, the "+N more" line
-// and the window's own bounds under them.
-function renderAutonomyPanels() {
+// renderAutonomyPanel draws the single project panel: its header row (the
+// project dropdown and that project's figures), its canvas, the "+N more" line
+// when the daemon's cap bit, and the window's own bounds under it.
+function renderAutonomyPanel() {
   const host = document.getElementById('history-autonomy-panels');
-  const wrap = document.getElementById('history-chart-wrap');
   if (!host) return;
-  const data = historyState.autonomyData;
+  const data = historyState.autonomyData?.projects;
   host.innerHTML = '';
   const panels = data?.panels || [];
-  if (wrap) wrap.classList.toggle('empty', panels.length === 0);
   if (!panels.length) return;
 
+  const choice = autonomyPanelChoice(data, historyState.autonomyProject);
   const cs = getComputedStyle(document.documentElement);
-  const opts = {
-    domain: autonomyYDomain(panels),
-    peakMax: autonomyPeakScale(panels),
+  host.appendChild(buildAutonomyPanel(choice, data, {
+    domain: autonomyYDomain(choice.panel),
+    peakMax: autonomyPeakScale(choice.panel),
     boundaries: autonomyVisibleBoundaries(data),
     bucketStarts: data.bucket_starts || [],
+    windowSeconds: (data.end || 0) - (data.start || 0),
     cs,
-  };
-  let panelIndex = 0;
-  for (const row of autonomyStackRows(data)) {
-    if (row.kind === 'panel') {
-      host.appendChild(buildAutonomyPanel(row.panel, { ...opts, index: panelIndex }));
-      panelIndex++;
-      continue;
-    }
+  }));
+  const more = autonomyMoreProjectsLabel(data);
+  if (more) {
     const el = document.createElement('div');
     el.className = 'history-autonomy-more';
-    el.textContent = row.label;
+    el.textContent = more;
     host.appendChild(el);
   }
   host.appendChild(buildAutonomyAxis(data));
 }
 
 // buildAutonomyAxis puts the window's start on the left and "now" on the right,
-// once under the whole stack — the five panels share one x domain, so five
-// copies would be five statements of one fact.
+// once under the panel.
 export function buildAutonomyAxis(data) {
   const axis = document.createElement('div');
   axis.className = 'history-autonomy-axis';
@@ -1237,22 +1623,57 @@ export function buildAutonomyAxis(data) {
   return axis;
 }
 
-function buildAutonomyPanel(panel, opts) {
+// buildAutonomyProjectSelect is the picker, in the panel's OWN header row —
+// beside the figures it changes, not up in the tab's control row with Range.
+// Range moves both elements; this moves one of them, and a control's place is
+// what says which.
+function buildAutonomyProjectSelect(data, choice) {
+  const sel = document.createElement('select');
+  sel.className = 'history-autonomy-project';
+  sel.id = 'history-autonomy-project';
+  sel.setAttribute('aria-label', 'Project');
+  for (const opt of autonomyProjectOptions(data, historyState.autonomyProject)) {
+    const o = document.createElement('option');
+    o.value = opt.value;
+    o.textContent = opt.label;
+    if (opt.missing) o.dataset.missing = 'true';
+    sel.appendChild(o);
+  }
+  sel.value = choice.project;
+  sel.addEventListener('change', () => {
+    // The NAME is held, not the rank — see historyState.autonomyProject. No
+    // refetch: the payload already carries every project, so switching is a
+    // repaint rather than a round trip.
+    historyState.autonomyProject = sel.value || null;
+    renderAutonomyPanel();
+  });
+  return sel;
+}
+
+function buildAutonomyPanel(choice, data, opts) {
   const el = document.createElement('div');
   el.className = 'history-autonomy-panel';
 
   const head = document.createElement('div');
   head.className = 'history-autonomy-panel-head';
-  const name = document.createElement('span');
-  name.className = 'history-autonomy-panel-name';
-  name.textContent = panel.project;
+  head.appendChild(buildAutonomyProjectSelect(data, choice));
   const figs = document.createElement('span');
   figs.className = 'history-autonomy-panel-figs';
-  figs.textContent = autonomyPanelHeadline(panel);
-  head.appendChild(name);
+  figs.textContent = choice.panel ? autonomyPanelHeadline(choice.panel) : '';
   head.appendChild(figs);
   el.appendChild(head);
 
+  if (!choice.panel) {
+    // A SENTENCE, not an empty frame: an empty plot with axes on it is the same
+    // picture a broken request draws, and the reader cannot tell them apart.
+    const note = document.createElement('div');
+    note.className = 'history-autonomy-panel-empty';
+    note.textContent = autonomyEmptyProjectNote(choice.project);
+    el.appendChild(note);
+    return el;
+  }
+
+  const panel = choice.panel;
   const canvas = document.createElement('canvas');
   canvas.className = 'history-autonomy-panel-canvas';
   canvas.setAttribute('role', 'img');
@@ -1260,11 +1681,77 @@ function buildAutonomyPanel(panel, opts) {
     + ', ' + (Number(panel.runs) || 0) + ' runs');
   el.appendChild(canvas);
 
+  const tip = document.createElement('div');
+  tip.className = 'history-autonomy-tip';
+  tip.hidden = true;
+  el.appendChild(tip);
+  wireAutonomyPanelTooltip(canvas, tip, panel, opts);
+
   // Painted on the next frame: the canvas has no layout width until it is in
   // the document, and a zero-width canvas would collapse every bucket into
   // nothing.
   requestAnimationFrame(() => paintAutonomyPanel(canvas, panel, opts));
   return el;
+}
+
+// autonomyBucketAtX is the tooltip's hit test: which bucket index the pointer is
+// over, as a value.
+//
+// IT IS THE INVERSE OF THE PAINTER'S OWN `xAt`, and that is the whole point —
+// derived from the same padL/plotW/n, so the tooltip cannot name a different
+// bucket from the one drawn under the pointer. A hit test built from its own
+// arithmetic drifts the moment either inset changes, and a tooltip that points
+// at the wrong bucket is worse than none: it is a wrong figure with nothing on
+// screen saying so.
+//
+// null outside the plot, so the gutters do not report the end buckets.
+export function autonomyBucketAtX(x, { padL, plotW, n }) {
+  if (!(n > 0) || !(plotW > 0)) return null;
+  if (x < padL || x > padL + plotW) return null;
+  if (n === 1) return 0;
+  const i = Math.round(((x - padL) / plotW) * (n - 1));
+  return Math.min(n - 1, Math.max(0, i));
+}
+
+// autonomyPanelTooltip is what the tooltip says about one bucket. '' for a
+// bucket the daemon omitted, which draws nothing and therefore says nothing.
+export function autonomyPanelTooltip(point, ts, windowSeconds) {
+  if (!point) return '';
+  const parts = [autonomyAxisLabel(ts, windowSeconds)];
+  const longest = Number(point.longest) || 0;
+  // A bucket a long run merely crossed carries a bar and no line point. Saying
+  // "longest 0s" there would claim a run of no length; the honest reading is
+  // that something was working and nothing finished.
+  parts.push(longest > 0
+    ? 'longest ' + autonomyDuration(longest) + (point.running ? ' (still going)' : '')
+    : 'nothing finished');
+  const atOnce = autonomyConcurrencyLabel(point.peak, point.peak_top, point.peak_sub, point.peak_split);
+  if (atOnce) parts.push(atOnce);
+  return parts.join(' · ');
+}
+
+// wireAutonomyPanelTooltip makes the concurrency figure readable per bucket.
+// The header states the window's peak; without this the individual bars are the
+// one number on the panel a reader cannot get at.
+function wireAutonomyPanelTooltip(canvas, tip, panel, opts) {
+  const points = autonomyPanelPoints(panel, opts.bucketStarts);
+  const hide = () => { tip.hidden = true; };
+  canvas.addEventListener('mouseleave', hide);
+  canvas.addEventListener('mousemove', (ev) => {
+    const rect = canvas.getBoundingClientRect();
+    const w = rect.width || canvas.offsetWidth || 0;
+    const { padL, padR } = AUTONOMY_PANEL;
+    const geo = { padL, plotW: Math.max(1, w - padL - padR), n: Math.max(1, points.length) };
+    const i = autonomyBucketAtX(ev.clientX - rect.left, geo);
+    const text = i == null ? '' : autonomyPanelTooltip(points[i], opts.bucketStarts[i], opts.windowSeconds);
+    if (!text) { hide(); return; }
+    tip.textContent = text;
+    tip.hidden = false;
+    // Clamped to the panel so the tip cannot hang off either edge, where it
+    // would read as a rendering fault rather than as an annotation.
+    const half = (tip.offsetWidth || 0) / 2;
+    tip.style.left = Math.max(half, Math.min(w - half, ev.clientX - rect.left)) + 'px';
+  });
 }
 
 function paintAutonomyPanel(canvas, panel, opts) {
@@ -1293,20 +1780,24 @@ function paintAutonomyPanel(canvas, panel, opts) {
   drawAutonomyGridlines(ctx, { domain: opts.domain, padL, padR, padT, lineH, w, muted, gridColor });
   // Under the marks, deliberately: a boundary explains the data, it is not part
   // of it, and a rule drawn over a line competes with what it annotates.
-  drawAutonomyBoundaries(ctx, { boundaries: opts.boundaries, padL, plotW, h, muted, index: opts.index });
-  drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax: opts.peakMax, color: barColor, gridColor, padL, padR, w });
+  drawAutonomyBoundaries(ctx, {
+    boundaries: opts.boundaries, padL, plotW, top: 0, height: h, muted, element: 'panel',
+  });
+  drawAutonomyBars(ctx, {
+    points, xAt, plotW, n, peakMax: opts.peakMax,
+    color: barColor, gridColor, muted, padL, padR, w,
+  });
   drawAutonomyLine(ctx, { points, xAt, domain: opts.domain, padT, lineH, color: lineColor });
 }
 
-// drawAutonomyGridlines draws the SHARED log Y gridlines, labelled in the same
-// duration units the panel headers use, so an axis tick and a headline figure
-// can never be read in different units.
+// drawAutonomyGridlines draws the line plot's linear Y gridlines, labelled in
+// the same duration units the panel header uses, so an axis tick and a headline
+// figure can never be read in different units.
 //
 // LABELS TO THE RIGHT OF THE PLOT (QA-1). On the left they shared a column with
-// the panel header's project name, and the topmost one was drawn half outside
-// the canvas — a figure sliced by the panel above, sitting on the same line as
-// that panel's own figures. `autonomyTickPlacement` is where the position is
-// decided, so both halves of the fix are testable without a canvas.
+// the panel header, and the topmost one was drawn half outside the canvas.
+// `autonomyTickPlacement` is where the position is decided, so both halves of
+// the fix are testable without a canvas.
 function drawAutonomyGridlines(ctx, { domain, padL, padR, padT, lineH, w, muted, gridColor }) {
   if (!domain) return;
   ctx.save();
@@ -1326,13 +1817,14 @@ function drawAutonomyGridlines(ctx, { domain, padL, padR, padT, lineH, w, muted,
   ctx.restore();
 }
 
-// autonomyTickValues returns the durations the shared axis is labelled at,
-// evenly spaced on the log scale, lowest first.
+// autonomyTickValues returns the durations an axis is labelled at, EVENLY
+// SPACED — which on a linear scale means evenly spaced in value too, where on
+// the log scale this replaced it meant evenly spaced in ratio.
 export function autonomyTickValues(domain, steps = 2) {
   if (!domain) return [];
   const out = [];
   for (let i = 0; i <= steps; i++) {
-    out.push(Math.exp(Math.log(domain.lo) + (Math.log(domain.hi) - Math.log(domain.lo)) * (i / steps)));
+    out.push(domain.lo + (domain.hi - domain.lo) * (i / steps));
   }
   return out;
 }
@@ -1342,7 +1834,7 @@ export function autonomyTickValues(domain, steps = 2) {
 // It carries the two properties QA-1 was about, so both can be asserted without
 // a canvas: the label sits in the gutter to the RIGHT of the plot (so the panel
 // header's row is free), and its upper edge is inside the canvas (so the
-// topmost figure is not sliced by the panel above). `top`/`bottom` are the
+// topmost figure is not sliced by the element above). `top`/`bottom` are the
 // label's own extent, since it is drawn centred on its gridline.
 export function autonomyTickPlacement(v, domain, width, panel = AUTONOMY_PANEL) {
   const y = panel.padT + autonomyYAt(v, domain, panel.lineH);
@@ -1355,14 +1847,22 @@ export function autonomyTickPlacement(v, domain, width, panel = AUTONOMY_PANEL) 
   };
 }
 
-// autonomyYAt maps a duration onto the shared log axis. Exported so a test can
-// assert two panels place the same duration at the same height — which is what
-// "shared" has to mean if the five panels are to be comparable at all.
+// autonomyLinearY maps a value onto a LINEAR axis of the given height, top
+// down. One helper for both elements, so the aggregate chart and the panel
+// cannot end up on different mappings.
+//
+// See autonomyYDomain for what linear costs and why it was chosen anyway.
+export function autonomyLinearY(v, domain, height) {
+  if (!domain) return height;
+  const span = domain.hi - domain.lo;
+  if (!(span > 0)) return height;
+  const clamped = Math.min(domain.hi, Math.max(domain.lo, Number(v) || 0));
+  return height * (1 - (clamped - domain.lo) / span);
+}
+
+// autonomyYAt maps a duration onto the panel's line axis.
 export function autonomyYAt(v, domain, lineH) {
-  if (!domain) return lineH;
-  const clamped = Math.min(domain.hi, Math.max(domain.lo, Math.max(1, Number(v) || 1)));
-  const t = (Math.log(clamped) - Math.log(domain.lo)) / (Math.log(domain.hi) - Math.log(domain.lo));
-  return lineH * (1 - t);
+  return autonomyLinearY(v, domain, lineH);
 }
 
 // drawAutonomyLine strokes the longest-run line, BREAKING at every gap rather
@@ -1402,8 +1902,9 @@ function drawAutonomyLine(ctx, { points, xAt, domain, padT, lineH, color }) {
   ctx.restore();
 }
 
-// autonomyBaselineY is the histogram's foot: the line every bar stands on, at
-// the very bottom of the panel canvas and directly beneath the plot.
+// autonomyBaselineY is the histogram's foot: the line every bar stands on,
+// directly beneath the plot and clear of the canvas's own bottom edge by padB,
+// which is what leaves room for the `0` label drawn centred on it.
 export function autonomyBaselineY(panel = AUTONOMY_PANEL) {
   return panel.padT + panel.lineH + panel.gap + panel.barsH;
 }
@@ -1413,9 +1914,9 @@ export function autonomyBaselineY(panel = AUTONOMY_PANEL) {
 //
 // EVERY BAR STANDS ON autonomyBaselineY. They always did arithmetically, but at
 // two or three pixels with nothing to stand on they scanned as dashes scattered
-// under the line rather than as a distribution — so the baseline is now DRAWN,
-// and the band is tall enough that a bar of 1 and a bar of 15 are visibly
-// different heights rather than both being a smudge.
+// under the line rather than as a distribution — so the baseline is DRAWN, and
+// the band is tall enough that a bar of 1 and a bar of 15 are visibly different
+// heights rather than both being a smudge.
 export function autonomyBarRect(peak, peakMax, panel = AUTONOMY_PANEL) {
   const n = Number(peak) || 0;
   const max = Number(peakMax) || 0;
@@ -1425,14 +1926,67 @@ export function autonomyBarRect(peak, peakMax, panel = AUTONOMY_PANEL) {
   return { top: bottom - height, bottom, height };
 }
 
+// autonomyBarAxisLabels is the histogram's OWN y axis, as values.
+//
+// TWO LABELS: the band's full-height value at the top, and `0` at the baseline.
+// Two is what the axis actually means — a bar's height is its peak as a fraction
+// of the highest peak, so the top and the floor are the only two readings that
+// are exact — and a ladder of intermediate ticks in a 44px band would be four
+// numbers 10px apart.
+//
+// Before this the gutter beside the bars was deliberately BLANK on both
+// surfaces, which is what "the number of agents running in parallel is not
+// visible" was about: the bars carried the only figure on the panel with no
+// scale of any kind. They share the line chart's gutter (padR) and tick font, so
+// the two axes read as one column rather than as two competing ones.
+//
+// [] when nothing overlapped anywhere in the panel: with no bar drawn, an axis
+// labelled 0 to 0 would be furniture claiming a measurement.
+export function autonomyBarAxisLabels(peakMax, panel = AUTONOMY_PANEL) {
+  const max = Math.round(Number(peakMax) || 0);
+  if (max <= 0) return [];
+  const baseline = autonomyBaselineY(panel);
+  return [
+    { value: max, text: String(max), y: baseline - panel.barsH },
+    { value: 0, text: '0', y: baseline },
+  ];
+}
+
+// autonomyGutterLabels is EVERY label drawn in the panel's right-hand gutter —
+// the line axis's ticks and the histogram's two — each with the vertical extent
+// it occupies, top to bottom.
+//
+// It exists because the two axes share one gutter and neither knows about the
+// other. QA of the shipped build caught the consequence: at the 3px gap the
+// five-panel stack used (where the bar band carried no labels at all) the line
+// axis's floor tick "0s" and the histogram's peak "15" were drawn 3px apart and
+// overprinted into an unreadable smudge — a wrong figure with nothing on screen
+// saying so, in the very gutter this change added to make the concurrency
+// figure legible.
+//
+// As a value, so "no two labels overlap" is one assertion over the real
+// geometry rather than a constant somebody has to keep in their head.
+export function autonomyGutterLabels(domain, peakMax, width, panel = AUTONOMY_PANEL) {
+  const half = panel.tickFont / 2;
+  const out = autonomyTickValues(domain).map((v) => {
+    const at = autonomyTickPlacement(v, domain, width, panel);
+    return { axis: 'line', text: autonomyDuration(v), y: at.y, top: at.top, bottom: at.bottom };
+  });
+  for (const label of autonomyBarAxisLabels(peakMax, panel)) {
+    out.push({ axis: 'bars', text: label.text, y: label.y, top: label.y - half, bottom: label.y + half });
+  }
+  return out.sort((a, b) => a.y - b.y);
+}
+
 // drawAutonomyBars draws the concurrency histogram: one bar per bucket, scaled
-// against the stack's shared peak, all of them standing on one drawn baseline.
+// against this panel's own peak, all of them standing on one drawn baseline,
+// with the band's own y axis labelled in the right-hand gutter.
 //
 // A BUCKET WITH NO ONE WORKING DRAWS NOTHING — no bar, however short. The
 // BASELINE is not a mark on that rule: it is drawn uniformly across the whole
 // plot in the gridline colour, exactly like the y gridlines above it, so it
 // reads as furniture rather than as a per-bucket measurement of zero.
-function drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax, color, gridColor, padL, padR, w }) {
+function drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax, color, gridColor, muted, padL, padR, w }) {
   const baseline = autonomyBaselineY();
   ctx.save();
   // The foot first, so a bar sits ON it rather than the rule cutting across.
@@ -1451,14 +2005,22 @@ function drawAutonomyBars(ctx, { points, xAt, plotW, n, peakMax, color, gridColo
       ctx.fillRect(xAt(i) - barW / 2, rect.top, barW, rect.height);
     }
   }
+  // …and the band's own scale, in the line chart's gutter and font.
+  ctx.fillStyle = muted;
+  ctx.font = AUTONOMY_PANEL.tickFont + 'px ui-monospace, monospace';
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+  for (const label of autonomyBarAxisLabels(peakMax)) {
+    ctx.fillText(label.text, w - padR + AUTONOMY_PANEL.tickGap, label.y);
+  }
   ctx.restore();
 }
 
 // drawAutonomyBoundaries marks each instant where the data's source changes: a
-// dashed hairline down the WHOLE panel — line plot and histogram both — so the
-// rule reads as one vertical through the stack rather than as five annotations.
-// The caption is drawn on the top panel only (autonomyBoundaryCaptionShown).
-function drawAutonomyBoundaries(ctx, { boundaries, padL, plotW, h, muted, index }) {
+// dashed hairline down the whole plot, so the rule reads as one vertical through
+// the section. The caption is written by the aggregate chart only
+// (autonomyBoundaryCaptionShown).
+function drawAutonomyBoundaries(ctx, { boundaries, padL, plotW, top, height, muted, element }) {
   if (!boundaries?.length) return;
   ctx.save();
   ctx.font = '9px ui-monospace, monospace';
@@ -1470,17 +2032,17 @@ function drawAutonomyBoundaries(ctx, { boundaries, padL, plotW, h, muted, index 
     ctx.lineWidth = 1;
     ctx.setLineDash([2, 3]);
     ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, h);
+    ctx.moveTo(x, top);
+    ctx.lineTo(x, top + height);
     ctx.stroke();
-    if (!autonomyBoundaryCaptionShown(index)) continue;
+    if (!autonomyBoundaryCaptionShown(element)) continue;
     const label = autonomyBoundaryLabel(b);
     ctx.setLineDash([]);
     if (x - 4 - ctx.measureText(label).width >= padL) {
       ctx.globalAlpha = 0.7;
       ctx.fillStyle = muted;
       ctx.textAlign = 'right';
-      ctx.fillText(label, x - 4, 1);
+      ctx.fillText(label, x - 4, top + 1);
       ctx.textAlign = 'left';
     }
   }
@@ -1496,25 +2058,28 @@ function drawAutonomyBoundaries(ctx, { boundaries, padL, plotW, h, muted, index 
 // value it is testable; as a `style.background =` buried in a render loop it
 // was not.
 //
-// The first TWO rows are the key, and they are the key because they are what a
-// panel draws: one line and one row of bars. runs/projects are FIGURES and stay
-// unswatched on purpose — a swatch would claim ink nothing lays down.
-export function autonomyPanelRows(summary, cs) {
-  const s = summary || {};
-  const [lineKey, barsKey] = autonomyKeyEntries(cs);
-  const figure = (label, value) => ({ kind: null, label, value, swatch: 'transparent' });
-  let longest = autonomyDuration(s.longest);
-  if (s.longest_running) longest += ' · still going';
+// The first FOUR rows are the key, and they are the key because they are what
+// the section draws: two lines, one plane and one row of bars. The two elements'
+// rows sit in the order they appear on screen — the aggregate chart's p50 and
+// band first, then the panel's longest and peak. runs/projects are FIGURES and
+// stay unswatched on purpose: a swatch would claim ink nothing lays down.
+export function autonomyPanelRows(data, cs) {
+  const d = data?.duration?.summary || {};
+  const p = data?.projects?.summary || {};
+  const [p50Key, bandKey, lineKey, barsKey] = autonomyKeyEntries(cs);
+  const key = (entry, value) => ({ kind: entry.kind, label: entry.label, value, swatch: entry.color, fill: entry.fill });
+  const figure = (label, value) => ({ kind: null, label, value, swatch: 'transparent', fill: '' });
+  let longest = autonomyDuration(p.longest);
+  if (p.longest_running) longest += ' · still going';
   return [
-    { kind: lineKey.kind, label: lineKey.label, value: longest, swatch: lineKey.color },
-    {
-      kind: barsKey.kind,
-      label: barsKey.label,
-      value: String(Number(s.peak) || 0),
-      swatch: barsKey.color,
-    },
-    figure('runs', String(Number(s.runs) || 0)),
-    figure('projects', String(Number(s.projects) || 0)),
+    key(p50Key, autonomyDuration(d.p50)),
+    // Both ends of the band, in the order they read on the chart: bottom edge
+    // to top edge. One row, two figures still visible.
+    key(bandKey, autonomyDuration(d.p5) + ' – ' + autonomyDuration(d.p95)),
+    key(lineKey, longest),
+    key(barsKey, String(Number(p.peak) || 0)),
+    figure('runs', String(Number(p.runs) || 0)),
+    figure('projects', String(Number(p.projects) || 0)),
   ];
 }
 
@@ -1526,13 +2091,17 @@ function renderAutonomySidePanel() {
   const fcEl = document.getElementById('history-forecast-line');
   const listEl = document.getElementById('history-contrib');
   const data = historyState.autonomyData;
+  const projects = data?.projects;
+  const duration = data?.duration;
   if (titleEl) titleEl.textContent = 'Autonomy · ' + (AUTONOMY_RANGE_LABELS[historyState.autonomyRange] || historyState.autonomyRange);
-  const s = data?.summary || {};
+  const s = projects?.summary || {};
   const runs = Number(s.runs) || 0;
-  if (totalEl) totalEl.textContent = runs > 0 ? autonomyDuration(s.longest) : '—';
+  // The headline is the TYPICAL run, which is the aggregate chart's subject and
+  // the first thing on screen; the longest is a key row below it.
+  if (totalEl) totalEl.textContent = runs > 0 ? autonomyDuration(duration?.summary?.p50) : '—';
   if (fcEl) {
     fcEl.textContent = runs > 0
-      ? 'longest run' + (s.longest_project ? ' · ' + s.longest_project : '') + ' · ' + runs + ' runs'
+      ? 'median run · ' + runs + ' runs across ' + (Number(s.projects) || 0) + ' projects'
       : '';
   }
   if (!listEl) return;
@@ -1540,17 +2109,25 @@ function renderAutonomySidePanel() {
   if (!(runs > 0)) {
     appendHistoryEmpty(listEl, autonomyEverRecorded() ? 'no runs in this range' : 'nothing recorded yet');
   } else {
-    for (const row of autonomyPanelRows(s, getComputedStyle(document.documentElement))) {
+    for (const row of autonomyPanelRows(data, getComputedStyle(document.documentElement))) {
       const li = document.createElement('li');
       // The key rows lay out differently from the figure rows below them: they
       // carry a sentence AND a figure, which do not fit one 228px line.
       if (row.kind) li.className = 'autonomy-key';
       const dot = document.createElement('span');
-      // The two key swatches take the SHAPE of what they stand for — a rule for
-      // the line, a pair of bars for the histogram. Two identical dots in one
-      // hue would be a key that says the same thing twice.
+      // Each key swatch takes the SHAPE of what it stands for — a rule for a
+      // line, a bounded plane for the band, a pair of bars for the histogram.
+      // Four identical dots in one hue would be a key that says the same thing
+      // four times.
       dot.className = row.kind ? 'dot autonomy-' + row.kind : 'dot';
-      if (row.kind) dot.style.color = row.swatch; else dot.style.background = row.swatch;
+      if (row.kind === 'band') {
+        dot.style.background = row.fill;
+        dot.style.borderColor = row.swatch;
+      } else if (row.kind) {
+        dot.style.color = row.swatch;
+      } else {
+        dot.style.background = row.swatch;
+      }
       const lbl = document.createElement('span');
       lbl.className = 'label';
       lbl.textContent = row.label;
@@ -1565,22 +2142,26 @@ function renderAutonomySidePanel() {
     // The caveat belongs beside the number it qualifies, not in a tooltip: the
     // `at once` figure is otherwise read as "N independent agents".
     appendHistoryEmpty(listEl, AUTONOMY_CONCURRENCY_CAVEAT);
+    // …and the thin-bucket marking is explained in words, because a fainter
+    // plane means nothing on its own.
+    const thin = autonomyThinNote(duration);
+    if (thin) appendHistoryEmpty(listEl, thin);
   }
   // What these figures counted (#1905 subagents). Above the provenance line
   // because it qualifies every number in the panel, where provenance qualifies
   // where they came from.
-  const countingLine = autonomyCountingLine(data);
+  const countingLine = autonomyCountingLine(projects);
   if (countingLine) appendHistoryEmpty(listEl, countingLine);
   // …and which of them are floors rather than measurements (#1905 recording).
-  const measurement = autonomyMeasurementNote(data);
+  const measurement = autonomyMeasurementNote(projects);
   if (measurement) appendHistoryEmpty(listEl, measurement);
   // The provenance line is part of the feature: "no data" must never read as
   // "you did nothing".
-  appendHistoryEmpty(listEl, autonomyProvenanceLine(data));
+  appendHistoryEmpty(listEl, autonomyProvenanceLine(projects));
   // …and a back-filled view says so, for the same reason: a reconstructed
   // figure rendered as a measured one is the wrong number with nothing on
   // screen saying it is wrong. Silent when nothing in view was reconstructed.
-  const reconstruction = autonomyReconstructionNote(data);
+  const reconstruction = autonomyReconstructionNote(projects);
   if (reconstruction) appendHistoryEmpty(listEl, reconstruction);
 }
 
@@ -2333,18 +2914,26 @@ function seriesCsvLines(d) {
   return lines;
 }
 
-// autonomyCsvLines exports the spans themselves — the raw rows both elements
-// are derived from, so a spreadsheet can re-derive either.
+// autonomyCsvLines exports EVERY project's per-bucket row, not just the panel
+// on screen — the dropdown shows one project at a time, and a CSV that carried
+// only the visible one would silently be a per-project export wearing a
+// section-wide name.
+//
+// The aggregate chart's own percentiles are not repeated here: they are
+// derivable from nothing in this file, so the JSON export (which carries BOTH
+// payloads) is the place that answers for them.
 function autonomyCsvLines() {
-  const spans = historyState.autonomyData?.spans?.spans || [];
-  const lines = ['start,end,duration_seconds,project,session,reason'];
-  for (const sp of spans) {
-    lines.push([
-      new Date(sp.start * 1000).toISOString(), new Date(sp.end * 1000).toISOString(),
-      String(Math.max(0, (sp.end || 0) - (sp.start || 0))),
-      historyCsvCell(sp.project || ''), historyCsvCell(sp.session || ''),
-      historyCsvCell(sp.reason || ''),
-    ].join(','));
+  const data = historyState.autonomyData?.projects;
+  const lines = ['bucket_start,project,longest_seconds,running,peak,peak_top,peak_sub,peak_split'];
+  for (const panel of (data?.panels || [])) {
+    for (const b of (panel.buckets || [])) {
+      lines.push([
+        new Date((b.ts || 0) * 1000).toISOString(), historyCsvCell(panel.project || ''),
+        String(Number(b.longest) || 0), String(!!b.running),
+        String(Number(b.peak) || 0), String(Number(b.peak_top) || 0),
+        String(Number(b.peak_sub) || 0), String(!!b.peak_split),
+      ].join(','));
+    }
   }
   return lines;
 }
@@ -2498,10 +3087,12 @@ export function initHistoryTab() {
   window.addEventListener('resize', () => {
     if (!historyTabOn() || !historyState.data) return;
     if (historyResizeRAF) cancelAnimationFrame(historyResizeRAF);
-    // Autonomy repaints its own stack: each panel is its own width-dependent
-    // canvas, so the shared painter would leave five stale plots at the old
-    // width while redrawing a canvas that is hidden.
-    const repaint = historyState.chart === 'autonomy' ? renderAutonomyPanels : paintHistoryChart;
+    // Autonomy repaints BOTH of its elements: the panel is its own
+    // width-dependent canvas, so the shared painter alone would leave a stale
+    // plot at the old width under a freshly redrawn aggregate chart.
+    const repaint = historyState.chart === 'autonomy'
+      ? () => { paintAutonomyChart(); renderAutonomyPanel(); }
+      : paintHistoryChart;
     historyResizeRAF = requestAnimationFrame(repaint);
   });
 

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -1130,14 +1130,35 @@ export function autonomyYDomain(panel) {
   return { lo: 0, hi: Math.max(...values) * 1.1 };
 }
 
-// autonomyAggregateDomain is the aggregate chart's LINEAR Y domain, taken from
-// the drawn p95s. Same decision and the same cost as autonomyYDomain above; the
-// summary row under the chart carries p95/p50/p5 and the true extremes as
-// FIGURES, which is what keeps them readable when the band flattens.
+// autonomyAggregateDomain is the aggregate chart's LINEAR Y domain: the highest
+// p95 it DRAWS, plus a tenth of headroom, from zero.
+//
+// THE DOMAIN FITS WHAT IS DRAWN, and `max` is not drawn. The chart draws p95,
+// p50, p5 and the plane between p95 and p5; a bucket's true maximum is a FIGURE
+// in the summary row, and it is a figure precisely so it cannot redraw the axis
+// — "one four-hour run left going overnight would otherwise redraw the whole Y
+// scale and flatten every other bucket into the floor" (#1905). Folding it back
+// into the domain re-created exactly that, and the first round of this restore
+// shipped it.
+//
+// MEASURED on the reference machine's live span log (30-day window, 27 of 30
+// buckets with data, 2735 runs, reduced the way the daemon buckets them):
+//
+//     highest p95 across buckets : 1h37m
+//     highest max across buckets : 11h39m
+//     domain inflation           : 7.19x
+//     tallest p50, domain to p95 : 6.60% of plot height
+//     tallest p50, domain to max : 0.92%
+//     median  p50, domain to max : 0.46%   (i.e. on the axis)
+//     empty plot above the band  : 87.4%
+//
+// Linear still costs what autonomyYDomain says it costs — a long p95 flattens
+// the short buckets under it — but that is a cost paid to a line the reader can
+// SEE. Paying it to one the chart never draws buys nothing.
 export function autonomyAggregateDomain(points) {
   const drawn = (points || []).filter(Boolean);
   if (!drawn.length) return null;
-  const hi = Math.max(...drawn.map(b => Math.max(Number(b.p95) || 0, Number(b.max) || 0, 1)));
+  const hi = Math.max(1, ...drawn.map(b => Number(b.p95) || 0));
   return { lo: 0, hi: hi * 1.1 };
 }
 

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -1174,8 +1174,29 @@ export function autonomyPeakScale(panel) {
   return max;
 }
 
-// autonomyAxisLabel formats one of the section's x bounds, coarsening with
-// the window the way stateBucketLabel does for the activity matrix.
+// autonomyAxisLabel is THE Autonomy section's date formatter — the ONE both x
+// axes and the tooltip go through.
+//
+// ONE FORMATTER, and it is a correctness rule rather than tidiness. The two
+// charts are stacked, share one window and one x domain, and are read against
+// each other: a reader lines a spike in the aggregate chart up with a bar in the
+// panel below it. Labelled by two different functions they said the same instant
+// two ways — the aggregate axis went through histAxisLabel and read `8/7`
+// (US numeric, hardcoded), while the panel's bounds and the tooltip read
+// `7. Aug.` — so lining the two up meant translating between them.
+//
+// histAxisLabel stays where it is for every OTHER chart; what it must not do is
+// label one half of this section. `both autonomy axes are labelled by the same
+// function` pins that, by provenance and not only by output.
+//
+// MONTH-NAME BASED, matching what macOS reads (AutonomyFormat.axisBound /
+// .axisDate produce `Aug 24`) rather than inventing a third shape — the sibling
+// of `the two surfaces name the key the same way`. The locale stays the
+// reader's, so `Aug 24` and `24. Aug.` are the same label in two languages,
+// where `8/7` was a different thing entirely.
+//
+// It coarsens with the window, the way stateBucketLabel does for the activity
+// matrix: a time of day under 36h, a date under 60 days, a month beyond that.
 export function autonomyAxisLabel(ts, windowSeconds) {
   const d = new Date((Number(ts) || 0) * 1000);
   if (windowSeconds <= 36 * 3600) return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
@@ -1535,16 +1556,26 @@ function drawAutonomyChartGridlines(ctx, { domain, yAt, padL, padR, w, muted, gr
   }
 }
 
+// drawAutonomyXLabels labels the aggregate chart's x axis — through
+// autonomyAxisLabel, the section's one formatter, NOT through the shared
+// histAxisLabel every other chart uses. See autonomyAxisLabel for why: the panel
+// directly beneath this axis shares its window and its domain, and the two must
+// not name one instant two ways.
+//
+// The whole WINDOW is what coarsens the label, not this chart's bucket width —
+// so the aggregate axis and the panel's bounds coarsen together at the same
+// range rather than at two different thresholds.
 function drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB }) {
   ctx.fillStyle = muted;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
   const starts = duration?.bucket_starts || [];
   if (!starts.length) return;
+  const windowSeconds = (Number(duration.end) || 0) - (Number(duration.start) || 0);
   const labels = Math.min(5, starts.length);
   for (let i = 0; i < labels; i++) {
     const c = Math.round(i * (starts.length - 1) / Math.max(1, labels - 1));
-    ctx.fillText(histAxisLabel(starts[c], duration.bucket_seconds), xAt(c), h - padB + 5);
+    ctx.fillText(autonomyAxisLabel(starts[c], windowSeconds), xAt(c), h - padB + 5);
   }
 }
 
@@ -1706,7 +1737,7 @@ function buildAutonomyPanel(choice, data, opts) {
   tip.className = 'history-autonomy-tip';
   tip.hidden = true;
   el.appendChild(tip);
-  wireAutonomyPanelTooltip(canvas, tip, panel, opts);
+  wireAutonomyPanelTooltip(el, canvas, tip, panel, opts);
 
   // Painted on the next frame: the canvas has no layout width until it is in
   // the document, and a zero-width canvas would collapse every bucket into
@@ -1751,10 +1782,46 @@ export function autonomyPanelTooltip(point, ts, windowSeconds) {
   return parts.join(' · ');
 }
 
+// AUTONOMY_TIP_OFFSET is how far below the pointer the tooltip sits, in CSS
+// pixels — far enough that the cursor does not sit on its own label.
+export const AUTONOMY_TIP_OFFSET = 12;
+
+// autonomyTipPlacement is where the tooltip is drawn, as a value, relative to
+// the panel's own box.
+//
+// TWO RULES, and the first is what QA caught. The tip used to be pinned to the
+// panel's TOP edge (`bottom: 100%`), which put it OUTSIDE the panel and over the
+// aggregate chart above — hovering to read one chart hid the other, covering its
+// x-axis labels and its lowest data. It stays INSIDE its own panel now: below
+// the pointer by default, flipped above it when that would overflow the bottom,
+// and never at a negative top.
+//
+// The second rule is the right-hand gutter. Both y axes label themselves there
+// (autonomyBarAxisLabels, autonomyTickPlacement), so the tip's right edge is
+// held clear of `padR` — otherwise reading a bucket covers the figures the
+// gutter exists to show.
+export function autonomyTipPlacement(x, y, box, panel = AUTONOMY_PANEL) {
+  const width = Math.max(0, Number(box?.width) || 0);
+  const height = Math.max(0, Number(box?.height) || 0);
+  const tipW = Math.max(0, Number(box?.tipW) || 0);
+  const tipH = Math.max(0, Number(box?.tipH) || 0);
+  const half = tipW / 2;
+  // `left` is the tip's CENTRE (it is translated by -50%), so both bounds are
+  // half a tip in from the edge they protect.
+  const rightBound = Math.max(half, width - panel.padR - half);
+  const left = Math.min(rightBound, Math.max(half, Number(x) || 0));
+  const below = (Number(y) || 0) + AUTONOMY_TIP_OFFSET;
+  const above = (Number(y) || 0) - AUTONOMY_TIP_OFFSET - tipH;
+  // Below the pointer unless that runs past the panel's foot, in which case
+  // above it — either way inside the panel, never over the chart above it.
+  const top = below + tipH <= height ? below : above;
+  return { left, top: Math.max(0, Math.min(top, Math.max(0, height - tipH))) };
+}
+
 // wireAutonomyPanelTooltip makes the concurrency figure readable per bucket.
 // The header states the window's peak; without this the individual bars are the
 // one number on the panel a reader cannot get at.
-function wireAutonomyPanelTooltip(canvas, tip, panel, opts) {
+function wireAutonomyPanelTooltip(host, canvas, tip, panel, opts) {
   const points = autonomyPanelPoints(panel, opts.bucketStarts);
   const hide = () => { tip.hidden = true; };
   canvas.addEventListener('mouseleave', hide);
@@ -1768,10 +1835,17 @@ function wireAutonomyPanelTooltip(canvas, tip, panel, opts) {
     if (!text) { hide(); return; }
     tip.textContent = text;
     tip.hidden = false;
-    // Clamped to the panel so the tip cannot hang off either edge, where it
-    // would read as a rendering fault rather than as an annotation.
-    const half = (tip.offsetWidth || 0) / 2;
-    tip.style.left = Math.max(half, Math.min(w - half, ev.clientX - rect.left)) + 'px';
+    // Measured against the PANEL, not the canvas: the tip is the panel's child
+    // and has to stay inside it, header row included.
+    const box = host.getBoundingClientRect();
+    const at = autonomyTipPlacement(ev.clientX - box.left, ev.clientY - box.top, {
+      width: box.width || w,
+      height: box.height || 0,
+      tipW: tip.offsetWidth || 0,
+      tipH: tip.offsetHeight || 0,
+    });
+    tip.style.left = at.left + 'px';
+    tip.style.top = at.top + 'px';
   });
 }
 

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -348,15 +348,13 @@
           <div class="history-matrix-scroll" id="history-matrix-scroll" hidden>
             <div class="history-matrix" id="history-matrix"></div>
           </div>
-          <!-- Autonomy (#1905): five per-project panels, stacked, replacing the
-               shared canvas inside this same card the way the activity matrix
-               does. Inside the card rather than in a full-width block below it
-               because the section is ONE element now — the run strip that used
-               to be the second one is gone — so it belongs where every other
-               chart is drawn, with the side panel keeping its place beside it.
-               Scrolls: five panels plus the "+N more" line and the axis run a
-               little past a 360px card, and clipping the explanation would be
-               worse than a scrollbar. -->
+          <!-- Autonomy (#1905): ONE project panel — a longest-run line over a
+               concurrency histogram, for whichever project the dropdown in its
+               own header row selects. It sits UNDER the canvas above rather
+               than replacing it (unlike the activity matrix), because the
+               canvas is where the section's other element is drawn: the
+               aggregate p95/p50/p5 chart over every project. Two elements, one
+               Range control, one card that grows to hold both. -->
           <div class="history-autonomy-panels" id="history-autonomy-panels" hidden></div>
           <div class="history-chart-empty" id="history-chart-empty">no cost data in this range yet</div>
           <a id="history-co2-info" class="history-co2-info" href="https://irrlicht.io/docs/co2-methodology.html" target="_blank" rel="noopener" title="How the CO2e estimate and its equivalents are calculated" hidden>How is this calculated?</a>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -59,6 +59,13 @@
          It is the --working RGB triple; `the bars are the line hue, not a
          second colour` in irrlicht.history.autonomy.test.js pins that. */
       --autonomy-bar: rgba(139, 92, 246, 0.45);
+      /* The aggregate chart's p5–p95 band (#1905), back with the chart. Same
+         hue again, at three more weights: the plane, the fainter plane a
+         thin bucket gets, and the edges that bound it. `the marks are one hue,
+         not four colours` in irrlicht.history.autonomy.test.js pins that. */
+      --autonomy-band: rgba(139, 92, 246, 0.20);
+      --autonomy-band-thin: rgba(139, 92, 246, 0.08);
+      --autonomy-edge: rgba(139, 92, 246, 0.45);
       /* Pressure-bar colors — mirror overlay's ContextBarColor / pressure_level mapping:
          safe → low, caution → medium, warning → high, critical → critical. */
       --pressure-low: #34C759;
@@ -109,6 +116,11 @@
            #0f1628, so a bar that is a faint wash on the dark card reads as a
            solid lavender block here — louder than the line it sits under. */
         --autonomy-bar: rgba(101, 38, 243, 0.38);
+        /* …and the band's three, re-tuned the same way and for the same
+           reason (see the dark block above). */
+        --autonomy-band: rgba(101, 38, 243, 0.11);
+        --autonomy-band-thin: rgba(101, 38, 243, 0.05);
+        --autonomy-edge: rgba(101, 38, 243, 0.38);
         /* #1801, same rule as the three above and measured the same way. The
            dark --error (#FF3B30) reads 3.01:1 against its own 12% wash on
            --surface #ffffff — under the 4.5:1 minimum, and the worst possible
@@ -147,6 +159,9 @@
       --ready-dim: rgba(32, 121, 54, 0.12);
       /* See the matching comment in the media-query block above. */
       --autonomy-bar: rgba(101, 38, 243, 0.38);
+      --autonomy-band: rgba(101, 38, 243, 0.11);
+      --autonomy-band-thin: rgba(101, 38, 243, 0.05);
+      --autonomy-edge: rgba(101, 38, 243, 0.38);
       --error: #CC0C00;
       --error-dim: rgba(204, 12, 0, 0.12);
     }
@@ -1776,20 +1791,23 @@
     .history-co2-info:hover { color: var(--text-bright); background: var(--working); }
     .history-co2-info[hidden] { display: none; }
 
-    /* Autonomy per-project panels (#1905). Five stacked panels inside the
-       shared chart card, replacing the canvas the way the activity matrix does
-       (see syncHistoryMatrixVisibility). The run strip this replaced was a
-       full-width block BELOW the card, because it was a second element; there
-       is only one now.
+    /* Autonomy (#1905). TWO elements inside the shared chart card: the
+       aggregate percentile chart on the canvas, and one project panel under it.
+       Unlike chart=state, this does NOT replace the canvas — it adds to it.
 
-       THE CARD GROWS; THE STACK DOES NOT SCROLL (QA-2). Five panels at a
-       readable height do not fit a 360px card, and an inner scrollbar cut off
-       the x axis and the "+N more" line — the row that says what the view left
-       out — while a couple of hundred pixels of page sat empty below the card.
-       So .autonomy releases the fixed height and the stack flows at its natural
-       size. `min-height` keeps the empty state's overlay a sensible size; it is
-       a FLOOR, never a ceiling, so nothing can be clipped by it. */
+       THE CARD GROWS; NOTHING SCROLLS INSIDE IT (QA-2, #1919). A chart plus a
+       panel at readable heights do not fit a fixed 360px card, and the rows an
+       inner scrollbar cut off first were the x axis and the "+N more" line —
+       the row that says what the view left out — while a couple of hundred
+       pixels of page sat empty below the card. So .autonomy releases the fixed
+       height and both elements flow at their natural size. `min-height` keeps
+       the empty state's overlay a sensible size; it is a FLOOR, never a
+       ceiling, so nothing can be clipped by it. */
     .history-chart-wrap.autonomy { height: auto; min-height: 220px; }
+    /* …which is exactly why the canvas needs an explicit height here: its
+       `height: 100%` resolves against an auto-height parent, i.e. to nothing,
+       and the aggregate chart would collapse to a zero-pixel strip. */
+    .history-chart-wrap.autonomy #history-chart { height: 220px; }
     .history-autonomy-panels { position: static; overflow: visible; }
     .history-autonomy-panels[hidden] { display: none; }
     .history-autonomy-panel { margin-bottom: 7px; }
@@ -1804,10 +1822,41 @@
       display: flex; align-items: baseline; gap: 10px;
       font-size: 11px; line-height: 15px; padding-bottom: 1px;
     }
-    .history-autonomy-panel-name {
-      color: var(--text); overflow: hidden;
-      text-overflow: ellipsis; white-space: nowrap; flex: 0 1 auto;
+    /* The project picker, in the panel's OWN header row — beside the figures it
+       changes, not up in the tab's control row with Range. Range moves both
+       elements; this moves one of them, and a control's place is what says
+       which. It is allowed to shrink (min-width: 0) so a long project name
+       ellipsises rather than pushing the figures off the row. */
+    .history-autonomy-project {
+      font: inherit; font-size: 11px; color: var(--text);
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 4px; padding: 1px 4px; max-width: 55%; min-width: 0;
     }
+    .history-autonomy-project:hover { border-color: var(--working); }
+    /* The sentence a panel draws instead of an empty frame when the selected
+       project has no runs in this range. An empty plot with axes on it is the
+       same picture a broken request draws; this says which it is. Its height is
+       the canvas's, so switching to an empty project does not make the card
+       jump. */
+    .history-autonomy-panel-empty {
+      height: 179px; display: flex; align-items: center; justify-content: center;
+      font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em;
+      text-transform: uppercase; color: var(--muted);
+    }
+    /* The per-bucket tooltip (#1905): the panel's bars carry a figure the
+       header can only state once, for the whole window. Positioned by JS
+       against the pointer and clamped to the panel, so it cannot hang off an
+       edge and read as a rendering fault. */
+    .history-autonomy-panel { position: relative; }
+    .history-autonomy-tip {
+      position: absolute; bottom: 100%; transform: translateX(-50%);
+      pointer-events: none; white-space: nowrap; z-index: 3;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 4px; padding: 3px 6px; margin-bottom: 4px;
+      font-family: var(--font-mono); font-size: 10px; color: var(--text-bright);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    }
+    .history-autonomy-tip[hidden] { display: none; }
     /* The two figures the maintainer asked for, on the panel that carries them
        — so the exact longest never depends on reading a shared log axis, and
        the concurrency split is legible rather than buried in a tooltip. */
@@ -1819,19 +1868,17 @@
        its backing store from the constant and lays out against it, so a
        stylesheet that disagreed would scale every panel. autonomyLayout.test.js
        reads both and fails on a mismatch. */
-    .history-autonomy-panel-canvas { width: 100%; height: 67px; display: block; }
-    /* "+N more projects" — what the five-panel view left out. Quieter than a
-       panel and clearly not one: it is a statement about the stack, not another
-       row of it. */
+    .history-autonomy-panel-canvas { width: 100%; height: 179px; display: block; }
+    /* "+N more projects" — what the daemon's payload cap left out, which is
+       nothing on any machine seen so far. Quieter than the panel and clearly
+       not one: it is a statement about the payload, not another row of it. */
     .history-autonomy-more {
       font-family: var(--font-mono); font-size: 10px; color: var(--muted);
       opacity: 0.85; padding: 4px 0 0;
     }
-    /* The window's bounds, once under the whole stack: the five panels share
-       one x domain, so five copies would be five statements of one fact. The
-       padding matches the plot's own inset (AUTONOMY_PANEL.padL / .padR), so
-       each bound sits under the end of the line it describes rather than under
-       the right-hand tick gutter. */
+    /* The window's bounds, once under the panel. The padding matches the plot's
+       own inset (AUTONOMY_PANEL.padL / .padR), so each bound sits under the end
+       of the line it describes rather than under the right-hand tick gutter. */
     .history-autonomy-axis {
       display: flex; justify-content: space-between;
       padding-left: 4px; padding-right: 46px;
@@ -1932,11 +1979,20 @@
     }
     .history-contrib li { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 12px; }
     .history-contrib .dot { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
-    /* The Autonomy key's two swatches. A panel draws one line and one row of
-       bars in a single hue, so the key has to distinguish them by SHAPE — two
-       identically-coloured dots would be a key that says the same thing twice.
-       Both take their colour from `currentColor`, which the JS resolvers set
-       from the same tokens the canvas painter reads, never from here. */
+    /* The Autonomy key's four swatches. The section draws two lines, one plane
+       and a row of bars in a SINGLE hue, so the key has to distinguish them by
+       SHAPE — four identically-coloured dots would be a key that says the same
+       thing four times. Every colour comes from `currentColor` (or, for the
+       band's fill, an inline background), which the JS resolvers set from the
+       same tokens the canvas painters read, never from here. */
+    .history-contrib .dot.autonomy-p50 {
+      width: 16px; height: 0; border-radius: 0; background: none;
+      border-top: 2px solid currentColor;
+    }
+    .history-contrib .dot.autonomy-band {
+      width: 16px; height: 10px; border-radius: 1px;
+      border-top: 1px solid currentColor; border-bottom: 1px solid currentColor;
+    }
     .history-contrib .dot.autonomy-line {
       width: 16px; height: 0; border-radius: 0; background: none;
       border-top: 2px solid currentColor;

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1844,15 +1844,22 @@
       text-transform: uppercase; color: var(--muted);
     }
     /* The per-bucket tooltip (#1905): the panel's bars carry a figure the
-       header can only state once, for the whole window. Positioned by JS
-       against the pointer and clamped to the panel, so it cannot hang off an
-       edge and read as a rendering fault. */
+       header can only state once, for the whole window.
+
+       IT STAYS INSIDE ITS OWN PANEL. It was pinned to the panel's top edge
+       (`bottom: 100%`), which put it OUTSIDE the panel and over the aggregate
+       chart above — hovering to read one chart hid the other, covering its
+       x-axis labels and its lowest data. Both offsets are set by JS now
+       (autonomyTipPlacement), which puts it below the pointer, flips it above
+       when that would overflow the panel's foot, and holds its right edge clear
+       of the gutter both y axes label themselves in. No `bottom` here, so the
+       panel's box can no longer be escaped upwards by a stale rule. */
     .history-autonomy-panel { position: relative; }
     .history-autonomy-tip {
-      position: absolute; bottom: 100%; transform: translateX(-50%);
+      position: absolute; top: 0; left: 0; transform: translateX(-50%);
       pointer-events: none; white-space: nowrap; z-index: 3;
       background: var(--surface); border: 1px solid var(--border);
-      border-radius: 4px; padding: 3px 6px; margin-bottom: 4px;
+      border-radius: 4px; padding: 3px 6px;
       font-family: var(--font-mono); font-size: 10px; color: var(--text-bright);
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
     }

--- a/platforms/web/irrlicht.history.autonomy.backfill.test.js
+++ b/platforms/web/irrlicht.history.autonomy.backfill.test.js
@@ -2,8 +2,9 @@ import {
   autonomyBoundaryCaptionShown,
   autonomyBoundaryLabel,
   autonomyMoreProjectsLabel,
+  autonomyPanelChoice,
+  autonomyProjectOptions,
   autonomyReconstructionNote,
-  autonomyStackRows,
   autonomyVisibleBoundaries,
 } from './historyTab.js'
 import { readFileSync } from 'node:fs'
@@ -104,10 +105,12 @@ describe('autonomyReconstructionNote — the panel marks a back-filled view', ()
   })
 })
 
-// The percentile band and the run strip were REMOVED, not hidden (#1905
-// redesign). Dead code that still parses is the thing a later reader restores
-// by accident, so their identifiers are checked out of the shipped files.
-describe('the percentile band and the run strip are gone from the shipped files', () => {
+// The run strip was REMOVED, not hidden (#1905 redesign), and it STAYS removed
+// through the #1905 restore that brought the percentile band back. Dead code
+// that still parses is the thing a later reader restores by accident, so its
+// identifiers are checked out of the shipped files — and the band's are checked
+// back IN, so a half-finished restore cannot pass as a whole one.
+describe('the run strip is gone from the shipped files, and the band is back', () => {
   const js = readFileSync(join(WEB_DIR, 'historyTab.js'), 'utf8')
   const css = readFileSync(join(WEB_DIR, 'irrlicht.css'), 'utf8')
   const html = readFileSync(join(WEB_DIR, 'index.html'), 'utf8')
@@ -121,13 +124,26 @@ describe('the percentile band and the run strip are gone from the shipped files'
     expect(html).toContain('history-autonomy-panels')
   })
 
-  test('no p5/p50/p95 apparatus survives', () => {
-    for (const gone of ['AUTONOMY_SERIES', 'AUTONOMY_BAND_TOKENS', 'autonomyBandSegments',
-      'autonomyBandColor', 'autonomySeriesColor', 'sample_floor', 'autonomyChartPoints']) {
-      expect(js).not.toContain(gone)
+  test('the p5–p95 band and its three tokens are back in the shipped files', () => {
+    for (const back of ['AUTONOMY_SERIES', 'autonomyBandSegments', 'autonomyChartPoints',
+      'sample_floor', 'autonomyAggregateDomain']) {
+      expect(js).toContain(back)
     }
-    expect(css).not.toContain('--autonomy-band')
-    expect(css).not.toContain('--autonomy-edge')
+    for (const token of ['--autonomy-band', '--autonomy-band-thin', '--autonomy-edge']) {
+      expect(css).toContain(token)
+    }
+  })
+
+  test('no log-scale mapping survives on either axis', () => {
+    // The maintainer's explicit call (#1905): linear, and no log path kept
+    // alive behind a flag. `Math.log` anywhere in the Autonomy code would be
+    // one, so it is checked out of the file rather than merely unused.
+    const section = js.slice(js.indexOf('// --- Autonomy (#1905) ---'),
+      js.indexOf('// --- Activity matrix'))
+    expect(section.length).toBeGreaterThan(1000) // the slice actually found the section
+    expect(section).not.toContain('Math.log')
+    expect(section).not.toContain('Math.exp')
+    expect(section).toContain('autonomyLinearY')
   })
 
   test('no run strip, end-reason colours, glyphs or legend survive', () => {
@@ -141,26 +157,18 @@ describe('the percentile band and the run strip are gone from the shipped files'
   })
 })
 
-// The section is a per-project view of the FIVE most important projects. The
-// daemon computes the five and says how many it left out; the client renders
-// what it was sent and names the rest.
-describe('the stack draws the panels it was sent and names the rest', () => {
+// The dropdown offers EVERY project the daemon sent. The daemon sends every
+// project in the window up to a high safety cap and says how many it left out;
+// the client offers what it was sent and names the rest.
+describe('the dropdown offers the projects it was sent, and names the rest', () => {
   const stack = (panelCount, more) => ({
     panels: Array.from({ length: panelCount }, (_, i) => ({ project: 'p' + i, buckets: [] })),
     more_projects: more,
-    panel_limit: 5,
+    panel_limit: 200,
   })
 
-  test('five panels and one overflow line, in that order', () => {
-    const rows = autonomyStackRows(stack(5, 7))
-    expect(rows.filter(r => r.kind === 'panel')).toHaveLength(5)
-    expect(rows[rows.length - 1]).toEqual({ kind: 'more', label: '+7 more projects, each with less autonomous time' })
-    expect(rows).toHaveLength(6)
-  })
-
-  test('nothing is said when every project already has a panel', () => {
-    const rows = autonomyStackRows(stack(3, 0))
-    expect(rows.map(r => r.kind)).toEqual(['panel', 'panel', 'panel'])
+  test('every project sent is offered, however many there are', () => {
+    expect(autonomyProjectOptions(stack(93, 0), null)).toHaveLength(93)
   })
 
   test('the overflow line says WHY those are the projects missing', () => {
@@ -170,23 +178,25 @@ describe('the stack draws the panels it was sent and names the rest', () => {
       .toContain('each with less autonomous time')
   })
 
-  test('one hidden project is singular', () => {
-    expect(autonomyStackRows(stack(5, 1)).at(-1).label).toMatch(/^\+1 more project,/)
+  test('nothing is said when the cap left nothing out', () => {
+    expect(autonomyMoreProjectsLabel(stack(93, 0))).toBe('')
   })
 
-  // The committed mutation: a client that re-decides the panel count itself.
-  // Two surfaces doing that is exactly how the run strip ended up drawing
-  // twelve rows on the web against six on macOS from one ranked list.
-  test('the client renders what it was sent, never its own count', () => {
-    const clientCap = (data) => data.panels.slice(0, 3)
-    const data = stack(5, 7)
-    expect(clientCap(data)).toHaveLength(3)
-    expect(autonomyStackRows(data).filter(r => r.kind === 'panel')).toHaveLength(data.panels.length)
+  // The committed mutation: a client that re-decides the list itself. Two
+  // surfaces doing that is exactly how the run strip ended up drawing twelve
+  // rows on the web against six on macOS from one ranked list — and a picker
+  // that caps its own list drops projects the summary beside it still counts.
+  test('the client offers what it was sent, never its own slice', () => {
+    const clientCap = (data) => data.panels.slice(0, 5)
+    const data = stack(93, 0)
+    expect(clientCap(data)).toHaveLength(5)
+    expect(autonomyProjectOptions(data, null)).toHaveLength(data.panels.length)
   })
 
-  test('an empty window draws no panels and claims no overflow', () => {
-    expect(autonomyStackRows({ panels: [], more_projects: 0 })).toEqual([])
-    expect(autonomyStackRows(null)).toEqual([])
+  test('an empty window offers nothing and claims no overflow', () => {
+    expect(autonomyProjectOptions({ panels: [], more_projects: 0 }, null)).toEqual([])
+    expect(autonomyProjectOptions(null, null)).toEqual([])
+    expect(autonomyPanelChoice(null, null).panel).toBeNull()
   })
 })
 
@@ -276,27 +286,27 @@ describe('source boundaries are marked across the panel stack', () => {
   })
 })
 
-// WITH FIVE PANELS THE RULE HAS TO READ ONCE. Every panel's line steps at the
-// same instant — they share one x domain — so the rule is drawn through all of
-// them, and the caption is drawn on exactly one. Five stacked copies of
-// "← cost log · 60s resolution" are five competing captions where the reader
-// needs one, and at 9px they collide with four project names.
-describe('the boundary caption is written once, not once per panel', () => {
-  test('exactly one of five panels carries it', () => {
-    const carrying = [0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)
+// WITH TWO ELEMENTS THE RULE HAS TO READ ONCE. Both step at the same instant —
+// they share one window — so the rule is drawn on both, and the caption is
+// written by exactly one. Two stacked copies of "← cost log · 60s resolution"
+// are two competing captions where the reader needs one, and at 9px the lower
+// one collides with the panel's own header row.
+describe('the boundary caption is written once, not once per element', () => {
+  test('exactly one of the two elements carries it', () => {
+    const carrying = ['aggregate', 'panel'].filter(autonomyBoundaryCaptionShown)
     expect(carrying).toHaveLength(1)
   })
 
-  test('it is the top panel, so the caption sits above the whole stack', () => {
-    expect(autonomyBoundaryCaptionShown(0)).toBe(true)
-    expect(autonomyBoundaryCaptionShown(4)).toBe(false)
+  test('it is the aggregate chart, which is the top element', () => {
+    expect(autonomyBoundaryCaptionShown('aggregate')).toBe(true)
+    expect(autonomyBoundaryCaptionShown('panel')).toBe(false)
   })
 
-  // The committed mutation: captioning every panel. It passes "a caption is
+  // The committed mutation: captioning every element. It passes "a caption is
   // drawn" and fails the thing that matters, which is that there is one.
-  test('production tells one caption from five', () => {
+  test('production tells one caption from two', () => {
     const captionEverywhere = () => true
-    expect([0, 1, 2, 3, 4].filter(captionEverywhere)).toHaveLength(5)
-    expect([0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)).toHaveLength(1)
+    expect(['aggregate', 'panel'].filter(captionEverywhere)).toHaveLength(2)
+    expect(['aggregate', 'panel'].filter(autonomyBoundaryCaptionShown)).toHaveLength(1)
   })
 })

--- a/platforms/web/irrlicht.history.autonomy.measurement.test.js
+++ b/platforms/web/irrlicht.history.autonomy.measurement.test.js
@@ -39,9 +39,12 @@ describe('autonomyMeasurementNote', () => {
     expect(line).toContain('SO FAR')
     expect(line).toContain('counts towards the longest run')
     expect(line).toContain('still going')
-    // The percentile-era wording must be gone with the percentiles: a sentence
-    // claiming an exclusion that no longer happens is a wrong number's alibi.
-    expect(line).not.toContain('percentile')
+    // BOTH halves of the asymmetry, because the section now draws both figures
+    // (#1905 restore): a running run IS the panel's longest, and is NOT a
+    // sample for the aggregate chart's percentiles. A sentence that named only
+    // one of the two would be an alibi for whichever number the reader was
+    // looking at.
+    expect(line).toContain('left out of the percentiles')
   })
 
   test('an unmeasured start says which end of the run is the estimate', () => {

--- a/platforms/web/irrlicht.history.autonomy.subagents.test.js
+++ b/platforms/web/irrlicht.history.autonomy.subagents.test.js
@@ -26,18 +26,21 @@ describe('autonomyQuery — no run-scope parameter reaches the daemon', () => {
   // payload while this panel's sentence said it counted everything — the exact
   // "wrong number with nothing on screen saying so" the section exists to
   // avoid. So the query is exactly the chart and its window, and nothing else.
-  test('the query is the chart and its window, and nothing else', () => {
-    expect(autonomyQuery(state())).toBe('chart=autonomy_projects&window=30d')
+  test('each element sends its chart and its window, and nothing else', () => {
+    expect(autonomyQuery('projects', state())).toBe('chart=autonomy_projects&window=30d')
+    expect(autonomyQuery('duration', state())).toBe('chart=autonomy_duration&window=30d')
   })
 
   test('no leftover state key can revive the parameter', () => {
     // The mutation this catches: a stale `autonomyRuns` left in local state (a
     // stored preference, a resumed session) silently re-filtering the view.
     const s = state({ autonomyRuns: 'all' })
-    expect(autonomyQuery(s)).not.toContain('include_subagents')
-    // …and the window survives: the section has one, and it is not one of
-    // chart=state's same-looking granularity keys.
-    expect(autonomyQuery(s)).toContain('window=30d')
+    for (const element of ['projects', 'duration']) {
+      expect(autonomyQuery(element, s)).not.toContain('include_subagents')
+      // …and the window survives: the section has one, and it is not one of
+      // chart=state's same-looking granularity keys.
+      expect(autonomyQuery(element, s)).toContain('window=30d')
+    }
   })
 })
 

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -3,14 +3,26 @@ import { describe, test, expect } from 'vitest'
 import {
   AUTONOMY_RANGE_LABELS,
   AUTONOMY_MARK_TOKENS,
-  AUTONOMY_BOUNDARY_CAPTION_PANEL,
+  AUTONOMY_BOUNDARY_CAPTION_ON,
   AUTONOMY_CONCURRENCY_CAVEAT,
   autonomyQuery,
   autonomyPanelPoints,
   autonomyLineSegments,
   autonomyYDomain,
+  autonomyAggregateDomain,
   autonomyYAt,
+  autonomyTickValues,
   autonomyPeakScale,
+  autonomyPanelChoice,
+  autonomyProjectOptions,
+  autonomyEmptyProjectNote,
+  autonomyBucketAtX,
+  autonomyPanelTooltip,
+  autonomyBarAxisLabels,
+  autonomyGutterLabels,
+  autonomyBaselineY,
+  AUTONOMY_PANEL,
+  AUTONOMY_PANEL_CANVAS_H,
   autonomyConcurrencyLabel,
   autonomyPanelHeadline,
   autonomyMoreProjectsLabel,
@@ -26,14 +38,15 @@ import {
   buildAutonomyAxis,
 } from './historyTab.js'
 
-// The Autonomy section (#1905), redesigned: five per-project panels, each a
-// longest-run line over a concurrency histogram.
+// The Autonomy section (#1905): an AGGREGATE percentile chart over every
+// project, and ONE per-project panel under it — a longest-run line over a
+// concurrency histogram — picked from a dropdown.
 //
-// What these pin is the set of claims the panels make about data they cannot
-// show in full — the gap rule on BOTH marks, the shared axis that makes five
-// panels comparable, the split that is only ever shown where the data supports
-// one, and the wording that keeps an empty view from reading as "you did
-// nothing".
+// What these pin is the set of claims the section makes about data it cannot
+// show in full — the gap rule on every mark, the split that is only ever shown
+// where the data supports one, the project the picker keeps when a range does
+// not hold it, and the wording that keeps an empty view from reading as "you
+// did nothing".
 
 // bucket builds one panel bucket. `longest` 0 means "no run ended here";
 // `peak` 0 means "nobody was working here".
@@ -89,48 +102,81 @@ describe('a bucket with no runs is a gap, not a zero', () => {
   })
 })
 
-describe('the five panels share one log Y axis', () => {
-  // Shared, so the projects are comparable — that is the point of picking
-  // five. Log, because a project whose best is two minutes would otherwise be
-  // a flat line under one whose best is eleven hours.
-  const panels = [
-    panel('big', [bucket(1, 41_940, 5)]),   // 11h39m
-    panel('small', [bucket(1, 120, 1)]),    // 2m
-  ]
+describe('the panel\u2019s Y axis is that project\u2019s own, and LINEAR', () => {
+  // Its own, because exactly one panel is drawn: there is nothing left to be
+  // comparable WITH, and a domain stretched to fit projects that are not on
+  // screen would flatten the one that is.
+  //
+  // Linear is the maintainer\u2019s explicit call, and these tests record BOTH
+  // halves of it — that the mapping is linear, and what linear costs.
+  const big = panel('big', [bucket(1, 41_940, 5)])   // 11h39m
+  const small = panel('small', [bucket(1, 120, 1)])  // 2m
 
-  test('the domain spans every panel, not just the one being drawn', () => {
-    const domain = autonomyYDomain(panels)
-    expect(domain.lo).toBeLessThanOrEqual(120)
-    expect(domain.hi).toBeGreaterThanOrEqual(41_940)
+  test('the domain is the drawn panel\u2019s own, not every panel\u2019s', () => {
+    // The MUTATION this refuses: the shared domain the five-panel stack used.
+    // Under it `small` is plotted against big\u2019s 11h39m and is a flat line on
+    // the floor; with its own domain its 2m fills the plot.
+    const own = autonomyYDomain(small)
+    const shared = { lo: 0, hi: 41_940 * 1.1 }
+    expect(own.hi).toBeLessThan(shared.hi)
+    expect(autonomyYAt(120, own, 100)).not.toBeCloseTo(autonomyYAt(120, shared, 100))
+    expect(autonomyYAt(120, own, 100)).toBeLessThan(10) // near the TOP of its own plot
+    expect(autonomyYAt(120, shared, 100)).toBeGreaterThan(99) // on the floor of the shared one
   })
 
-  test('the same duration lands at the same height in every panel', () => {
-    // The MUTATION this refuses: a per-panel domain. Under it `small`'s own
-    // 120s would sit at the top of its plot while `big`'s 120s sat near the
-    // bottom, and the five panels would not be comparable at all.
-    const shared = autonomyYDomain(panels)
-    const perPanel = autonomyYDomain([panels[1]])
-    expect(autonomyYAt(120, shared, 32)).toBeCloseTo(autonomyYAt(120, shared, 32))
-    expect(autonomyYAt(120, perPanel, 32)).not.toBeCloseTo(autonomyYAt(120, shared, 32))
+  test('the mapping is linear, not logarithmic', () => {
+    // The MUTATION this refuses: the log mapping that shipped before. Halfway
+    // up a LINEAR plot is half the domain; on a log plot it is its geometric
+    // mean, which for 0\u2026100 is a different number entirely.
+    const domain = { lo: 0, hi: 100 }
+    expect(autonomyYAt(50, domain, 100)).toBeCloseTo(50)
+    const logY = (v) => 100 * (1 - (Math.log(Math.max(1, v)) - Math.log(1)) / (Math.log(100) - Math.log(1)))
+    expect(logY(50)).not.toBeCloseTo(autonomyYAt(50, domain, 100))
   })
 
-  test('a log axis keeps a two-minute project off the floor', () => {
-    const domain = autonomyYDomain(panels)
-    const y = autonomyYAt(120, domain, 32)
-    // Linear, 120 of 41 940 would be 0.3% of the plot height — indistinguishable
-    // from the axis itself.
-    expect(y).toBeLessThan(32 * 0.997)
-    expect(y).toBeGreaterThan(0)
+  test('the axis starts at zero, which the log axis could not', () => {
+    // A linear axis whose origin is not zero exaggerates every difference above
+    // it, and the "a log scale cannot plot 0" reason for lifting it is gone.
+    expect(autonomyYDomain(big).lo).toBe(0)
+    expect(autonomyYAt(0, autonomyYDomain(big), 100)).toBe(100)
   })
 
-  test('an empty window has no domain rather than a fabricated one', () => {
-    expect(autonomyYDomain([])).toBeNull()
-    expect(autonomyYDomain([panel('p', [bucket(1, 0, 2)])])).toBeNull()
+  test('the ticks are evenly spaced in VALUE, not in ratio', () => {
+    const ticks = autonomyTickValues({ lo: 0, hi: 100 }, 2)
+    expect(ticks).toEqual([0, 50, 100])
   })
 
-  test('the histogram scale is shared too, and absent when nothing overlapped', () => {
-    expect(autonomyPeakScale(panels)).toBe(5)
-    expect(autonomyPeakScale([panel('p', [bucket(1, 60, 0)])])).toBe(0)
+  test('the cost of linear is real, and this is what it looks like', () => {
+    // Recorded rather than hidden: on a linear axis a project whose longest day
+    // is 11h39m plots its typical 10m runs in the bottom ~1.5% of the plot.
+    const domain = autonomyYDomain(big)
+    const y = autonomyYAt(600, domain, 110)
+    expect(y).toBeGreaterThan(110 * 0.98)
+  })
+
+  test('an empty panel has no domain rather than a fabricated one', () => {
+    expect(autonomyYDomain(null)).toBeNull()
+    expect(autonomyYDomain(panel('p', [bucket(1, 0, 2)]))).toBeNull()
+  })
+
+  test('the histogram scale is the panel\u2019s own, and absent when nothing overlapped', () => {
+    expect(autonomyPeakScale(big)).toBe(5)
+    expect(autonomyPeakScale(panel('p', [bucket(1, 60, 0)]))).toBe(0)
+  })
+})
+
+describe('the aggregate chart\u2019s Y axis is linear too', () => {
+  const pts = [{ ts: 1, p95: 1200, p50: 200, p5: 60, min: 60, max: 1500, count: 30 }]
+
+  test('the domain covers the drawn p95s and the true max, from zero', () => {
+    const domain = autonomyAggregateDomain(pts)
+    expect(domain.lo).toBe(0)
+    expect(domain.hi).toBeGreaterThanOrEqual(1500)
+  })
+
+  test('a window with nothing drawn has no domain', () => {
+    expect(autonomyAggregateDomain([])).toBeNull()
+    expect(autonomyAggregateDomain([null, null])).toBeNull()
   })
 })
 
@@ -176,14 +222,15 @@ describe('a panel states its own two figures in its header', () => {
   })
 })
 
-describe('the five-panel stack names what it left out', () => {
+describe('the payload cap names what it left out', () => {
   test('the overflow line says how many projects and why they are the ones missing', () => {
     const label = autonomyMoreProjectsLabel({ more_projects: 7 })
-    expect(label).toBe('+7 more projects, each with less autonomous time')
+    expect(label).toMatch(/^\+7 more projects past the payload cap/)
+    expect(label).toMatch(/less autonomous time/)
   })
 
   test('one hidden project is singular', () => {
-    expect(autonomyMoreProjectsLabel({ more_projects: 1 })).toMatch(/^\+1 more project,/)
+    expect(autonomyMoreProjectsLabel({ more_projects: 1 })).toMatch(/^\+1 more project past/)
   })
 
   test('nothing is said when every project fits', () => {
@@ -214,14 +261,21 @@ describe('the source-boundary rule reads once across the stack', () => {
     })).toEqual([])
   })
 
-  test('the caption is drawn on exactly one panel', () => {
-    // The rule runs through all five — it has to, or it annotates one project's
-    // line and leaves the four below it stepping for no stated reason — but
-    // five stacked copies of "← cost log · 60s resolution" would be five
+  test('the caption is written by exactly one of the two elements', () => {
+    // The rule is drawn on BOTH — it has to be, or it annotates the aggregate
+    // line and leaves the panel below it stepping for no stated reason — but
+    // two stacked copies of "← cost log · 60s resolution" would be two
     // competing captions where the reader needs one.
-    const shown = [0, 1, 2, 3, 4].filter(autonomyBoundaryCaptionShown)
-    expect(shown).toEqual([AUTONOMY_BOUNDARY_CAPTION_PANEL])
+    const shown = ['aggregate', 'panel'].filter(autonomyBoundaryCaptionShown)
+    expect(shown).toEqual([AUTONOMY_BOUNDARY_CAPTION_ON])
     expect(shown).toHaveLength(1)
+  })
+
+  test('it is the aggregate chart, which is the TOP element', () => {
+    // On the panel the caption would collide with the header row that carries
+    // the project picker and its figures.
+    expect(AUTONOMY_BOUNDARY_CAPTION_ON).toBe('aggregate')
+    expect(autonomyBoundaryCaptionShown('panel')).toBe(false)
   })
 
   test('the caption describes the era to the LEFT of the rule', () => {
@@ -239,9 +293,16 @@ describe('the window vocabulary stays distinct from chart=state’s', () => {
   // Autonomy windows OVERLAP textually and mean different things — a
   // granularity is a bucket width times a count ('24h' → a 30-DAY window), an
   // autonomy window IS the window.
-  test('the section sends one chart and one window', () => {
-    expect(autonomyQuery({ autonomyRange: '1y' })).toBe('chart=autonomy_projects&window=1y')
-    expect(autonomyQuery({ autonomyRange: '30d' })).toBe('chart=autonomy_projects&window=30d')
+  test('both elements send the SAME window, which is what makes one Range control honest', () => {
+    expect(autonomyQuery('duration', { autonomyRange: '1y' })).toBe('chart=autonomy_duration&window=1y')
+    expect(autonomyQuery('projects', { autonomyRange: '1y' })).toBe('chart=autonomy_projects&window=1y')
+    expect(autonomyQuery('duration', { autonomyRange: '30d' })).toBe('chart=autonomy_duration&window=30d')
+    expect(autonomyQuery('projects', { autonomyRange: '30d' })).toBe('chart=autonomy_projects&window=30d')
+    // The MUTATION this refuses: a per-element window, the shape the run
+    // strip's Span picker had. Two windows under one control is how a reader
+    // ends up comparing a month against a year with nothing saying so.
+    const split = (el) => (el === 'projects' ? 'window=24h' : 'window=30d')
+    expect(split('duration')).not.toBe(split('projects'))
   })
 
   test('the picker offers two windows, neither of them a granularity key', () => {
@@ -297,9 +358,19 @@ describe('the panels are one hue in two weights', () => {
     expect(Number(alpha[1])).toBeLessThan(1)
   })
 
-  test('a mark the panels do not draw has no colour to give it', () => {
-    expect(autonomyKeyColor('band', unstyled)).toBe('')
-    expect(autonomyKeyColor('p50', unstyled)).toBe('')
+  test('every mark the section draws is the same hue', () => {
+    // One hue throughout: the band, its edges and the bars are all the line's
+    // hue at lower alphas, because they are further readings of the same
+    // activity and not further subjects.
+    const line = rgbOf(autonomyKeyColor('line', unstyled))
+    for (const mark of ['p50', 'band', 'bandThin', 'edge', 'bars']) {
+      expect(rgbOf(autonomyKeyColor(mark, unstyled))).toBe(line)
+    }
+  })
+
+  test('a mark the section does not draw has no colour to give it', () => {
+    expect(autonomyKeyColor('p99', unstyled)).toBe('')
+    expect(autonomyKeyColor('', unstyled)).toBe('')
   })
 
   test('a live stylesheet wins over the fallback', () => {
@@ -308,30 +379,45 @@ describe('the panels are one hue in two weights', () => {
   })
 })
 
-describe('the key has two entries, and both stand for a mark on the panel', () => {
+describe('the key has four entries, and each stands for a mark on screen', () => {
   const unstyled = { getPropertyValue: () => '' }
 
-  test('one line and one row of bars, and nothing else', () => {
+  test('two lines, one plane and a row of bars, in the order they appear', () => {
     const entries = autonomyKeyEntries(unstyled)
-    expect(entries.map(e => e.kind)).toEqual(['line', 'bars'])
+    expect(entries.map(e => e.kind)).toEqual(['p50', 'band', 'line', 'bars'])
     for (const e of entries) expect(e.color).toBeTruthy()
   })
 
-  test('the p50/band key went with the percentiles', () => {
+  test('the aggregate chart\u2019s two marks are named, and so are the panel\u2019s', () => {
     const labels = autonomyKeyEntries(unstyled).map(e => e.label).join(' ')
-    expect(labels).not.toMatch(/p50|p95|p5\b|spread/)
+    expect(labels).toMatch(/p50/)
+    expect(labels).toMatch(/spread/)
     expect(labels).toMatch(/longest run/)
     expect(labels).toMatch(/at once/)
+  })
+
+  test('only the band has a fill \u2014 a line has no area', () => {
+    const entries = autonomyKeyEntries(unstyled)
+    const withFill = entries.filter(e => e.fill)
+    expect(withFill.map(e => e.kind)).toEqual(['band'])
   })
 })
 
 describe('the side panel carries the window’s figures', () => {
   const unstyled = { getPropertyValue: () => '' }
+  const both = (durationSummary, projectsSummary) => ({
+    duration: { summary: durationSummary },
+    projects: { summary: projectsSummary },
+  })
 
-  test('the two key rows carry the two headline numbers', () => {
-    const rows = autonomyPanelRows({ longest: 41_940, peak: 5, runs: 312, projects: 12 }, unstyled)
-    expect(rows[0].value).toBe('11h39m')
-    expect(rows[1].value).toBe('5')
+  test('the four key rows carry both elements\u2019 headline numbers', () => {
+    const rows = autonomyPanelRows(
+      both({ p95: 7080, p50: 660, p5: 41, min: 6, max: 41_940, count: 312 },
+           { longest: 41_940, peak: 5, runs: 312, projects: 12 }), unstyled)
+    expect(rows[0].value).toBe('11m')                 // p50
+    expect(rows[1].value).toBe('41s \u2013 1h58m')        // p5 \u2013 p95
+    expect(rows[2].value).toBe('11h39m')              // the panel\u2019s longest
+    expect(rows[3].value).toBe('5')                   // peak at once
     expect(rows.map(r => r.label)).toContain('runs')
     expect(rows.map(r => r.label)).toContain('projects')
   })
@@ -339,27 +425,26 @@ describe('the side panel carries the window’s figures', () => {
   test('every key row has a real swatch colour', () => {
     // The defect this pins: rows built and then every dot blanked, leaving
     // marks on the canvas with no key at all.
-    for (const row of autonomyPanelRows({ longest: 60, peak: 1, runs: 1, projects: 1 }, unstyled)) {
+    for (const row of autonomyPanelRows(both({ p50: 60, p5: 6, p95: 90 }, { longest: 60, peak: 1, runs: 1, projects: 1 }), unstyled)) {
       if (row.kind) expect(row.swatch).toBeTruthy()
     }
   })
 
   test('a still-running longest run says so here too', () => {
-    const rows = autonomyPanelRows({ longest: 10_800, longest_running: true, runs: 1, projects: 1 }, unstyled)
-    expect(rows[0].value).toMatch(/still going/)
+    const rows = autonomyPanelRows(both({}, { longest: 10_800, longest_running: true, runs: 1, projects: 1 }), unstyled)
+    expect(rows[2].value).toMatch(/still going/)
   })
 
   test('the figure rows stay unswatched', () => {
-    // A swatch would claim ink the panels deliberately do not lay down.
-    const rows = autonomyPanelRows({ longest: 60, peak: 1, runs: 4, projects: 2 }, unstyled)
+    // A swatch would claim ink the section deliberately does not lay down.
+    const rows = autonomyPanelRows(both({}, { longest: 60, peak: 1, runs: 4, projects: 2 }), unstyled)
     for (const row of rows.filter(r => !r.kind)) expect(row.swatch).toBe('transparent')
   })
 })
 
-describe('the stack states its own time bounds', () => {
-  // Without them the panels are texture: at 30d and 1y a mark cannot be placed
-  // in time at all. ONE axis under the whole stack, because the five panels
-  // share one x domain and five copies would be five statements of one fact.
+describe('the panel states its own time bounds', () => {
+  // Without them the panel is texture: at 30d and 1y a mark cannot be placed
+  // in time at all.
   const jan2 = Date.UTC(2026, 0, 2, 15, 30) / 1000
 
   test('a short window labels a time of day, a long one a date', () => {
@@ -395,5 +480,253 @@ describe('autonomyDuration', () => {
     expect(autonomyDuration(7080)).toBe('1h58m')
     expect(autonomyDuration(86_400)).toBe('1d')
     expect(autonomyDuration(0)).toBe('0s')
+  })
+})
+
+// --- One panel at a time, and the picker that chooses it (#1905) -------------
+
+describe('the panel draws ONE project, chosen from the dropdown', () => {
+  const data = {
+    panels: [panel('irrlicht', [bucket(1, 600, 2)]), panel('articles', [bucket(1, 300, 1)])],
+    bucket_starts: [1],
+  }
+
+  test('nothing selected draws rank 1, the busiest project', () => {
+    const choice = autonomyPanelChoice(data, null)
+    expect(choice.project).toBe('irrlicht')
+    expect(choice.panel).toBe(data.panels[0])
+    expect(choice.missing).toBe(false)
+  })
+
+  test('a selection this range holds draws that project', () => {
+    const choice = autonomyPanelChoice(data, 'articles')
+    expect(choice.project).toBe('articles')
+    expect(choice.panel).toBe(data.panels[1])
+    expect(choice.missing).toBe(false)
+  })
+
+  test('a selection this range does NOT hold is kept, and marked', () => {
+    // The MUTATION this refuses: `panels.find(...) || panels[0]`, the silent
+    // fall back to rank 1. Under it a Range change looks like a click the
+    // reader never made, and the project they were looking at is gone with
+    // nothing on screen saying where it went.
+    const silentFallback = data.panels.find(p => p.project === 'besenkammer') || data.panels[0]
+    expect(silentFallback.project).toBe('irrlicht')
+
+    const choice = autonomyPanelChoice(data, 'besenkammer')
+    expect(choice.project).toBe('besenkammer')
+    expect(choice.panel).toBeNull()
+    expect(choice.missing).toBe(true)
+  })
+
+  test('an empty window chooses nothing rather than inventing a project', () => {
+    const choice = autonomyPanelChoice({ panels: [] }, null)
+    expect(choice.panel).toBeNull()
+    expect(choice.project).toBe('')
+  })
+
+  test('the dropdown offers every project the window holds, ranked', () => {
+    expect(autonomyProjectOptions(data, null).map(o => o.value)).toEqual(['irrlicht', 'articles'])
+  })
+
+  test('…and keeps an absent selection in the list, last and labelled', () => {
+    const opts = autonomyProjectOptions(data, 'besenkammer')
+    expect(opts.map(o => o.value)).toEqual(['irrlicht', 'articles', 'besenkammer'])
+    // Last by the SAME rule the rest follow — the order is most autonomous
+    // time first, and a project with no runs in this range has none of it.
+    expect(opts[2].missing).toBe(true)
+    expect(opts[2].label).toMatch(/no runs in this range/)
+  })
+
+  test('an absent selection gets a sentence, not an empty frame', () => {
+    // An empty plot with axes on it is the same picture a broken request
+    // draws, and the reader cannot tell which they are looking at.
+    expect(autonomyEmptyProjectNote('besenkammer')).toBe('no runs for besenkammer in this range')
+    expect(autonomyEmptyProjectNote('')).toMatch(/this project/)
+  })
+})
+
+// --- The concurrency figure is legible: an axis, and a tooltip ---------------
+
+describe('the histogram labels its own y axis', () => {
+  test('the band’s full-height value sits at its top, and 0 on the baseline', () => {
+    const labels = autonomyBarAxisLabels(15)
+    expect(labels.map(l => l.text)).toEqual(['15', '0'])
+    expect(labels[1].y).toBe(autonomyBaselineY())
+    expect(labels[0].y).toBe(autonomyBaselineY() - AUTONOMY_PANEL.barsH)
+  })
+
+  test('the axis goes red against the blank gutter that shipped', () => {
+    // The MUTATION, which is what shipped in #1919 on both surfaces: a gutter
+    // kept for alignment and deliberately left EMPTY. That is what "the number
+    // of agents running in parallel is not visible" was about — the bars
+    // carried the only figure on the panel with no scale of any kind.
+    const blankGutter = []
+    expect(blankGutter).not.toEqual(autonomyBarAxisLabels(15))
+    expect(autonomyBarAxisLabels(15)).toHaveLength(2)
+  })
+
+  test('nothing overlapped anywhere means no axis at all', () => {
+    // An axis labelled 0 to 0 would be furniture claiming a measurement.
+    expect(autonomyBarAxisLabels(0)).toEqual([])
+    expect(autonomyBarAxisLabels(undefined)).toEqual([])
+  })
+
+  test('both labels are inside the canvas, in the line chart’s own gutter', () => {
+    // padB exists for the baseline label: it is drawn CENTRED on the baseline,
+    // so without an inset half of it would fall off the bottom of the canvas.
+    const half = AUTONOMY_PANEL.tickFont / 2
+    for (const l of autonomyBarAxisLabels(9)) {
+      expect(l.y - half).toBeGreaterThanOrEqual(0)
+      expect(l.y + half).toBeLessThanOrEqual(AUTONOMY_PANEL_CANVAS_H)
+    }
+  })
+})
+
+describe('the tooltip names the bucket the pointer is actually over', () => {
+  // n = 5 buckets across a 200px plot starting at padL.
+  const geo = { padL: 4, plotW: 200, n: 5 }
+  // The painter's own mapping, copied here so the inverse can be checked
+  // against it rather than against a second guess at it.
+  const xAt = (i) => geo.padL + geo.plotW * (i / (geo.n - 1))
+
+  test('every bucket’s own x hits that bucket', () => {
+    for (let i = 0; i < geo.n; i++) expect(autonomyBucketAtX(xAt(i), geo)).toBe(i)
+  })
+
+  test('the hit test goes red against arithmetic of its own', () => {
+    // The MUTATION: a plausible-looking hit test that divides the plot into n
+    // equal COLUMNS, instead of inverting xAt — which spaces n POINTS across
+    // the plot, so the gap between them is plotW/(n-1) and the nearest point to
+    // a pixel is a rounding, not a flooring.
+    //
+    // It happens to agree at the bucket centres, which is exactly why the sweep
+    // below is over the whole plot: a tooltip that is right only where the
+    // pointer lands dead on a gridline is a tooltip that is wrong nearly
+    // everywhere, and it would name a different bucket from the one drawn under
+    // the pointer with nothing on screen saying so.
+    const ownArithmetic = (x) => Math.min(geo.n - 1, Math.floor(((x - geo.padL) / geo.plotW) * geo.n))
+    let disagreements = 0
+    for (let x = geo.padL; x <= geo.padL + geo.plotW; x++) {
+      if (ownArithmetic(x) !== autonomyBucketAtX(x, geo)) disagreements++
+    }
+    // ~40 of the plot's 201 pixel columns, i.e. roughly a fifth of it.
+    expect(disagreements).toBeGreaterThan(geo.plotW / 10)
+  })
+
+  test('the gutters report nothing rather than the end buckets', () => {
+    expect(autonomyBucketAtX(0, geo)).toBeNull()
+    expect(autonomyBucketAtX(geo.padL + geo.plotW + 20, geo)).toBeNull()
+  })
+
+  test('a single-bucket window is bucket 0, not a division by zero', () => {
+    expect(autonomyBucketAtX(4, { padL: 4, plotW: 200, n: 1 })).toBe(0)
+  })
+
+  test('a degenerate plot hits nothing', () => {
+    expect(autonomyBucketAtX(10, { padL: 4, plotW: 0, n: 5 })).toBeNull()
+    expect(autonomyBucketAtX(10, { padL: 4, plotW: 200, n: 0 })).toBeNull()
+  })
+})
+
+describe('what the tooltip says', () => {
+  const day = Date.UTC(2026, 0, 9) / 1000
+  const month = 30 * 86400
+
+  test('the bucket’s date, its longest run and how many ran at once', () => {
+    const text = autonomyPanelTooltip(bucket(day, 41_940, 15), day, month)
+    expect(text).toMatch(/Jan/)
+    expect(text).toContain('longest 11h39m')
+    expect(text).toContain('15 at once')
+  })
+
+  test('the split rides along wherever the daemon says it is derivable', () => {
+    const text = autonomyPanelTooltip(
+      bucket(day, 600, 5, { peak_top: 3, peak_sub: 2, peak_split: true }), day, month)
+    expect(text).toContain('5 at once (3 + 2 sub)')
+  })
+
+  test('…and never where it is not', () => {
+    const text = autonomyPanelTooltip(bucket(day, 600, 5, { peak_top: 3, peak_sub: 2 }), day, month)
+    expect(text).toContain('5 at once')
+    expect(text).not.toContain('sub)')
+  })
+
+  test('a bucket a run merely crossed says so rather than claiming a zero run', () => {
+    // longest 0 with a bar: something WAS working, nothing finished. "longest
+    // 0s" would claim a run of no length.
+    const text = autonomyPanelTooltip(bucket(day, 0, 3), day, month)
+    expect(text).toContain('nothing finished')
+    expect(text).not.toContain('0s')
+    expect(text).toContain('3 at once')
+  })
+
+  test('a still-going longest run is marked here too', () => {
+    expect(autonomyPanelTooltip(bucket(day, 10_800, 1, { running: true }), day, month))
+      .toContain('(still going)')
+  })
+
+  test('a bucket the daemon omitted says nothing at all', () => {
+    // It draws nothing, so it has nothing to report — and a tooltip over a gap
+    // would be the one place the section claimed a measurement it does not have.
+    expect(autonomyPanelTooltip(null, day, month)).toBe('')
+  })
+})
+
+// --- QA-4: two axes, one gutter (#1905) ------------------------------------
+
+describe('the two y axes share one gutter without overprinting', () => {
+  // THE DEFECT, caught by QA of this very change in a browser: adding the
+  // histogram's own axis put a second set of labels in the gutter the line
+  // axis already used, and at the 3px gap the five-panel stack had — where the
+  // bar band carried NO labels — the line axis's floor tick "0s" and the
+  // histogram's peak "15" were drawn 3px apart and overprinted into a smudge.
+  // A wrong figure with nothing on screen saying so, in the gutter this change
+  // added precisely to make the concurrency figure legible.
+  const domain = { lo: 0, hi: 41_940 }
+  const width = 420
+
+  const overlaps = (labels) => {
+    const bad = []
+    for (let i = 1; i < labels.length; i++) {
+      if (labels[i].top < labels[i - 1].bottom) bad.push([labels[i - 1].text, labels[i].text])
+    }
+    return bad
+  }
+
+  test('every label in the gutter is listed, from both axes', () => {
+    // Fail-loud: an empty or single-axis list would satisfy the overlap check
+    // vacuously, which is the one thing a geometry check must not do.
+    const labels = autonomyGutterLabels(domain, 15, width)
+    expect(labels.length).toBeGreaterThanOrEqual(5) // 3 line ticks + 2 bar labels
+    expect(new Set(labels.map(l => l.axis))).toEqual(new Set(['line', 'bars']))
+  })
+
+  test('no two of them overlap', () => {
+    expect(overlaps(autonomyGutterLabels(domain, 15, width))).toEqual([])
+  })
+
+  test('the check goes red against the gap that shipped', () => {
+    // THE COMMITTED MUTATION: the 3px gap, which is what the browser showed.
+    const before = { ...AUTONOMY_PANEL, gap: 3 }
+    const bad = overlaps(autonomyGutterLabels(domain, 15, width, before))
+    expect(bad.length, 'the shipped gap did not overprint, so this fixture cannot show the fix')
+      .toBeGreaterThan(0)
+    expect(bad[0]).toEqual(['0s', '15'])
+  })
+
+  test('the gap is derived from the tick font, not a lucky constant', () => {
+    // The two labels nearest each other are the line axis's floor and the
+    // histogram's peak, one at each end of `gap`. Clearing one whole glyph is
+    // what keeps them apart for any larger tick font.
+    expect(AUTONOMY_PANEL.gap).toBeGreaterThanOrEqual(AUTONOMY_PANEL.tickFont)
+  })
+
+  test('a panel nobody overlapped in still lays its line axis out cleanly', () => {
+    // peakMax 0 draws no histogram axis at all, so the gutter is the line
+    // axis's alone — and must still not overlap itself.
+    const labels = autonomyGutterLabels(domain, 0, width)
+    expect(labels.every(l => l.axis === 'line')).toBe(true)
+    expect(overlaps(labels)).toEqual([])
   })
 })

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -165,18 +165,75 @@ describe('the panel\u2019s Y axis is that project\u2019s own, and LINEAR', () =>
   })
 })
 
-describe('the aggregate chart\u2019s Y axis is linear too', () => {
+describe('the aggregate chart’s Y axis is linear too', () => {
   const pts = [{ ts: 1, p95: 1200, p50: 200, p5: 60, min: 60, max: 1500, count: 30 }]
 
-  test('the domain covers the drawn p95s and the true max, from zero', () => {
+  test('the domain fits the drawn p95s, from zero', () => {
     const domain = autonomyAggregateDomain(pts)
     expect(domain.lo).toBe(0)
-    expect(domain.hi).toBeGreaterThanOrEqual(1500)
+    expect(domain.hi).toBeCloseTo(1200 * 1.1)
   })
 
   test('a window with nothing drawn has no domain', () => {
     expect(autonomyAggregateDomain([])).toBeNull()
     expect(autonomyAggregateDomain([null, null])).toBeNull()
+  })
+})
+
+describe('the aggregate domain fits what is DRAWN, never an undrawn outlier', () => {
+  // THE DEFECT: the domain was `max(p95, max)`, and `max` is a value the chart
+  // does not draw. It draws p95, p50, p5 and the plane between p95 and p5; the
+  // true extremes are FIGURES in the summary row, which is the whole reason
+  // #1905 made them figures — "one four-hour run left going overnight would
+  // otherwise redraw the whole Y scale and flatten every other bucket into the
+  // floor".
+  //
+  // Measured on the reference machine's live span log (30-day window, 27 of 30
+  // buckets with data, 2735 runs): highest p95 1h37m against a highest max of
+  // 11h39m — a 7.19x inflation that put the tallest p50 at 0.92% of the plot
+  // height and the median p50 at 0.46%, i.e. on the axis, with 87.4% of the
+  // plot empty above the band.
+  const outlier = [
+    { ts: 1, p95: 5820, p50: 424, p5: 60, min: 60, max: 41_940, count: 300 },
+    { ts: 2, p95: 3000, p50: 210, p5: 30, min: 30, max: 4000, count: 120 },
+  ]
+
+  test('the top tracks the highest drawn p95', () => {
+    expect(autonomyAggregateDomain(outlier).hi).toBeCloseTo(5820 * 1.1)
+  })
+
+  test('an 11h39m outlier nothing plots does not move the axis', () => {
+    // The SAME buckets with the outlier removed from `max` alone. A domain
+    // that reads only what it draws cannot tell the two apart.
+    const withoutOutlier = outlier.map(b => ({ ...b, max: b.p95 }))
+    expect(autonomyAggregateDomain(outlier).hi)
+      .toBeCloseTo(autonomyAggregateDomain(withoutOutlier).hi)
+  })
+
+  test('the p50 line stays legible instead of collapsing onto the axis', () => {
+    // The measured consequence, as an executable claim. Fitting p95 puts the
+    // tallest p50 at ~6.6% of the plot; fitting max put it at ~0.9%.
+    const hi = autonomyAggregateDomain(outlier).hi
+    const tallestP50 = Math.max(...outlier.map(b => b.p50))
+    expect(tallestP50 / hi).toBeGreaterThan(0.05)
+
+    // THE COMMITTED MUTATION: the domain that shipped, scaled to the undrawn
+    // max. It has to be distinguishable here, or this fixture proves nothing.
+    const scaledToMax = Math.max(...outlier.map(b => Math.max(b.p95, b.max))) * 1.1
+    expect(scaledToMax).toBeGreaterThan(hi * 5)
+    expect(tallestP50 / scaledToMax).toBeLessThan(0.01)
+  })
+
+  test('the extremes keep their place as FIGURES, which is where they belong', () => {
+    // Not a claim about the domain: a claim that dropping `max` from the axis
+    // does not drop it from the panel. The side panel's band row still carries
+    // p5–p95, and the longest run is still stated as a number.
+    const rows = autonomyPanelRows({
+      duration: { summary: { p95: 5820, p50: 424, p5: 60, min: 6, max: 41_940, count: 420 } },
+      projects: { summary: { longest: 41_940, peak: 5, runs: 420, projects: 3 } },
+    }, { getPropertyValue: () => '' })
+    expect(rows[1].value).toBe('1m – 1h37m')
+    expect(rows[2].value).toBe('11h39m')
   })
 })
 

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -20,6 +20,8 @@ import {
   autonomyPanelTooltip,
   autonomyBarAxisLabels,
   autonomyGutterLabels,
+  autonomyTipPlacement,
+  AUTONOMY_TIP_OFFSET,
   autonomyBaselineY,
   AUTONOMY_PANEL,
   AUTONOMY_PANEL_CANVAS_H,
@@ -37,6 +39,14 @@ import {
   autonomyPanelRows,
   buildAutonomyAxis,
 } from './historyTab.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { WEB_DIR } from './shippedFiles.testutil.js'
+
+// The shipped source, for the two provenance checks below — a drift that
+// reintroduces a second formatter is a change in SOURCE, not in output.
+const HISTORY_TAB_SRC = readFileSync(join(WEB_DIR, 'historyTab.js'), 'utf8')
+const CSS_SRC = readFileSync(join(WEB_DIR, 'irrlicht.css'), 'utf8')
 
 // The Autonomy section (#1905): an AGGREGATE percentile chart over every
 // project, and ONE per-project panel under it — a longest-run line over a
@@ -785,5 +795,157 @@ describe('the two y axes share one gutter without overprinting', () => {
     const labels = autonomyGutterLabels(domain, 0, width)
     expect(labels.every(l => l.axis === 'line')).toBe(true)
     expect(overlaps(labels)).toEqual([])
+  })
+})
+
+// --- QA-5: one date format for the whole section (#1905) --------------------
+
+describe('both autonomy axes are labelled by the same function', () => {
+  // THE DEFECT: the aggregate chart's x axis went through the SHARED
+  // histAxisLabel and read `8/7` — US numeric, hardcoded — while the panel
+  // directly beneath it and the tooltip went through autonomyAxisLabel and read
+  // `7. Aug.`. Two stacked charts over one window and one x domain, naming the
+  // same instant two ways, so lining a spike in the top chart up with a bar in
+  // the bottom one meant translating between them. macOS has never had this: it
+  // reads `Aug 24` on both.
+  const aug7 = Date.UTC(2026, 7, 7, 12) / 1000
+  const month = 30 * 86400
+
+  // The shipped aggregate formatter, reproduced here as the committed mutation
+  // — production must not agree with it, or this fixture proves nothing.
+  const usNumeric = (ts) => {
+    const d = new Date(ts * 1000)
+    return (d.getMonth() + 1) + '/' + d.getDate()
+  }
+
+  test('the two axes and the tooltip render one instant identically', () => {
+    // Compared against EACH OTHER, not each against a literal: a test that
+    // checked every label in isolation would pass happily while the two drifted
+    // apart, which is exactly how this shipped.
+    const axisLabel = autonomyAxisLabel(aug7, month)
+    const panelBound = [...buildAutonomyAxis({ start: aug7, end: aug7 + month })
+      .querySelectorAll('i')].map(i => i.textContent)[0]
+    const tooltipDate = autonomyPanelTooltip(bucket(aug7, 600, 2), aug7, month).split(' · ')[0]
+    expect(panelBound).toBe(axisLabel)
+    expect(tooltipDate).toBe(axisLabel)
+  })
+
+  test('…at every window the section offers, so they coarsen together', () => {
+    // The two used to coarsen on different inputs — the aggregate axis on its
+    // BUCKET width, the panel on the WINDOW — so a range change could move one
+    // and not the other.
+    for (const windowSeconds of [30 * 86400, 365 * 86400]) {
+      const axisLabel = autonomyAxisLabel(aug7, windowSeconds)
+      const tooltipDate = autonomyPanelTooltip(bucket(aug7, 600, 2), aug7, windowSeconds).split(' · ')[0]
+      expect(tooltipDate).toBe(axisLabel)
+    }
+    // …and the two windows really do read differently, or the loop above is
+    // comparing one label with itself.
+    expect(autonomyAxisLabel(aug7, 30 * 86400)).not.toBe(autonomyAxisLabel(aug7, 365 * 86400))
+  })
+
+  test('the label is month-name based, not the shared chart’s US numeric', () => {
+    expect(autonomyAxisLabel(aug7, month)).not.toBe(usNumeric(aug7))
+    expect(autonomyAxisLabel(aug7, month)).toMatch(/[A-Za-z]/)
+    expect(usNumeric(aug7)).toMatch(/^\d+\/\d+$/)
+  })
+
+  test('the aggregate painter routes through the section’s formatter, by PROVENANCE', () => {
+    // The output check above catches a drift that changes what is rendered;
+    // this catches one that reintroduces a second SOURCE, which is the shape
+    // the defect actually had. Both halves are needed: two formatters that
+    // happen to agree today would pass the first check and fail this one.
+    const painter = /function drawAutonomyXLabels\([\s\S]*?\n}/.exec(HISTORY_TAB_SRC)
+    expect(painter, 'fail-loud: drawAutonomyXLabels not found in historyTab.js').not.toBeNull()
+    expect(painter[0]).toContain('autonomyAxisLabel(')
+    expect(painter[0]).not.toContain('histAxisLabel')
+  })
+
+  test('no CODE in the Autonomy section calls histAxisLabel', () => {
+    // It keeps its place for every OTHER chart; what it must not do is label
+    // one half of this section.
+    //
+    // Comment lines are stripped first, deliberately: the section's prose NAMES
+    // histAxisLabel to say why it is not used here, and a check that could not
+    // tell a mention from a call would force that explanation out of the file.
+    const section = HISTORY_TAB_SRC.slice(
+      HISTORY_TAB_SRC.indexOf('// --- Autonomy (#1905) ---'),
+      HISTORY_TAB_SRC.indexOf('// --- Activity matrix'))
+    expect(section.length, 'fail-loud: the Autonomy section was not found').toBeGreaterThan(1000)
+    const code = section.split('\n').filter(l => !l.trim().startsWith('//')).join('\n')
+    expect(code.length, 'fail-loud: stripping comments left no code to check').toBeGreaterThan(1000)
+    expect(code).not.toContain('histAxisLabel')
+    // …and the stripping is not what makes this pass: the prose does mention it,
+    // so an over-eager strip would hide a real call just as well.
+    expect(section).toContain('histAxisLabel')
+    expect(code).toContain('autonomyAxisLabel(')
+  })
+})
+
+// --- QA-6: the tooltip never covers the chart above it (#1905) -------------
+
+describe('the tooltip stays inside its own panel', () => {
+  // THE DEFECT: the tip was pinned to the panel's TOP edge (`bottom: 100%`),
+  // which put it OUTSIDE the panel and over the aggregate chart — hovering to
+  // read one chart hid the other, covering its x-axis labels and its lowest
+  // data.
+  const box = { width: 860, height: 200, tipW: 220, tipH: 18 }
+
+  test('it sits BELOW the pointer, inside the panel', () => {
+    const at = autonomyTipPlacement(400, 60, box)
+    expect(at.top).toBe(60 + AUTONOMY_TIP_OFFSET)
+    expect(at.top + box.tipH).toBeLessThanOrEqual(box.height)
+  })
+
+  test('no pointer position can put it above the panel', () => {
+    // A LOCK, and said so rather than dressed up: the shipped defect lived in
+    // the STYLESHEET (`bottom: 100%`), never in a function — the old wiring set
+    // `left` alone and let CSS place the tip. Moving the decision into
+    // autonomyTipPlacement is what makes the bad placement inexpressible, and
+    // this pins that it stays inexpressible. The CSS half is checked below,
+    // which is where a red-first proof is actually available.
+    const shipped = -box.tipH - 4
+    expect(shipped, 'the shipped placement really was outside the panel').toBeLessThan(0)
+    for (const y of [-50, 0, 40, 120, 199, 5000]) {
+      expect(autonomyTipPlacement(400, y, box).top).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  test('the stylesheet no longer lets it escape the panel upwards', () => {
+    // THE COMMITTED MUTATION, and the shipped rule verbatim: `bottom: 100%`
+    // anchors the tip's foot to the panel's head, putting the whole tip outside
+    // the panel and over the chart above. Both offsets come from JS now, so the
+    // rule declares neither `bottom` nor a margin that could reintroduce it.
+    const shippedRule = 'position: absolute; bottom: 100%; transform: translateX(-50%);'
+    expect(shippedRule).toMatch(/bottom:\s*100%/)
+
+    const rule = /\.history-autonomy-tip\s*\{([^}]*)\}/.exec(CSS_SRC)
+    expect(rule, 'fail-loud: no .history-autonomy-tip rule found in irrlicht.css').not.toBeNull()
+    expect(rule[1]).not.toMatch(/bottom:/)
+    expect(rule[1]).not.toMatch(/margin-bottom:/)
+    expect(rule[1]).toMatch(/position:\s*absolute/)
+  })
+
+  test('near the foot it flips above the pointer rather than overflowing', () => {
+    const at = autonomyTipPlacement(400, box.height - 4, box)
+    expect(at.top + box.tipH).toBeLessThanOrEqual(box.height)
+    expect(at.top).toBeGreaterThanOrEqual(0)
+  })
+
+  test('its right edge never reaches the gutter the y axes label in', () => {
+    // Both axes write their figures into padR (autonomyBarAxisLabels,
+    // autonomyTickPlacement). A tip that covered them would hide the numbers
+    // the gutter exists to show.
+    for (const x of [0, 400, 800, 860, 2000]) {
+      const at = autonomyTipPlacement(x, 60, box)
+      expect(at.left + box.tipW / 2).toBeLessThanOrEqual(box.width - AUTONOMY_PANEL.padR)
+      expect(at.left - box.tipW / 2).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  test('a degenerate box cannot produce a placement outside itself', () => {
+    const at = autonomyTipPlacement(10, 10, { width: 0, height: 0, tipW: 0, tipH: 0 })
+    expect(at.top).toBe(0)
+    expect(at.left).toBe(0)
   })
 })


### PR DESCRIPTION
Closes part of #1905 — the four changes the maintainer asked for after #1919.

> no, i still want the first chart, that shows the aggregated view over all projects with p95, p50 and p5. And additionally the new view on a per project level. If there are no numbers for a certain period […] The charts per project should be much shorter. actually it would be better to only display the top 1 chart and have the ability to select the other projects via drop down. On the bar chart below. the number of agents running in parallel is not visible. Also i do not want the logarithmic display. i'd prefere linear.

## 1. The aggregate chart is back

`chart=autonomy_duration` is restored as it was before #1919 deleted it: p95 / p50 / p5 per bucket, the translucent plane between p95 and p5, ONE hue at three weights, the sample floor with its thin-bucket marking (fainter plane, dashed edges, hollow points), and the min/max/count that stay **figures** rather than lines. Its code is `core/cmd/irrlichd/history_autonomy_duration.go`, split out from the shared file so the two elements' types cannot collide.

`chart=autonomy_spans` — the per-project run strip, its end-reason colours, glyphs, legend and collapse ladder — **stays deleted**. A `describe` in `irrlicht.history.autonomy.backfill.test.js` now checks the band's identifiers back **in** and the strip's still **out**, so a half-finished restore cannot pass as a whole one.

Both elements share **one** `?window=` vocabulary and one Range control. `TestAutonomy_BothElementsShareOneWindowVocabulary` pins that they resolve to the same period, with the run strip's per-element vocabulary as its committed mutation.

## 2. One project panel with a dropdown

The daemon now sends a panel for **every** project with a run in the window, ranked by total autonomous time as before. `autonomyPanelCount` is a **200 safety cap**, not a design; `more_projects` keeps counting past it honestly (0 on every machine seen so far).

The client draws **one** panel, chosen from a `<select>` in that panel's own header row — Range moves both elements and stays in the tab's control row, the project picker moves one and lives beside the figures it changes. Switching is a repaint, not a refetch: the payload already carries every project.

The selection is held as a **name**, not a rank, so it survives a Range change instead of silently swapping projects when a longer window reorders the ranking.

**"If there are no numbers for a certain period" — both readings are handled:**
- a bucket with no runs stays a **gap** (line breaks, no bar, never a zero) — the existing rule, still pinned;
- a **selected project with nothing in the new range** is *kept*: it stays in the dropdown, last, labelled `<project> — no runs in this range`, and the panel renders `no runs for <project> in this range` instead of an empty frame. Verified live: picked `ms-timing` in the Year range, switched to 30 days, selection kept and the sentence rendered.

With one panel drawn its scales are **that project's own** — `autonomyYDomain(panel)` / `autonomyPeakScale(panel)` on web, `HistoryAutonomyPanel.yDomain` / `.peakScale` on macOS. The comments that claimed sharing say so. The panel gets 110px for its line and 44px for its bars (macOS: 96 pt / 40 pt) where five squeezed each to 40px / 32 pt.

### Measured payload

```
go build -o /tmp/irrmeas/irrlichd ./core/cmd/irrlichd
mkdir -p /tmp/irrmeas/home
cp -R "$HOME/Library/Application Support/Irrlicht/autonomy" /tmp/irrmeas/home/autonomy
IRRLICHT_HOME=/tmp/irrmeas/home IRRLICHT_BIND_ADDR=127.0.0.1:7899 /tmp/irrmeas/irrlichd &
curl -s "http://127.0.0.1:7899/api/v1/history?chart=autonomy_projects&window=1y" \
  -o /dev/null -w "%{size_download}\n"
```

| request | bytes |
|---|---|
| `chart=autonomy_projects&window=1y` (93 panels, 9886 runs, 93 projects) | **24 291** |
| `chart=autonomy_projects&window=30d` | 7 617 |
| `chart=autonomy_duration&window=1y` | 3 096 |

24 KB against the ~500 KB stop-line. It reads a **copy** of the reference machine's span store under an isolated `IRRLICHT_HOME` on port 7899 — production was not touched, and `test-mac.sh` was not run.

## 3. The concurrency figure is legible

The gutter beside the bars was deliberately **blank** on both surfaces — `AxisMarks(values: [0])` with a spacer string on macOS, nothing at all on web. That is what "the number of agents running in parallel is not visible" was: the bars carried the only figure on the panel with no scale of any kind.

- **Both surfaces**: the histogram's own y axis is labelled — its peak at the top of the band, `0` on the baseline — in the **line chart's** right-hand gutter and tick font, so the two axes read as one column. `autonomyBarAxisLabels` / `AutonomyBarAxis`.
- **Web**: a mousemove tooltip over the panel canvas reading `<bucket date> · longest <d> · N at once`, with the `(N + M sub)` split wherever `peak_split` allows one. A bucket a long run merely crossed says `nothing finished` rather than `longest 0s`; a bucket the daemon omitted says nothing at all.
- The hit test (`autonomyBucketAtX`) **inverts the painter's own `xAt`** off the same `padL`/`plotW`/`n`, so the tooltip cannot name a bucket other than the one drawn under the pointer.
- A bucket with nobody working still draws nothing.

## 4. Linear, not logarithmic

`Math.log`/`Math.exp` are gone from `autonomyYAt` and `autonomyTickValues`; `.chartYScale(… type: .log)` is gone from macOS; the "a log scale cannot plot 0" floor went with them (the axis starts at **0** now, which is the honest origin for a linear scale). No toggle, no log path behind a flag — a `backfill.test.js` check greps the Autonomy section of `historyTab.js` for `Math.log`/`Math.exp` and fails on either.

### Correction: the domain fits what is DRAWN (QA round 2)

The first round scaled the aggregate domain to `max(p95, bucket.max)`, and `max` is a value the chart does not draw — it draws p95, p50, p5 and the plane between p95 and p5. A bucket's true maximum is a **figure** in the summary row, and it is a figure precisely so it cannot redraw the axis. Folding it back in re-created exactly the failure the ticket rejected, two lines under a comment saying the extremes stay figures. Fixed on both surfaces: `hi = max(p95 over drawn buckets) * 1.1`, `lo` stays 0. `max` and `min` keep their place in the figure row.

**Measured** — a python reduction over `~/Library/Application Support/Irrlicht/autonomy/*.jsonl` that mirrors `history_autonomy_duration.go` exactly (trailing 30 days, 30 daily buckets, span credited to the bucket its END falls in, R-7 percentiles). 2735 runs across 93 project files, 27 of 30 buckets with data:

```
highest p95 across buckets : 1h37m
highest max across buckets : 11h39m
domain inflation           : 7.19x

tallest p50, domain to p95  : 6.60% of plot height
tallest p50, domain to max  : 0.92%
median  p50, domain to max  : 0.46%    (i.e. on the axis)
band top (highest p95)      : 12.64%   — 87.4% of the plot empty above it
```

**Red first, on both surfaces** — a payload whose `max` is an order of magnitude above every `p95`:

| test | result against the shipped line |
|---|---|
| web `the top tracks the highest drawn p95` | `expected 46134 to be close to 6402` |
| web `an 11h39m outlier nothing plots does not move the axis` | same 7.2x gap |
| web `the p50 line stays legible instead of collapsing onto the axis` | `expected 0.00919 to be greater than 0.05` — the measured 0.92% |
| macOS `testTheDomainFitsWhatIsDrawnNotAnUndrawnOutlier` | `("46134.0") is not equal to ("6402.0")`, and `0.00919 is not greater than 0.05` |
| macOS `testTheExtremesKeepTheirPlaceAsFigures` | `41940.0 is not greater than 46134.0` |

Each carries the shipped domain as its committed mutation and asserts it is distinguishable from production, so neither can pass vacuously. The macOS pair also asserts the outlier is still reported as a number — above the top of its own chart, which is the point.

One fixture moved with the fix: `testTheCostOfALinearAxisIsRecorded` made its long value a `max`, so it no longer drove the axis. Its claim is unchanged and still true — a long **drawn** p95 flattens the short buckets under it — so it now says that with a p95.

### Sweep for the same leak

| site | verdict |
|---|---|
| web `autonomyAggregateDomain` | **was the bug** — fixed |
| macOS `HistoryAutonomyDurationResponse.yDomain` | **was the bug** — fixed |
| web/macOS panel line domain (`autonomyYDomain`, `HistoryAutonomyPanel.yDomain`) | clean — reads `b.longest`, which the line plots |
| web/macOS histogram scale (`autonomyPeakScale`, `.peakScale`, `autonomyBarRect`, `autonomyBarAxisLabels`) | clean — reads `b.peak`, which the bars plot |
| `autonomyLineSegments` / `drawAutonomyLine` | clean — `longest`; `running` only changes a marker's style, never the axis |
| `autonomyPanelHeadline`, `autonomyPanelTooltip`, `autonomyConcurrencyLabel` | clean — labels, no geometry |
| `historyMaxY` (cost/tokens/CO2) | clean — sums the bands it stacks and covers the forecast points it draws |
| `stateMatrixMaxTotal` (activity matrix) | clean — scales to `stateCellTotal`, the quantity each bar's height plots |
| yield chart `maxTotal` | clean — scales to `total_cost`; the productive segment is a fraction of that drawn width |
| `pickCO2Equivalents` | clean — takes the already-computed `maxY` |

No geometry on either surface still reads a bucket's `max` or `min`; the only surviving reads are `summary.max` / `summary.min` in the figure row, which is correct.

Added one lock for the same class in the other direction — `TestAutonomy_PanelLongestIsAlwaysOnItsOwnAxis`: the panel header's window-wide longest must be reachable on the panel's own axis. It holds because `foldSpanRow` returns only spans whose end is inside the window, so every counted run is also bucketed. Green by construction, with the dropping-instead-of-clamping mutation committed beside it.

**The cost is recorded in a code comment where each domain is chosen** (`autonomyYDomain`, `autonomyAggregateDomain`, `HistoryAutonomyPanel.yDomain`, `HistoryAutonomyDurationResponse.yDomain`), and as an executable claim: on a linear axis one 11-hour run sets the domain and the typical 10-minute runs land in the bottom ~1.5% of the plot. Both surfaces state the exact figures as **numbers** for that reason — the panel header's `longest`, the aggregate chart's `p95 · p50 · p5 · longest · shortest · N runs` row.

## QA, and the two defects it found

**Round 1** was driven against an isolated daemon serving this worktree's `platforms/web`. Verified: both elements draw, the dropdown lists all 12 projects in the 30-day window, the empty-project path, the tooltip at five x positions (including a gap, which correctly says nothing).

**Round 2** — the Y-domain defect above — was found and fixed by **reading the code and reducing the live span log**, with no browser and no running daemon. Nothing was brought to the front.

**Round 1 found one real defect, fixed here.** Adding the histogram's axis put a second set of labels into the gutter the line axis already used, and at the 3px gap the five-panel stack had the line axis's `0s` and the histogram's `15` were drawn 3px apart and overprinted into a smudge — a wrong figure with nothing on screen saying so, in the gutter this change added to make the figure legible. The gap now clears one whole tick font (web 14px, macOS 10 pt), and `autonomyGutterLabels` is the value the check reads.

## QA round 3 — two presentation defects, both web-only

macOS had neither; the web was the odd surface out against its own twin.

**One date format for the section.** The aggregate chart's x axis went through the shared `histAxisLabel` and read `8/7` — US numeric, hardcoded — while the panel directly beneath it and the tooltip went through `autonomyAxisLabel` and read `7. Aug.`. Two stacked charts over one window and one x domain, naming the same instant two ways, so lining a spike in the top chart up with a bar in the bottom one meant translating between them. Every autonomy label routes through `autonomyAxisLabel` now — month-name based, matching what macOS reads (`Aug 24`) rather than inventing a third shape, with the locale left as the reader's. The aggregate axis also coarsens on the **window** now rather than on its own bucket width, so both change together at one threshold instead of two.

Live, after: `7. Aug. / 14. Aug. / 22. Aug. / 29. Aug. / 5. Sep` up top, `7. Aug. … now` below, `26. Aug.` in the tooltip.

**The tooltip stays in its panel.** It was pinned to the panel's top edge (`bottom: 100%`), which put it *outside* the panel and over the aggregate chart — hovering to read one chart hid the other, covering its x-axis labels and its lowest data. Both offsets come from `autonomyTipPlacement` now: below the pointer, flipped above when that would overflow the panel's foot, never at a negative top, and with its right edge held clear of the gutter both y axes label themselves in.

### Evidence

| check | kind |
|---|---|
| the two axes and the tooltip render one instant identically, at both windows | red-first — went red with the aggregate axis back on `histAxisLabel` |
| `drawAutonomyXLabels` calls `autonomyAxisLabel`, not `histAxisLabel` (**provenance**) | red-first — same mutation |
| no *code* in the Autonomy section calls `histAxisLabel` | red-first — same mutation |
| `.history-autonomy-tip` declares no `bottom` / `margin-bottom` | red-first — went red against the shipped `bottom: 100%` rule |
| the tip sits below the pointer, inside the panel | red-first — went red with the placement pinned above |
| no pointer position can put it above the panel | **LOCK** — the final clamp makes the bad placement inexpressible; the shipped defect lived in CSS, never in a function, so the red-first proof is the stylesheet check above |
| right edge never reaches the gutter; flips near the foot; degenerate box | lock |

The output check and the provenance check are both needed and fail differently: a test checking each label in isolation would pass happily while the two drifted, which is how this shipped; two formatters that happened to agree today would pass the output check and fail the provenance one. The section's prose still **names** `histAxisLabel` to say why it is not used here, so the source check strips comments first, then asserts both that the code has no call *and* that the prose still has the mention — an over-eager strip would hide a real call just as well.

**Verified against the maintainer's daemon on live data:** 105 visible tooltip positions across the full canvas width at three heights, **zero** violations of any of five bounds (escapes panel top / bottom / left, covers the aggregate chart, enters the y-axis gutter); 18 gap buckets correctly draw no tip; hides on leave.

Untouched, as asked: the linear axis, the domain, the dropdown, the empty-project sentence, the histogram gutter.

## Tests

**Seen red before the fix:**

| test | mutation that made it red |
|---|---|
| `TestAutonomy_SendsEveryProjectRankedNotJustTheTopFew` | `autonomyPanelCount = 5` → `drew 5 panels over 8 projects, want 8` |
| `TestAutonomyDuration_RunningRunIsNotAPercentileSample` | removed the `if s.Running { continue }` guard → `summary count = 2, want 1` / `max = 10800, want 600` |
| `the two y axes share one gutter…: no two of them overlap` | `AUTONOMY_PANEL.gap = 3` → `expected [ [ '0s', '15' ] ] to deeply equal []` — the exact pair the browser showed |

**Committed mutation fixtures** (added behaviour with no before-state; each asserts the mutation is distinguishable from production, so the check cannot pass vacuously): the uncapped payload (`TestAutonomy_PanelCapStillBitesAndSaysSo`), the split window vocabulary, `panels.find(…) || panels[0]` for the picker, the equal-columns hit test, the blank gutter (web and macOS), the shared Y domain, the log mapping, the log domain's 1s floor, the 3px gap.

**Locks — green by construction, not red-first:** everything in `core/cmd/irrlichd/history_autonomy_duration_test.go` except the running-run test, and everything in `platforms/macos/Tests/HistoryAutonomyDurationTests.swift` except `testTheAggregateAxisIsLinearAndStartsAtZero`. They pin behaviour that existed before #1919 and came back unchanged; what they can and do show is that the restore is faithful (the band's gap rule, the thin-bucket split, the shared seam, the R-7 arithmetic spelled out).

**Honesty properties kept**, all still asserted: gaps are not zeros (both marks, both elements), running runs are marked as floors *and* excluded from the percentiles while counting toward the maximum — with the asymmetry now asserted in one test rather than two places that could drift — reconstructed rows are marked, the source-boundary rule with its caption drawn once across the section (`AUTONOMY_BOUNDARY_CAPTION_ON`), the provenance / counting / measurement sentences, and the `AUTONOMY_KEY` ⟺ `AutonomyPalette.keyEntries` cross-check (now four entries each, read out of the Swift source).

**Gates:** `--only go`, `--only web`, `--only swift`, `--only tools` — all PASS. `--only go` / `--only web` / `--only swift` re-run green after the domain fix; `--only web` re-run green after the two presentation fixes and again after the final rebase onto `ae1bb040`.

## Found but not changed

- **`kirocli` is flaky on a loaded machine.** `TestRefreshVerdicts_GarbageVersionIsAlsoUnknown` failed once with `signal: killed` after its 5s budget while another session was recording on this machine, and passed on retry. My diff touches no kirocli file (`git diff --stat origin/main...HEAD -- core/adapters/inbound/agents/kirocli` is empty). It shells out to the real `kiro-cli` binary against a wall-clock timeout, so it is load-sensitive by construction — worth a longer budget, but not in this PR.
- **`autonomyCsvLines` was exporting a field that no longer exists.** It read `autonomyData.spans.spans`, left behind when #1919 removed `chart=autonomy_spans`, so the Autonomy CSV button had been silently emitting a header row and nothing else since that PR. It now exports every project's per-bucket row — all projects, not just the panel on screen, since the dropdown shows one at a time and a CSV carrying only the visible one would be a per-project export wearing a section-wide name.
- **`requestAnimationFrame` never fires in a background tab**, so the panel canvas keeps its 300×150 default backing store until the tab is foregrounded. Pre-existing (the five-panel build painted the same way) and invisible to a real user; it only bit my automated probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB


