### PR TITLE
fix(onboard): live stability for the Claude Desktop driver

### DIFF
--- a/tools/onboarding-factory/internal/desktopdriver/driver.go
+++ b/tools/onboarding-factory/internal/desktopdriver/driver.go
@@ -152,6 +152,11 @@ func Run(ctx context.Context, runtime Runtime, request RunRequest) (result RunRe
 	if err := Plan(script); err != nil {
 		return result, err
 	}
+	// A recipe declares its own steps, so a tool call in its transcript is what
+	// the cell asked for. A bare prompt keeps the no-tool safety boundary.
+	if teller, ok := runtime.(interface{ ExpectTools(bool) }); ok {
+		teller.ExpectTools(len(request.Script) > 0)
+	}
 	ctx, cancel := context.WithTimeout(ctx, request.OverallTimeout)
 	defer cancel()
 

--- a/tools/onboarding-factory/internal/desktopdriver/live.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live.go
@@ -40,6 +40,10 @@ type LiveRuntime struct {
 	// workspace is the composer WaitComposer verified. Submit re-resolves
 	// against it rather than against a caller-supplied value.
 	workspace string
+	// toolsExpected records that this run drives a RECIPE, whose steps are
+	// declared, rather than a bare prompt. It relaxes the no-tool evidence rule
+	// to the form that rule was written for. See validateTranscriptToolUse.
+	toolsExpected bool
 	// environment is what the composer showed when WaitComposer verified it.
 	// It is captured then because it cannot be read later: a Desktop turn
 	// replaces its own composer with the session it created.
@@ -573,4 +577,11 @@ func transientHelperError(err error) error {
 		return nil
 	}
 	return err
+}
+
+// ExpectTools tells the runtime that this run drives a declared recipe, so a
+// tool call in its transcript is what the cell asked for rather than something
+// the driver caused.
+func (runtime *LiveRuntime) ExpectTools(expected bool) {
+	runtime.toolsExpected = expected
 }

--- a/tools/onboarding-factory/internal/desktopdriver/live.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live.go
@@ -395,6 +395,12 @@ func (runtime *LiveRuntime) SetPrompt(ctx context.Context, prompt string) error 
 	if err != nil {
 		return err
 	}
+	// Front Desktop first: the composer is not in the accessibility tree at all
+	// while the app is in the background, and focus can move between the wait
+	// that verified this selector and now.
+	if err := runtime.front(ctx); err != nil {
+		return err
+	}
 	return runtime.helper.setValue(ctx, selector, prompt)
 }
 
@@ -407,14 +413,27 @@ func (runtime *LiveRuntime) Submit(ctx context.Context) error {
 	// Resolve and click inside the retry. Desktop's renderer can swap the
 	// composer out between the two, and re-using a selector resolved before
 	// that is exactly what fails with a stale control.
-	if err := retryTransientAX(ctx, "submit the Desktop prompt", func() error {
+	if err := retryTransientAXFor(ctx, "submit the Desktop prompt", submitAttempts, func() error {
+		// Front on EVERY attempt. Looking again without doing so is what made
+		// live run 25 spend all its retries reading a backgrounded window that
+		// carried a sidebar and no composer.
+		if err := runtime.front(ctx); err != nil {
+			return err
+		}
 		send, stop, err := runtime.sendAndStop(ctx)
 		if err != nil {
 			return fmt.Errorf("resolve the Desktop send button after the prompt was typed: %w", err)
 		}
-		return runtime.helper.click(ctx, send, helperPostcondition{
+		err = runtime.helper.click(ctx, send, helperPostcondition{
 			Selector: stop, Condition: "exists", TimeoutMilliseconds: 10_000,
 		})
+		if err != nil && isMissedPostcondition(err) {
+			// The click landed; only the Stop button never showed, which a fast
+			// turn never renders. The Desktop registry row is the real proof,
+			// and waitForOwned is the very next step. Retrying would send twice.
+			return nil
+		}
+		return err
 	}); err != nil {
 		return err
 	}
@@ -512,8 +531,25 @@ func isPreClickAXFailure(err error) bool {
 // action must re-resolve from a fresh reading each time: the whole reason the
 // last attempt failed is that the tree moved.
 func retryTransientAX(ctx context.Context, what string, action func() error) error {
+	return retryTransientAXFor(ctx, what, transientAXAttempts, action)
+}
+
+// submitAttempts is deliberately far larger. Everything else here waits out a
+// re-render; submit waits out Claude Desktop taking the whole composer away and
+// bringing it back, which is measured in seconds.
+const submitAttempts = 40
+
+// isMissedPostcondition reports whether a click landed but the state it was told
+// to watch for never appeared. The helper posts the mouse event and only then
+// verifies, so this is strictly POST-click. It must never drive a retry: the
+// click already took effect.
+func isMissedPostcondition(err error) bool {
+	return strings.Contains(err.Error(), "postcondition_failed")
+}
+
+func retryTransientAXFor(ctx context.Context, what string, attempts int, action func() error) error {
 	var err error
-	for attempt := 1; attempt <= transientAXAttempts; attempt++ {
+	for attempt := 1; attempt <= attempts; attempt++ {
 		err = action()
 		if err == nil || !isPreClickAXFailure(err) {
 			return err
@@ -526,7 +562,7 @@ func retryTransientAX(ctx context.Context, what string, action func() error) err
 	}
 	return fmt.Errorf(
 		"%s: Claude Desktop's accessibility tree kept moving across %d attempts; last failure: %w",
-		what, transientAXAttempts, err)
+		what, attempts, err)
 }
 
 func transientHelperError(err error) error {

--- a/tools/onboarding-factory/internal/desktopdriver/live_evidence.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_evidence.go
@@ -74,7 +74,7 @@ func (runtime *LiveRuntime) verifiedTranscriptPath(sessionID string) (string, er
 	if err != nil {
 		return "", err
 	}
-	if err := validateNoToolTranscript(transcriptPath); err != nil {
+	if err := validateTranscriptToolUse(transcriptPath, runtime.toolsExpected); err != nil {
 		return "", err
 	}
 	return transcriptPath, nil

--- a/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
@@ -352,3 +352,34 @@ func TestWorkingIsAcceptedFromTheLiveStateOnTheFirstTurn(t *testing.T) {
 		t.Fatalf("turn two accepted a live working state with no recorded history: %t, %v", observed, err)
 	}
 }
+
+// The no-tool rule is the safety boundary of the ONE-TURN form: a bare prompt
+// the driver sends must not have caused tool execution in the user's workspace.
+//
+// A recipe is different. Its steps are declared, reviewed and refused up front
+// when they need a control the driver lacks, and many catalog cells exist
+// precisely to exercise tool use — task lists, subagents, background processes.
+// Applying the one-turn rule to them made every such cell impossible: cell 3-3
+// drove its whole recipe and then failed with `Desktop transcript … contains a
+// tool call or tool result`.
+func TestToolsAreRefusedForABarePromptAndAllowedForARecipe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	withTool := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(withTool), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateTranscriptToolUse(path, false); err == nil {
+		t.Fatal("a bare prompt was allowed to have caused tool execution")
+	}
+	if err := validateTranscriptToolUse(path, true); err != nil {
+		t.Fatalf("a recipe was refused for using tools it declares: %v", err)
+	}
+
+	// An unreadable transcript fails either way: a check that cannot look must
+	// never report what a check that looked and found nothing reports.
+	missing := filepath.Join(dir, "absent.jsonl")
+	if err := validateTranscriptToolUse(missing, true); err == nil {
+		t.Fatal("a transcript that could not be read was accepted")
+	}
+}

--- a/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
@@ -311,3 +311,37 @@ func TestCapturedEnvironmentComesFromTheVerifiedComposer(t *testing.T) {
 		t.Fatal("captureEnvironment() accepted a foreign workspace")
 	}
 }
+
+// The recording is written by the daemon; the live state comes from its HTTP
+// API. The file can lag, and when it does the driver waits for a transition
+// that has already happened.
+//
+// Measured 2026-09-06 on cell 1-1: the run failed with `wait for Irrlicht state
+// working timed out after 1m30s`, and the recording read afterwards held
+// `ready (new session created)`, `working (force ready→working on first
+// activity)`, `ready (agent finished turn)` for that very session. Nothing was
+// missing; it simply was not on disk yet.
+//
+// For the FIRST turn the live state settles that: if the daemon says the
+// session is working, it is. For a later turn it cannot, because a live
+// "working" does not say WHICH turn it belongs to — only the cumulative
+// recorded sequence does. So the shortcut is confined to turn one.
+func TestWorkingIsAcceptedFromTheLiveStateOnTheFirstTurn(t *testing.T) {
+	empty := t.TempDir() // no recording flushed yet
+	runtime := &LiveRuntime{options: LiveOptions{RecordingDirectory: empty}}
+
+	observed, err := runtime.stateObserved("cli-1", "working", "working")
+	if err != nil || !observed {
+		t.Fatalf("a live working state was not accepted on turn one: %t, %v", observed, err)
+	}
+	if observed, err := runtime.stateObserved("cli-1", "ready", "working"); err != nil || observed {
+		t.Fatalf("a session that is not working read as working: %t, %v", observed, err)
+	}
+
+	// On a later turn the live state cannot say which turn it belongs to, so
+	// only the recorded sequence counts.
+	later := &LiveRuntime{options: LiveOptions{RecordingDirectory: empty}, turn: 2}
+	if observed, err := later.stateObserved("cli-1", "working", "working"); err != nil || observed {
+		t.Fatalf("turn two accepted a live working state with no recorded history: %t, %v", observed, err)
+	}
+}

--- a/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
@@ -334,8 +334,15 @@ func TestWorkingIsAcceptedFromTheLiveStateOnTheFirstTurn(t *testing.T) {
 	if err != nil || !observed {
 		t.Fatalf("a live working state was not accepted on turn one: %t, %v", observed, err)
 	}
-	if observed, err := runtime.stateObserved("cli-1", "ready", "working"); err != nil || observed {
-		t.Fatalf("a session that is not working read as working: %t, %v", observed, err)
+	// A short turn is already ready before any poll can see it working, and the
+	// recording that proves it worked has not been flushed. Moving on is right:
+	// waitForCompletion still demands the recorded working→ready sequence.
+	if observed, err := runtime.stateObserved("cli-1", "ready", "working"); err != nil || !observed {
+		t.Fatalf("a turn that finished before the first poll blocked the run: %t, %v", observed, err)
+	}
+	// A session that has not started at all must still wait.
+	if observed, err := runtime.stateObserved("cli-1", "error", "working"); err != nil || observed {
+		t.Fatalf("a session in error read as a turn that ran: %t, %v", observed, err)
 	}
 
 	// On a later turn the live state cannot say which turn it belongs to, so

--- a/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
@@ -109,7 +109,16 @@ func (runtime *LiveRuntime) stateObserved(sessionID, currentState, wantedState s
 	// A later turn cannot use that shortcut. A live "working" does not say which
 	// turn it belongs to, and the whole point of the cumulative sequence is that
 	// turn two must not be satisfied by turn one's transition.
-	if runtime.turn <= 1 && currentState == "working" {
+	if runtime.turn <= 1 && (currentState == "working" || currentState == "ready") {
+		// "ready" counts here too, and deliberately. A short turn reaches ready
+		// before any poll can catch it working, and the recording that proves it
+		// worked has not been flushed yet — so neither source can show working,
+		// for a turn that ran perfectly. Cell 2-13 failed exactly that way.
+		//
+		// Nothing is given up by moving on. waitForCompletion still demands the
+		// recorded sequence working→ready for this session, by which time the
+		// daemon has flushed it. That is the evidence; this wait is only a gate
+		// on the way to it.
 		return true, nil
 	}
 	return recorded, nil

--- a/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
@@ -95,10 +95,24 @@ func (runtime *LiveRuntime) WaitIrrlichtState(
 func (runtime *LiveRuntime) stateObserved(sessionID, currentState, wantedState string) (bool, error) {
 	expected := cumulativeExpectedStates(runtime.turn, wantedState)
 	recorded, err := recordingHasStateSequence(runtime.options.RecordingDirectory, sessionID, expected)
-	if wantedState == "ready" {
-		return currentState == "ready" && recorded, err
+	if err != nil {
+		return false, err
 	}
-	return recorded, err
+	if wantedState == "ready" {
+		return currentState == "ready" && recorded, nil
+	}
+	// The recording is written by the daemon and can lag its own HTTP API. Cell
+	// 1-1 timed out after 1m30s waiting for a `working` that the recording, read
+	// moments later, already held. On the FIRST turn the live state settles it:
+	// if the daemon says this session is working, it is.
+	//
+	// A later turn cannot use that shortcut. A live "working" does not say which
+	// turn it belongs to, and the whole point of the cumulative sequence is that
+	// turn two must not be satisfied by turn one's transition.
+	if runtime.turn <= 1 && currentState == "working" {
+		return true, nil
+	}
+	return recorded, nil
 }
 
 // cumulativeExpectedStates returns the full state sequence a recording must

--- a/tools/onboarding-factory/internal/desktopdriver/live_transcript.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_transcript.go
@@ -12,6 +12,32 @@ import (
 	"sort"
 )
 
+// validateTranscriptToolUse enforces the no-tool rule only where it belongs.
+//
+// For the ONE-TURN form it is the safety boundary: a bare prompt the driver
+// sends must not have caused tool execution in the user's workspace, and a
+// transcript that shows otherwise means the run did something it was not asked
+// to do.
+//
+// A recipe is different. Its steps are declared, and refused up front when they
+// need a control the driver lacks, and many catalog cells exist precisely to
+// exercise tool use. Cell 3-3 drove its whole recipe and then failed with
+// `contains a tool call or tool result` for doing what it was written to do.
+//
+// The transcript is read either way. A file that cannot be read is an error in
+// both modes: a check that cannot look must never report what a check that
+// looked and found nothing reports.
+func validateTranscriptToolUse(path string, toolsExpected bool) error {
+	found, err := jsonlContains(path, containsToolRecord)
+	if err != nil {
+		return err
+	}
+	if found && !toolsExpected {
+		return fmt.Errorf("Desktop transcript %q contains a tool call or tool result", path)
+	}
+	return nil
+}
+
 func validateNoToolTranscript(path string) error {
 	found, err := jsonlContains(path, containsToolRecord)
 	if err != nil {

--- a/tools/onboarding-factory/scripts/lib/desktop-profile.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile.sh
@@ -388,3 +388,22 @@ desktop_write_execution_results() {
         }
       } + (if $reason == "" then {} else {reason: $reason} end)]}' > "$path"
 }
+
+# desktop_default_hook_wait_paths names the file a desktop-local run must wait
+# for before it drives Claude Desktop.
+#
+# The CLI profile can skip this: it spawns a fresh `claude` per run, so the
+# hook config is read after the install by construction. Claude Desktop cannot.
+# Its engine is already running and reads hook config when it CREATES a
+# session, so a run that starts driving before the install has landed sends its
+# hooks to whichever daemon the config named before — in practice the
+# production one on 7837, which this run is not reading.
+#
+# The symptom is not a hook error. It is `wait for Claude Code hook timed out`
+# against a turn that ran perfectly, because the observations went somewhere
+# else. Runs 40 and 44 of 2026-09-06 failed exactly that way, each with
+# `hook-install-wait: NOT waiting` in its own log.
+desktop_default_hook_wait_paths() {
+  local home="${1:-$HOME}"
+  printf '%s\n' "$home/.claude/settings.json"
+}

--- a/tools/onboarding-factory/scripts/lib/desktop-profile.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile.sh
@@ -407,3 +407,45 @@ desktop_default_hook_wait_paths() {
   local home="${1:-$HOME}"
   printf '%s\n' "$home/.claude/settings.json"
 }
+
+# desktop_require_hooks_point_here refuses a run whose hook config does not name
+# THIS run's daemon.
+#
+# The managed-file installer refuses to overwrite a file that changed under it,
+# which is correct — but the run then carried on and drove Claude Desktop with
+# whatever hook configuration was already there. On 2026-09-06 that was a
+# previous run's port: the daemon bound 61198 while the hooks still named 61432,
+# so every observation went to a dead address and the run failed 80 seconds
+# later with `wait for Irrlicht state working timed out`, which says nothing
+# about the real cause.
+#
+# ~/.claude/settings.json is app-wide. This adapter has no isolated home wired,
+# so two claudecode recordings anywhere on the machine share this one file and
+# the second one silently loses.
+desktop_require_hooks_point_here() {
+  local settings="$1" bind="$2"
+  if [[ -z "$settings" || -z "$bind" ]]; then
+    echo "desktop-local: usage: desktop_require_hooks_point_here <settings> <bind>" >&2
+    return 1
+  fi
+  if [[ ! -f "$settings" ]]; then
+    echo "desktop-local: no hook configuration at $settings; nothing would be observed" >&2
+    return 1
+  fi
+  # Hook URLs are written as http://localhost:PORT (daemonaddr.LocalURL) while
+  # the bind address is 127.0.0.1:PORT, so match on the port. Matching the whole
+  # bind string silently never matches, which would refuse every run.
+  local port="${bind##*:}"
+  if [[ -z "$port" || "$port" == "$bind" ]]; then
+    echo "desktop-local: cannot read a port out of the daemon address '"'"'$bind'"'"'" >&2
+    return 1
+  fi
+  if ! grep -q ":$port" "$settings"; then
+    echo "desktop-local: the hook configuration at $settings does not name this run's daemon ($bind)." >&2
+    echo "desktop-local:   Observations would go somewhere else and the run would fail later, blaming Desktop." >&2
+    echo "desktop-local:   The usual cause is another claudecode recording on this machine: that file is" >&2
+    echo "desktop-local:   app-wide and this adapter has no isolated home, so two runs share it." >&2
+    return 1
+  fi
+  return 0
+}

--- a/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
@@ -332,6 +332,28 @@ else
 fi
 
 echo ""
+echo "== A desktop-local run refuses hooks that name another daemon =="
+# Measured 2026-09-06: run 55's daemon bound 61198 while ~/.claude/settings.json
+# still named 61432 from an earlier run, because the managed-file installer had
+# refused to overwrite a file another session changed. The run drove Claude
+# Desktop anyway and failed 80s later with `wait for Irrlicht state working
+# timed out`, which points at the wrong thing entirely.
+printf '%s' '{"hooks":{"Stop":[{"url":"http://localhost:61198/x"}]}}' > "$TMP/ok.json"
+desktop_require_hooks_point_here "$TMP/ok.json" "127.0.0.1:61198" 2>/dev/null
+assert_eq "hooks naming this daemon are accepted" 0 "$?"
+printf '%s' '{"hooks":{"Stop":[{"url":"http://localhost:61432/x"}]}}' > "$TMP/stale.json"
+if desktop_require_hooks_point_here "$TMP/stale.json" "127.0.0.1:61198" 2>/dev/null; then
+  fail "stale hook port is refused" "it was accepted"
+else
+  pass "stale hook port is refused"
+fi
+if desktop_require_hooks_point_here "$TMP/missing.json" "127.0.0.1:61198" 2>/dev/null; then
+  fail "absent hook config is refused" "it was accepted"
+else
+  pass "absent hook config is refused"
+fi
+
+
 if [[ "$fails" -eq 0 ]]; then
 echo "== A desktop-local run is gated on its hook config landing =="
 # Claude Desktop's engine is long-lived and reads hook config when it creates a

--- a/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
@@ -333,6 +333,23 @@ fi
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then
+echo "== A desktop-local run is gated on its hook config landing =="
+# Claude Desktop's engine is long-lived and reads hook config when it creates a
+# session, so a run that starts driving before the install has landed sends its
+# hooks to whichever daemon the config named BEFORE — the production one.
+#
+# Measured: runs 40 and 44 of 2026-09-06 failed with `wait for Claude Code hook
+# timed out after 1m20s`, while each run's own log said `hook-install-wait: NOT
+# waiting; if the CLI reads its hook config at startup, this run can race the
+# install`.
+assert_eq "hook wait path is defaulted for desktop-local" \
+  "/home/someone/.claude/settings.json" "$(desktop_default_hook_wait_paths /home/someone)"
+# hook-install-wait refuses a relative path outright, so this must be absolute.
+case "$(desktop_default_hook_wait_paths /home/someone)" in
+  /*) pass "the defaulted hook wait path is absolute" ;;
+  *) fail "the defaulted hook wait path is absolute" "it is relative" ;;
+esac
+
   echo "desktop-profile_test: ALL PASS"
 else
   echo "desktop-profile_test: $fails FAILURE(S)" >&2

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -634,6 +634,16 @@ if [[ "$ATTACH" != "1" ]]; then
   # evaluated yet. wait_for_unapplied_grants_clear trusts a refusal instantly
   # but polls a clean reading out to a deadline before believing it.
   wait_for_unapplied_grants_clear "$ONBOARD_BIND" "$ADAPTER" || exit 1
+  # BEGIN desktop_hook_install_gate
+  # Claude Desktop's engine is already running and reads hook config when it
+  # CREATES a session, so this profile cannot rely on the fresh-process
+  # ordering the CLI profile gets for free. Name the file explicitly so the
+  # wait is real; an operator who set the variable themselves keeps their value.
+  if [[ "$EXECUTION_PROFILE" == "desktop-local" && -z "${HOOK_INSTALL_WAIT_PATHS:-}" ]]; then
+    HOOK_INSTALL_WAIT_PATHS="$(desktop_default_hook_wait_paths "$HOME")"
+    export HOOK_INSTALL_WAIT_PATHS
+  fi
+  # END desktop_hook_install_gate
   wait_for_hook_install "$ADAPTER" "$STAGING" "$ONBOARD_BIND" || exit 1
   if [[ "$EXECUTION_PROFILE" == "desktop-local" ]]; then
     seal_managed_files || {

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -645,6 +645,15 @@ if [[ "$ATTACH" != "1" ]]; then
   fi
   # END desktop_hook_install_gate
   wait_for_hook_install "$ADAPTER" "$STAGING" "$ONBOARD_BIND" || exit 1
+  # BEGIN desktop_hook_target_check
+  # Waiting proves the file exists, not that it names THIS daemon. The
+  # managed-file installer refuses to overwrite a file another process changed,
+  # and without this the run drove Desktop with a previous run's port and
+  # blamed Desktop 80 seconds later.
+  if [[ "$EXECUTION_PROFILE" == "desktop-local" ]]; then
+    desktop_require_hooks_point_here "$HOME/.claude/settings.json" "$ONBOARD_BIND" || exit 1
+  fi
+  # END desktop_hook_target_check
   if [[ "$EXECUTION_PROFILE" == "desktop-local" ]]; then
     seal_managed_files || {
       echo "desktop-local could not seal the expected daemon hook state" >&2


### PR DESCRIPTION
Live stability for the Claude Desktop driver, found by running the basic turn
sixty-odd times against the real app rather than by reading the code.

Every fix below names the run that produced it and the message it produced.

## The failures, and what each one really was

**A backgrounded window.** Claude Desktop drops the composer from the
accessibility tree entirely while it is not frontmost, and does not put it
back. `SetPrompt` and every `Submit` attempt now bring it forward. Run 25
spent all five retries reading the same wrong window, which carried a sidebar
and no composer.

**A budget sized for the wrong thing.** Every other retry waits out a repaint.
Submit waits out Desktop taking the whole composer away and bringing it back,
which is measured in seconds. Runs 23, 24, 27 and 28 recovered; 25, 26 and 29
gave up after two.

**A postcondition that a fast turn never satisfies.** Submit watched for the
Stop button, which exists only while a turn is in flight. The helper posts the
mouse event and only then checks, so this failure is strictly post-click: the
prompt was sent. Retrying it would send twice. Runs 46, 48 and 50.

**Hooks pointing at another daemon.** `~/.claude/settings.json` is app-wide and
this adapter has no isolated home, so two claudecode recordings anywhere on the
machine share one file and the second silently loses. Run 55's daemon bound
61198 while the hooks still named 61432 from an earlier run; it drove Desktop
anyway and blamed Desktop eighty seconds later. Now the run refuses before
touching the app, and says which of the two it is.

**A hook install the run never waited for.** The CLI profile spawns a fresh
process per run, so its config is read after the install by construction.
Desktop's engine is already running and reads config when it creates a session.
Each failing run said so in its own log; desktop-local now supplies
`HOOK_INSTALL_WAIT_PATHS` itself rather than leaving an operator to know.

**A recording read before it was flushed.** The recording is written by the
daemon; the live state comes from its HTTP API. Cell 1-1 timed out waiting for
a `working` that the recording, read moments later, already held. On the first
turn the live state settles it. A later turn keeps the recorded-sequence
requirement, because a live `working` does not say which turn it belongs to.

**A turn that finished before the first poll.** A short turn is ready before
any poll can catch it working. Nothing is given up by moving on:
`waitForCompletion` still demands the recorded `working → ready` sequence.

## Evidence

`2-1 basic-turn` and `1-1 session-start` both record end to end on this branch.

## Known limitation, stated rather than hidden

Some cells still fail, and at least one failure is not a timing problem: on a
`2-13` run the driver bound one session while a different one carried the turn.
That is a correctness gap in session binding, not a race, and it is not fixed
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc

## The campaign's real blocker, found by running it

Four cells drove end to end through Claude Desktop and produced complete
recordings: `1-1 session-start`, `2-1 basic-turn`, `2-21
streaming-partial-writes`, `3-3 background-process`.

**None of them can be promoted, and no Desktop recording ever will be under the
current spec.** `expected-validate` fails them on `session_birth`:

```
"phase": "session_birth", "expected_state": "ready",
"relative_to": "start", "max_delay_ms": 1000
→ event arrived 4921 ms after anchor, exceeds max_delay_ms=1000
```

`1-1`'s own spec note says why, without knowing it: *"Both phases anchor to
recording start (agent launch) and budget 1000ms."* For the CLI those are the
same instant — the recording begins when `claude` is launched. Under Desktop
they cannot be: the recording daemon starts first, and Claude Desktop creates
the session seconds later, after the deep link, the workspace trust prompt and
the composer. The measured gap was 4.9 seconds.

This is a spec-model mismatch, not a driver defect and not a daemon defect. The
timing anchor assumes the CLI's process model.

I have deliberately not changed it. Both #1890 and #1891 say not to change CLI
Local results or daemon behaviour to make a scenario pass, and giving
`session_birth` a per-profile anchor — the session's own creation rather than
recording start — is a design decision for the maintainer rather than something
to slip into a stability PR.

Until that is decided, `desktop-local` can record and cannot promote.
