### PR TITLE
fix(onboard): do not wait for a recorded ready that is still being written

### DIFF
--- a/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_evidence_test.go
@@ -383,3 +383,38 @@ func TestToolsAreRefusedForABarePromptAndAllowedForARecipe(t *testing.T) {
 		t.Fatal("a transcript that could not be read was accepted")
 	}
 }
+
+// The recorded `ready` is the LAST event a turn writes, so it is the one most
+// likely not to be on disk when the driver looks. Cells 2-3, 3-1 and 2-16 all
+// timed out at `wait for Irrlicht state ready` on turns that had finished.
+//
+// What the gate needs to establish is that this turn ran and is over. The
+// recorded `working` for this turn establishes the first; the live state
+// establishes the second. Requiring the recorded `ready` as well adds nothing
+// the other two do not already say, and costs runs.
+//
+// The recording is still validated in full at promotion time, by
+// expected-validate against expected.jsonl. This gate is not that check.
+func TestReadyIsSatisfiedByALiveIdleSessionThatHasWorked(t *testing.T) {
+	dir := t.TempDir()
+	worked := `{"kind":"state_transition","session_id":"cli-1","new_state":"working"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "recording.jsonl"), []byte(worked), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &LiveRuntime{options: LiveOptions{RecordingDirectory: dir}}
+	observed, err := runtime.stateObserved("cli-1", "ready", "ready")
+	if err != nil || !observed {
+		t.Fatalf("a finished turn whose ready is not flushed yet blocked the run: %t, %v", observed, err)
+	}
+
+	// Still working: not finished, must wait.
+	if observed, err := runtime.stateObserved("cli-1", "working", "ready"); err != nil || observed {
+		t.Fatalf("a turn still in flight read as finished: %t, %v", observed, err)
+	}
+
+	// Never worked: there is no turn to be finished with.
+	empty := &LiveRuntime{options: LiveOptions{RecordingDirectory: t.TempDir()}}
+	if observed, err := empty.stateObserved("cli-1", "ready", "ready"); err != nil || observed {
+		t.Fatalf("a session that never worked read as a completed turn: %t, %v", observed, err)
+	}
+}

--- a/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
@@ -106,13 +106,21 @@ func (runtime *LiveRuntime) stateObserved(sessionID, currentState, wantedState s
 			return true, nil
 		}
 		// The recorded `ready` is the LAST event a turn writes and the one most
-		// likely still unflushed. What this gate needs to know is that the turn
-		// ran and is over: the recorded `working` for this turn says the first,
-		// the live idle state says the second. Requiring the recorded `ready`
-		// too adds nothing and cost cells 2-3, 3-1 and 2-16 their runs.
+		// likely still unflushed. On the FIRST turn, the recorded `working`
+		// plus a live idle state say everything this gate needs: the turn ran,
+		// and it is over. Cells 2-3, 3-1 and 2-16 lost runs to waiting for a
+		// `ready` that was on its way to disk.
 		//
-		// The recording is still checked in full at promotion, by
+		// A later turn cannot use that. Turn two's `working` is in the
+		// recording as soon as turn two STARTS, so accepting it as proof of
+		// completion would let a turn report finished the moment it began —
+		// which is the multi-turn defect this file already fixed once.
+		//
+		// The recording is still validated in full at promotion, by
 		// expected-validate against expected.jsonl. This is not that check.
+		if runtime.turn > 1 {
+			return false, nil
+		}
 		worked, err := recordingHasStateSequence(
 			runtime.options.RecordingDirectory, sessionID,
 			cumulativeExpectedStates(runtime.turn, "working"))

--- a/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
+++ b/tools/onboarding-factory/internal/desktopdriver/live_irrlicht.go
@@ -99,7 +99,24 @@ func (runtime *LiveRuntime) stateObserved(sessionID, currentState, wantedState s
 		return false, err
 	}
 	if wantedState == "ready" {
-		return currentState == "ready" && recorded, nil
+		if currentState != "ready" {
+			return false, nil
+		}
+		if recorded {
+			return true, nil
+		}
+		// The recorded `ready` is the LAST event a turn writes and the one most
+		// likely still unflushed. What this gate needs to know is that the turn
+		// ran and is over: the recorded `working` for this turn says the first,
+		// the live idle state says the second. Requiring the recorded `ready`
+		// too adds nothing and cost cells 2-3, 3-1 and 2-16 their runs.
+		//
+		// The recording is still checked in full at promotion, by
+		// expected-validate against expected.jsonl. This is not that check.
+		worked, err := recordingHasStateSequence(
+			runtime.options.RecordingDirectory, sessionID,
+			cumulativeExpectedStates(runtime.turn, "working"))
+		return worked, err
 	}
 	// The recording is written by the daemon and can lag its own HTTP API. Cell
 	// 1-1 timed out after 1m30s waiting for a `working` that the recording, read


### PR DESCRIPTION
The driver waited for a recorded `ready` that was still being written.

Cells `2-3 task-list`, `3-1 foreground-subagent` and `2-16
oversized-transcript-line` timed out at `wait for Irrlicht state ready` on turns
that had finished. The recorded `ready` is the LAST event a turn writes, so it
is the one most likely not to be on disk when the driver looks.

On the first turn, the recorded `working` and a live idle state say everything
this gate needs between them: the turn ran, and it is over. The recording is
still validated in full at promotion, by `expected-validate` against
`expected.jsonl`. This gate is not that check and should not duplicate it.

## The mistake in the middle, kept in the history

My first version applied that fallback to every turn, which broke the
multi-turn guard — turn two's `working` is in the recording the moment turn two
starts, so accepting it as proof of completion lets a turn report finished as it
begins. That is the defect this file fixed once already, reintroduced from the
other side.

Its test caught it: `turn two's wait for "ready" matched before its own
transition existed`. I had committed by then, because I did not read the suite
output before moving on. The second commit is the correction, and I have left
both rather than squashing the error out of the history.

## Live evidence

Six cells now record end to end through Claude Desktop: `1-1 session-start`,
`2-1 basic-turn`, `2-13 turn-end-terminal-text`, `2-21
streaming-partial-writes`, `3-3 background-process`, `5-2 model-identification`.

## Two failure classes still open, named rather than hidden

- `set Desktop prompt: helper postcondition_failed: The value_equals
  postcondition` — `setValue` into the composer does not reproduce every prompt
  exactly. Seen on `2-3` and `2-17`.
- `wait for Claude Code hook timed out` on longer turns, seen on `2-16`.

Neither is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc
