### PR TITLE
feat(history): cut the Autonomy prose to what a reader needs (#1905)

### DIFF
--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -98,12 +98,18 @@ struct HistoryAutonomyContentView: View {
 
     /// Thin buckets are MARKED, never hidden and never smoothed — and the
     /// marking is explained in words, because a fainter plane means nothing on
-    /// its own. Three signals, since a distinction is easy to lose inside a
-    /// smooth band: the plane itself, the edges bounding it, and the points.
+    /// its own.
+    ///
+    /// It has to say what p95 and p5 ARE in a thin bucket, not merely that the
+    /// bucket is thin: with two samples they are the longest and the shortest
+    /// run, and a reader who takes them for percentiles reads a two-run week as
+    /// a spread. SAME WORDING AS THE WEB's `autonomyThinNote`.
     private var thinNote: some View {
-        Text("\(duration.thinCount) of \(duration.buckets.count) buckets hold fewer than "
-             + "\(duration.sampleFloor) runs (fainter band, dashed edges, hollow points): there, p95 is "
-             + "that bucket's longest run and p5 its shortest — not percentiles.")
+        Text("\(duration.thinCount) of \(duration.buckets.count) "
+             + "bucket\(duration.buckets.count == 1 ? "" : "s") "
+             + "\(duration.thinCount == 1 ? "has" : "have") under \(duration.sampleFloor) "
+             + "run\(duration.sampleFloor == 1 ? "" : "s") (drawn fainter): p95 and p5 there are just "
+             + "the longest and shortest.")
             .font(.caption2)
             .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -211,31 +217,24 @@ struct HistoryAutonomyContentView: View {
     /// States when collection started, so an empty or short history is never
     /// read as "you did nothing" (#1905) — and, when any of the view was
     /// back-filled, says that too.
+    ///
+    /// TWO LINES, one of them conditional. The run census (`countingLine`) and
+    /// the three-sentence reconstruction paragraph were both deleted by #1905's
+    /// prose cut: the first was reassurance rather than a caveat, and the
+    /// second's count now hangs off the provenance line as four words.
     private var collectionProvenance: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp1) {
-            // What these figures counted (#1905 subagents). Above the
-            // provenance line because it qualifies every number in the section,
-            // where provenance qualifies where they came from — and because its
-            // `unknown` clause is why a panel's `at once` figure sometimes
-            // carries no split.
-            if let counting = AutonomyFormat.countingLine(data.kinds) {
-                Text(counting)
-            }
-            // …and which of them are floors rather than measurements (#1905
-            // recording). Same register, same reason: a lower bound rendered as
-            // a measurement is a wrong number with nothing on screen saying it
-            // is wrong. Silent when every run in view is finished and measured.
+            // Which of the figures are floors rather than measurements (#1905
+            // recording): a lower bound rendered as a measurement is a wrong
+            // number with nothing on screen saying it is wrong. Silent when
+            // nothing is running, which is most of the time.
             if let measurement = AutonomyFormat.measurementLine(data.measurementOrNone) {
                 Text(measurement)
             }
             Text(AutonomyFormat.provenance(earliest: data.earliestSpan,
                                            total: data.totalRecorded,
+                                           reconstructed: data.provenanceOrNone.reconstructed,
                                            timeZone: formatTimeZone))
-            if let note = AutonomyFormat.reconstructionNote(data.provenanceOrNone,
-                                                            inView: data.summary.runs,
-                                                            timeZone: formatTimeZone) {
-                Text(note)
-            }
         }
         .font(.caption2)
         .foregroundColor(.secondary)
@@ -961,10 +960,7 @@ enum AutonomyFormat {
     /// which is the exact failure this section keeps writing sentences to avoid.
     ///
     /// SAME WORDING AS THE WEB's AUTONOMY_CONCURRENCY_CAVEAT.
-    static let concurrencyCaveat =
-        "A parent is held working while its subagents run, so one agent with three subagents counts as "
-        + "four at once. Four things really were working — but not four independent agents. That is what "
-        + "the “N + M sub” split separates, and it is shown wherever every run at the peak said which it was."
+    static let concurrencyCaveat = "A parent counts as working while its subagents run."
 
     /// The stack's left bound, coarsening with the window the way the activity
     /// matrix's column headers do: a 30-day stack needs a date, a year-long one
@@ -994,7 +990,18 @@ enum AutonomyFormat {
 
     /// The provenance line. Says when collection started — the sentence that
     /// keeps an empty view from reading as "you did nothing".
-    static func provenance(earliest: Int64, total: Int, timeZone: TimeZone) -> String {
+    ///
+    /// THE RECONSTRUCTED SUFFIX IS THE LAST SURVIVOR of the three-sentence
+    /// reconstruction paragraph #1905's prose cut deleted.
+    /// `tools/autonomy-backfill` rebuilds pre-feature runs from logs a machine
+    /// already had, and a reconstructed figure rendered as a measured one is
+    /// exactly the "wrong number with nothing on screen saying so" this section
+    /// was built to prevent — so the count cannot go. It costs the reader it is
+    /// written for nothing: a machine that was never back-filled reports 0 and
+    /// the clause never appears. SAME WORDING AS THE WEB's
+    /// `autonomyProvenanceLine`.
+    static func provenance(earliest: Int64, total: Int, reconstructed: Int,
+                           timeZone: TimeZone) -> String {
         guard earliest > 0 else {
             return "No autonomous runs recorded yet. Irrlicht began measuring them with this update; "
                 + "the panels above fill in as sessions run."
@@ -1004,108 +1011,29 @@ enum AutonomyFormat {
         f.timeZone = timeZone
         f.dateFormat = "MMM d, yyyy"
         let since = f.string(from: Date(timeIntervalSince1970: TimeInterval(earliest)))
-        return "Collecting since \(since) · \(total) runs recorded."
-    }
-
-    /// States WHAT the figures counted (#1905 subagents, retargeted by #1905
-    /// recording). `nil` only for a payload from a daemon that predates the
-    /// census — absence there means "this response never said", which is not
-    /// the same claim as "there were none".
-    ///
-    /// THERE IS NO MODE. Every run counts, subagent runs included, because
-    /// Irrlicht recorded them — so no excluded count is reported and there is no
-    /// control whose position a reader has to remember. What the sentence still
-    /// does is describe the window's MAKEUP.
-    ///
-    /// THE UNKNOWN CLAUSE STAYS LOAD-BEARING, and now carries its consequence
-    /// for the concurrency figure: a row written before Irrlicht told the two
-    /// apart is counted like the rest, but a peak one of them was alive for
-    /// cannot be split, and the sentence says so rather than leaving a missing
-    /// split to read as a bug.
-    static func countingLine(_ k: HistoryAutonomyKinds?) -> String? {
-        guard let k else { return nil }
-        var out = k.subagent > 0
-            ? "Counting every run, including \(k.subagent) subagent run\(k.subagent == 1 ? "" : "s") "
-                + "— each of which happened inside its parent's run."
-            : "Counting every run, subagent runs included. This window holds none."
-        if k.unknown > 0 {
-            out += " \(k.unknown) run\(k.unknown == 1 ? " was" : "s were") recorded before Irrlicht told "
-                + "top-level and subagent runs apart, so which they were is unknown — those are counted "
-                + "either way, and a peak one of them was alive for is shown as a total with no split."
-        }
-        return out
+        let backfill = reconstructed > 0 ? " · \(reconstructed) in view reconstructed" : ""
+        return "Collecting since \(since) · \(total) run\(total == 1 ? "" : "s") recorded\(backfill)."
     }
 
     /// Marks the runs in view whose duration is a FLOOR rather than a
-    /// measurement (#1905 recording). `nil` when every run in view is finished
-    /// and fully measured — the quiet case on a machine whose daemon has been
-    /// up all day.
+    /// measurement (#1905 recording). `nil` when nothing is running — the quiet
+    /// case on a machine between sessions.
     ///
-    /// Two kinds, two sentences, because they are two different limits and a
-    /// reader who merged them would misread the panels in opposite directions:
+    /// A run that has not ended has no length yet, only how long it has lasted
+    /// SO FAR. That floor still COUNTS towards the longest (the section reports
+    /// a maximum, and "already lasted 3h" is true) and is deliberately not a
+    /// sample for the aggregate chart's percentiles, where a floor shortens the
+    /// longest runs hardest.
     ///
-    ///   - STILL RUNNING. The run has not ended, so its length is how long it
-    ///     has lasted SO FAR. It COUNTS towards the longest — the section
-    ///     reports a maximum, and "already lasted 3h" is true — and the panel
-    ///     that shows it says "still going" rather than presenting a floor as
-    ///     final.
-    ///   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its
-    ///     start is where the watching began. Dropping those is what left 5 of a
-    ///     day's 35 runs on the record.
+    /// THE SECOND SENTENCE WENT (#1905 prose cut). It named the runs already
+    /// going when Irrlicht started watching, whose start is a lower bound
+    /// rather than a beginning — a real limit, but a restart artefact a reader
+    /// can do nothing with, and the longest sentence in the section.
+    /// `measurement.start_lower_bound` stays on the wire; only the sentence
+    /// went. SAME WORDING AS THE WEB's `autonomyMeasurementNote`.
     static func measurementLine(_ m: HistoryAutonomyMeasurement) -> String? {
-        guard m.any else { return nil }
-        var parts: [String] = []
-        if m.running > 0 {
-            let one = m.running == 1
-            parts.append("\(m.running) run\(one ? " is" : "s are") still going: "
-                + "\(one ? "its length is" : "their lengths are") how long \(one ? "it has" : "they have") "
-                + "lasted SO FAR. \(one ? "It counts" : "They count") towards the longest run, marked "
-                + "\"still going\".")
-        }
-        if m.lowerBoundStart > 0 {
-            let one = m.lowerBoundStart == 1
-            parts.append("\(m.lowerBoundStart) run\(one ? "" : "s") already going when Irrlicht started "
-                + "watching — \(one ? "its" : "their") start is when it started watching, not when the run "
-                + "began, so \(one ? "that length is a minimum" : "those lengths are minimums").")
-        }
-        return parts.joined(separator: " ")
-    }
-
-    /// Marks a view that is showing back-filled history (#1905). `nil` when
-    /// every run in view was measured as it happened — which is every install
-    /// but the one `tools/autonomy-backfill` was run on, so a normal machine
-    /// says nothing at all here.
-    ///
-    /// Three facts, in the register the empty state already uses, because each
-    /// answers a question the reader would otherwise answer wrongly: HOW MANY
-    /// of the runs in view are reconstructed, the date BEFORE WHICH everything
-    /// is reconstructed, and whether any of it came from a source that cannot
-    /// say how a run ended.
-    static func reconstructionNote(_ p: HistoryAutonomyProvenance,
-                                   inView: Int,
-                                   timeZone: TimeZone) -> String? {
-        guard p.isReconstructed else { return nil }
-        let total = inView > 0 ? inView : p.reconstructed
-        var out = "\(p.reconstructed) of \(total) runs in view were reconstructed from logs this Mac "
-            + "already had, not measured as they happened. "
-        if p.liveSince > 0 {
-            let f = DateFormatter()
-            f.locale = Locale(identifier: "en_US_POSIX")
-            f.timeZone = timeZone
-            f.dateFormat = "MMM d, yyyy"
-            out += "Everything before \(f.string(from: Date(timeIntervalSince1970: TimeInterval(p.liveSince)))) "
-                + "is reconstructed."
-        } else {
-            // liveSince == 0 is "nothing has ever been measured live", which is
-            // a different claim from "measured since the epoch". Printing Jan 1
-            // 1970 would be a fabricated date — the exact failure this whole
-            // marking exists to prevent.
-            out += "Nothing here was measured live — every run on record is reconstructed."
-        }
-        if p.costDerived > 0 {
-            out += " \(p.costDerived) of them come from the cost log, which records when a session was "
-                + "working and never why it stopped, so their end reason is unknown — not assumed."
-        }
-        return out
+        guard m.running > 0 else { return nil }
+        let one = m.running == 1
+        return "\(m.running) run\(one ? "" : "s") still going — \(one ? "length" : "lengths") so far."
     }
 }

--- a/platforms/macos/Tests/HistoryAutonomyBackfillTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyBackfillTests.swift
@@ -6,6 +6,15 @@ import XCTest
 /// any other row, and this surface has to say so — a reconstructed figure
 /// rendered as a measured one is the wrong number with nothing on screen
 /// admitting it.
+///
+/// #1905's prose cut deleted the three-sentence reconstruction paragraph and
+/// kept its COUNT as a suffix on the provenance line that was already there.
+/// What had to survive is the claim, not the paragraph. Two of the paragraph's
+/// three facts moved rather than went: the boundary DATE is still on screen as
+/// the rule and caption the charts draw (pinned further down this file), and
+/// the cost-log sentence is the one that is simply gone — it explained why a
+/// run's END REASON was unknown, and #1919 deleted the run strip, which was the
+/// only thing that ever drew an end reason.
 final class HistoryAutonomyBackfillTests: XCTestCase {
 
     private let utc = TimeZone(identifier: "UTC")!
@@ -38,55 +47,68 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
         let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
         XCTAssertEqual(d.provenanceOrNone, .none)
         XCTAssertFalse(d.provenanceOrNone.isReconstructed)
-        XCTAssertNil(AutonomyFormat.reconstructionNote(d.provenanceOrNone, inView: 0, timeZone: utc))
+        XCTAssertFalse(AutonomyFormat.provenance(earliest: 1_755_000_000, total: 12,
+                                                 reconstructed: d.provenanceOrNone.reconstructed,
+                                                 timeZone: utc).contains("reconstructed"))
     }
 
-    // MARK: The note
+    // MARK: The surviving clause
 
-    func testNoNoteWhenEveryRunInViewWasMeasured() {
+    private func line(_ p: HistoryAutonomyProvenance, total: Int = 100) -> String {
+        AutonomyFormat.provenance(earliest: 1_755_000_000, total: total,
+                                  reconstructed: p.reconstructed, timeZone: utc)
+    }
+
+    /// The silent case is the one every install but the maintainer's own gets —
+    /// the reader this cut was made for. Here the clause costs them zero
+    /// characters, which is why it could be kept at all.
+    func testNoClauseWhenEveryRunInViewWasMeasured() {
         let p = HistoryAutonomyProvenance(reconstructed: 0, costDerived: 0, liveSince: 1_755_000_000)
-        XCTAssertNil(AutonomyFormat.reconstructionNote(p, inView: 100, timeZone: utc))
+        let out = line(p)
+        XCTAssertFalse(out.contains("reconstructed"), "got: \(out)")
+        XCTAssertTrue(out.contains("100 runs recorded"), "got: \(out)")
     }
 
-    func testNoteStatesHowManyAndTheBoundaryDate() throws {
-        // 1755000000 = 2025-08-12T12:00:00Z
+    func testTheClauseStatesHowManyOfTheRunsInViewAreReconstructed() {
         let p = HistoryAutonomyProvenance(reconstructed: 40, costDerived: 0, liveSince: 1_755_000_000)
-        let note = try XCTUnwrap(AutonomyFormat.reconstructionNote(p, inView: 100, timeZone: utc))
-        XCTAssertTrue(note.contains("40 of 100 runs in view"), "got: \(note)")
-        XCTAssertTrue(note.contains("not measured as they happened"), "got: \(note)")
-        XCTAssertTrue(note.contains("Everything before Aug 12, 2025 is reconstructed."), "got: \(note)")
-        XCTAssertFalse(note.contains("cost log"), "no cost-derived run is in range; the sentence must be absent")
+        let out = line(p)
+        // On the SAME line as the total it qualifies, not a second line below.
+        XCTAssertEqual(out, "Collecting since Aug 12, 2025 · 100 runs recorded · 40 in view reconstructed.")
     }
 
-    func testNoteNamesTheCostDerivedRunsAndCallsTheirReasonUnknown() throws {
+    /// The cost-log sentence is gone, and with it every word about a run's end
+    /// reason: #1919 removed the only thing that ever drew one.
+    func testNoCostLogOrEndReasonSentenceSurvives() {
         let p = HistoryAutonomyProvenance(reconstructed: 90, costDerived: 55, liveSince: 1_755_000_000)
-        let note = try XCTUnwrap(AutonomyFormat.reconstructionNote(p, inView: 120, timeZone: utc))
-        XCTAssertTrue(note.contains("55 of them come from the cost log"), "got: \(note)")
-        XCTAssertTrue(note.contains("unknown"), "got: \(note)")
-        XCTAssertTrue(note.contains("not assumed"), "got: \(note)")
+        let out = line(p, total: 120)
+        XCTAssertFalse(out.contains("cost log"), "got: \(out)")
+        XCTAssertFalse(out.contains("end reason"), "got: \(out)")
+        XCTAssertFalse(out.contains("not assumed"), "got: \(out)")
+        // …and the count itself still speaks: `costDerived` changes nothing.
+        XCTAssertTrue(out.contains("90 in view reconstructed"), "got: \(out)")
     }
 
-    /// `liveSince == 0` means "nothing has ever been measured live", which is a
-    /// different claim from "measured since the epoch". Printing Jan 1 1970
-    /// would be a fabricated date — exactly the failure this marking exists to
-    /// prevent.
-    func testNoteNeverPrintsAnEpochDate() throws {
+    /// `liveSince` is no longer formatted into this sentence at all, which is
+    /// the strongest possible form of "never prints an epoch date": there is no
+    /// date in the clause to get wrong.
+    func testTheClauseCarriesNoDateOfItsOwn() {
         let p = HistoryAutonomyProvenance(reconstructed: 40, costDerived: 40, liveSince: 0)
-        let note = try XCTUnwrap(AutonomyFormat.reconstructionNote(p, inView: 40, timeZone: utc))
-        XCTAssertTrue(note.contains("Nothing here was measured live"), "got: \(note)")
-        XCTAssertFalse(note.contains("1970"), "got: \(note)")
+        let out = line(p, total: 40)
+        XCTAssertTrue(out.contains("40 in view reconstructed"), "got: \(out)")
+        XCTAssertFalse(out.contains("1970"), "got: \(out)")
     }
 
-    /// The note takes its zone as an input (#1659), never `NSTimeZone.default`.
-    func testNoteHonoursTheCallersZone() throws {
+    /// The provenance line still takes its zone as an input (#1659), never
+    /// `NSTimeZone.default` — the date it names is the collection start.
+    func testTheLineHonoursTheCallersZone() {
         // 1755014400 = 2025-08-12T16:00:00Z — still Aug 12 in UTC, already
-        // Aug 13 in Tokyo (UTC+9). A date that reads the same in both zones
-        // would make this test pass against a formatter that ignored the
-        // parameter entirely.
-        let p = HistoryAutonomyProvenance(reconstructed: 1, costDerived: 0, liveSince: 1_755_014_400)
+        // Aug 13 in Tokyo (UTC+9). A date that read the same in both zones
+        // would make this pass against a formatter that ignored the parameter.
         let tokyo = TimeZone(identifier: "Asia/Tokyo")!
-        let inUTC = try XCTUnwrap(AutonomyFormat.reconstructionNote(p, inView: 1, timeZone: utc))
-        let inTokyo = try XCTUnwrap(AutonomyFormat.reconstructionNote(p, inView: 1, timeZone: tokyo))
+        let inUTC = AutonomyFormat.provenance(earliest: 1_755_014_400, total: 1,
+                                              reconstructed: 1, timeZone: utc)
+        let inTokyo = AutonomyFormat.provenance(earliest: 1_755_014_400, total: 1,
+                                                reconstructed: 1, timeZone: tokyo)
         XCTAssertTrue(inUTC.contains("Aug 12, 2025"), "got: \(inUTC)")
         XCTAssertTrue(inTokyo.contains("Aug 13, 2025"), "got: \(inTokyo)")
     }
@@ -101,13 +123,14 @@ final class HistoryAutonomyBackfillTests: XCTestCase {
         let allLive = HistoryAutonomyProvenance(reconstructed: 0, costDerived: 0, liveSince: 1_755_000_000)
         let backfilled = HistoryAutonomyProvenance(reconstructed: 5, costDerived: 2, liveSince: 1_755_000_000)
 
-        let alwaysSpeaks: (HistoryAutonomyProvenance) -> String? = { _ in "some runs here were reconstructed" }
-        let neverSpeaks: (HistoryAutonomyProvenance) -> String? = { _ in nil }
+        let alwaysSpeaks: (HistoryAutonomyProvenance) -> String = { _ in "some runs here were reconstructed" }
+        let neverSpeaks: (HistoryAutonomyProvenance) -> String = { _ in "" }
         XCTAssertEqual(alwaysSpeaks(allLive), alwaysSpeaks(backfilled))
         XCTAssertEqual(neverSpeaks(allLive), neverSpeaks(backfilled))
 
-        XCTAssertNil(AutonomyFormat.reconstructionNote(allLive, inView: 100, timeZone: utc))
-        XCTAssertNotNil(AutonomyFormat.reconstructionNote(backfilled, inView: 100, timeZone: utc))
+        XCTAssertNotEqual(line(allLive), line(backfilled))
+        XCTAssertFalse(line(allLive).contains("reconstructed"))
+        XCTAssertTrue(line(backfilled).contains("5 in view reconstructed"))
     }
 
     // MARK: Source boundaries across the panel stack (QA-2)

--- a/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyMeasurementTests.swift
@@ -4,18 +4,18 @@ import XCTest
 /// The panel's marking for runs whose duration is a FLOOR rather than a
 /// measurement (#1905 recording).
 ///
-/// Two kinds, and they are two different limits:
+/// A run that has not ended has no length yet — only how long it has lasted SO
+/// FAR. That floor COUNTS towards the longest run (the section reports a
+/// maximum, and "already lasted 3h" is true), the panel drawing it says "still
+/// going", and it is deliberately not a sample for the aggregate chart's
+/// percentiles.
 ///
-///   - STILL RUNNING — the run has not ended, so its length is how long it has
-///     lasted SO FAR. It COUNTS towards the longest run (the section reports a
-///     maximum, and "already lasted 3h" is true) and is marked "still going"
-///     rather than presented as final.
-///   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
-///     start is where Irrlicht began watching. Those ARE samples; dropping them
-///     is what left 5 of a day's 35 runs on the record.
-///
-/// A reader who conflated the two would misread the chart in opposite
-/// directions, which is why the sentence never merges them.
+/// THE SECOND SENTENCE WENT (#1905 prose cut). It named the runs already going
+/// when Irrlicht started watching, whose start is a lower bound rather than a
+/// beginning. That is a real limit, but it is a restart artefact a reader can
+/// do nothing with — and `start_lower_bound` still ships on the wire, so
+/// nothing about what the daemon measures changed. The tests that pinned that
+/// sentence are retargeted below onto the fact that it no longer speaks.
 final class HistoryAutonomyMeasurementTests: XCTestCase {
 
     // MARK: Decoding
@@ -66,71 +66,55 @@ final class HistoryAutonomyMeasurementTests: XCTestCase {
         HistoryAutonomyMeasurement(running: running, lowerBoundStart: lowerBound)
     }
 
-    /// The quiet case, and the one that must stay quiet: a machine whose daemon
-    /// has been up all day, every run in view finished and fully measured.
-    func testSaysNothingWhenEveryRunIsFinishedAndMeasured() {
+    /// The quiet case, and the one that must stay quiet: a machine between
+    /// sessions, with nothing running.
+    func testSaysNothingWhenNoRunIsStillGoing() {
         XCTAssertNil(AutonomyFormat.measurementLine(measurement()))
     }
 
-    /// A running run COUNTS towards the longest and is MARKED, and the
-    /// sentence has to say both — otherwise a reader who can see "longest 3h"
-    /// beside a project is left unsure whether that figure is finished.
-    func testARunningRunIsNamedAsGoingAndAsCounted() throws {
+    /// A running run's figure is a floor, and the sentence has to say so —
+    /// otherwise a reader who can see "longest 3h" beside a project is left
+    /// unsure whether that figure is finished.
+    /// SAME WORDING AS THE WEB's `autonomyMeasurementNote`.
+    func testARunningRunIsNamedAndItsLengthCalledASoFar() throws {
         let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 1)))
-        XCTAssertTrue(line.contains("1 run is still going"), line)
-        XCTAssertTrue(line.contains("SO FAR"), line)
-        XCTAssertTrue(line.contains("counts towards the longest run"), line)
-        // The percentile-era wording must be gone with the percentiles: a
-        // sentence claiming an exclusion that no longer happens is an alibi for
-        // a wrong number.
-        XCTAssertFalse(line.contains("percentile"), line)
+        XCTAssertEqual(line, "1 run still going — length so far.")
     }
 
-    func testAnUnmeasuredStartSaysWhichEndIsTheEstimate() throws {
-        let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 4)))
-        XCTAssertTrue(line.contains("4 runs already going when Irrlicht started watching"), line)
-        XCTAssertTrue(line.contains("not when the run began"), line)
-        XCTAssertTrue(line.contains("minimums"), line)
-        // It must NOT claim those runs were dropped from the figures: they are
-        // finished runs, and they are samples.
-        XCTAssertFalse(line.contains("left out of the percentiles"), line)
-    }
-
-    func testBothAtOnceReadAsTwoSeparateFacts() throws {
-        let line = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 2, lowerBound: 3)))
-        XCTAssertTrue(line.contains("2 runs are still going"), line)
-        XCTAssertTrue(line.contains("3 runs already going when Irrlicht started watching"), line)
+    /// `start_lower_bound` still arrives; it just no longer produces prose. A
+    /// payload carrying ONLY that is silent, and one carrying both says exactly
+    /// what the running-only payload says — which is the check that would fail
+    /// if half the old sentence survived.
+    func testTheLowerBoundSentenceIsGoneAndTakesNoOtherLineWithIt() throws {
+        XCTAssertNil(AutonomyFormat.measurementLine(measurement(lowerBound: 4)))
+        XCTAssertEqual(AutonomyFormat.measurementLine(measurement(running: 2, lowerBound: 3)),
+                       AutonomyFormat.measurementLine(measurement(running: 2)))
+        let both = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 2, lowerBound: 3)))
+        XCTAssertFalse(both.contains("minimum"), both)
+        XCTAssertFalse(both.contains("watching"), both)
     }
 
     func testSingularAndPluralBothReadAsEnglish() throws {
         let one = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 1)))
-        XCTAssertTrue(one.contains("1 run is still going"), one)
+        XCTAssertEqual(one, "1 run still going — length so far.")
         let two = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(running: 2)))
-        XCTAssertTrue(two.contains("2 runs are still going"), two)
-        let oneBound = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 1)))
-        XCTAssertTrue(oneBound.contains("that length is a minimum"), oneBound)
-        let twoBound = try XCTUnwrap(AutonomyFormat.measurementLine(measurement(lowerBound: 2)))
-        XCTAssertTrue(twoBound.contains("those lengths are minimums"), twoBound)
+        XCTAssertEqual(two, "2 runs still going — lengths so far.")
     }
 
     /// COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get this
     /// wrong, and each passes at least one assertion above on its own.
-    func testProductionTellsTheTwoLimitsApartAndBothFromSilence() {
+    func testProductionTellsARunningWindowFromAStillOneAndCountsIt() {
         let running = measurement(running: 3)
-        let bounded = measurement(lowerBound: 3)
+        let one = measurement(running: 1)
         let clean = measurement()
 
-        // Merged: a run still going and a run whose start was guessed read
-        // identically, so the reader cannot tell which figure to distrust.
-        let merged: (HistoryAutonomyMeasurement) -> String = {
-            "\($0.running + $0.lowerBoundStart) runs are approximate."
-        }
-        XCTAssertEqual(merged(running), merged(bounded))
-        XCTAssertNotEqual(AutonomyFormat.measurementLine(running),
-                          AutonomyFormat.measurementLine(bounded))
+        // Count-blind: one long-running session reads exactly like a fleet.
+        let countBlind: (HistoryAutonomyMeasurement) -> String = { _ in "Some runs are still going." }
+        XCTAssertEqual(countBlind(running), countBlind(one))
+        XCTAssertNotEqual(AutonomyFormat.measurementLine(running), AutonomyFormat.measurementLine(one))
 
-        // Never-silent: a fully measured window carries a caveat it does not
-        // need, and the caveat stops meaning anything.
+        // Never-silent: a window with nothing running carries a caveat it does
+        // not need, and the caveat stops meaning anything.
         let always: (HistoryAutonomyMeasurement) -> String = { _ in "Some runs are approximate." }
         XCTAssertEqual(always(clean), always(running))
         XCTAssertNil(AutonomyFormat.measurementLine(clean))

--- a/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomySubagentTests.swift
@@ -6,9 +6,16 @@ import XCTest
 ///
 /// The maintainer's decision: every run counts, subagent runs included, because
 /// Irrlicht recorded them. So there is no mode, no picker and no excluded
-/// count. The classification survives on every row — a subagent's run is still
-/// identifiable, and still attributable to the run that contains it — and the
-/// panel still describes a window's MAKEUP.
+/// count. The classification survives on every row and on the wire — a
+/// subagent's run is still identifiable, and still attributable to the run that
+/// contains it.
+///
+/// THE SENTENCE THAT REPORTED THE CENSUS IS GONE (#1905 prose cut). "Counting
+/// every run, including 259 subagent runs" is reassurance rather than a caveat,
+/// and its `unknown` clause described legacy rows a machine installing Irrlicht
+/// today will never hold. What a reader still needs from the nesting is the one
+/// place it changes how a NUMBER reads — the concurrency figure — and that is
+/// the caveat beside it, pinned below and in HistoryAutonomyTests.
 final class HistoryAutonomySubagentTests: XCTestCase {
 
     // MARK: Decoding
@@ -51,74 +58,44 @@ final class HistoryAutonomySubagentTests: XCTestCase {
                        "a peak an unclassified run was alive for must show the total alone, never a guess")
     }
 
-    // MARK: The sentence
+    // MARK: What survives of the sentence
 
-    private func kinds(topLevel: Int = 10,
-                       subagent: Int = 0,
-                       unknown: Int = 0) -> HistoryAutonomyKinds {
-        HistoryAutonomyKinds(topLevel: topLevel, subagent: subagent, unknown: unknown)
+    /// The census sentence is gone. The one consequence of nesting that changes
+    /// how a figure READS stays, because the `at once` number is otherwise
+    /// taken for a count of independent agents: a parent is held `working`
+    /// while its subagents run, so one agent with three subagents overlaps as
+    /// four. SAME WORDING AS THE WEB's AUTONOMY_CONCURRENCY_CAVEAT.
+    func testTheCaveatIsWhatSurvivesOfTheNestingProse() {
+        let caveat = AutonomyFormat.concurrencyCaveat
+        XCTAssertTrue(caveat.contains("parent"), caveat)
+        XCTAssertTrue(caveat.contains("subagents"), caveat)
+        XCTAssertTrue(caveat.contains("working"), caveat)
+        // The census wording itself must NOT be back: it is the paragraph the
+        // cut removed, and a sentence reporting a count is not a caveat.
+        XCTAssertFalse(caveat.contains("subagent run"), caveat)
+        XCTAssertFalse(caveat.contains("Counting every run"), caveat)
+        XCTAssertFalse(caveat.contains("unknown"), caveat)
     }
 
-    func testAWindowWithNoSubagentRunsSaysSo() throws {
-        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds()))
-        XCTAssertTrue(line.contains("Counting every run"), line)
-        XCTAssertTrue(line.contains("holds none"), line)
-    }
-
-    /// The word that has to be GONE. Nothing is excluded any more, and a
-    /// sentence still claiming so would describe a filter that no longer exists.
-    func testItSaysHowManyRunsWereSubagentsAndExcludesNothing() throws {
-        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 37)))
-        XCTAssertTrue(line.contains("37 subagent runs"), line)
-        XCTAssertTrue(line.contains("inside its parent"), line)
-        XCTAssertFalse(line.contains("excluded"), line)
-    }
-
-    func testSingularAndPluralBothReadAsEnglish() throws {
-        let one = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 1)))
-        XCTAssertTrue(one.contains("1 subagent run —"), one)
-        let two = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 2)))
-        XCTAssertTrue(two.contains("2 subagent runs —"), two)
-    }
-
-    /// THE TRAP THIS CLAUSE EXISTS FOR. A row written before Irrlicht told the
-    /// two apart carries no classification. It is counted like the rest — and
-    /// counting it in SILENCE would let the panel imply a classification nobody
-    /// made.
-    func testUnknownKindRunsAreNamed() throws {
-        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 3, unknown: 8148)))
-        XCTAssertTrue(line.contains("8148 runs were recorded before Irrlicht told"), line)
-        XCTAssertTrue(line.contains("counted either way"), line)
-        // …and the clause now carries its consequence for the concurrency
-        // figure: a peak one of those runs was alive for cannot be split.
-        XCTAssertTrue(line.contains("no split"), line)
-    }
-
-    func testAWindowWithNoUnknownRunsSaysNothingAboutThem() throws {
-        let line = try XCTUnwrap(AutonomyFormat.countingLine(kinds(subagent: 3)))
-        XCTAssertFalse(line.contains("unknown"), line)
-    }
-
-    /// COMMITTED IN-LANGUAGE MUTANTS, the idiom this suite already uses. Each
-    /// is a plausible way to get the sentence wrong and each passes at least one
-    /// assertion above on its own, so production has to be shown to tell the
-    /// fixtures apart rather than merely to produce a string.
-    func testProductionTellsTheCensusCasesApart() throws {
-        let withSubs = kinds(subagent: 5, unknown: 9)
-        let noSubs = kinds(subagent: 0, unknown: 9)
-        let noUnknown = kinds(subagent: 5, unknown: 0)
-
-        // Subagent-blind: a window full of nested runs reads exactly like one
-        // with none.
-        let subBlind: (HistoryAutonomyKinds) -> String = { _ in "Counting every run." }
-        XCTAssertEqual(subBlind(withSubs), subBlind(noSubs))
-        XCTAssertNotEqual(AutonomyFormat.countingLine(withSubs), AutonomyFormat.countingLine(noSubs))
-
-        // Unknown-blind: the silent classification.
-        let unknownBlind: (HistoryAutonomyKinds) -> String = {
-            "Counting every run, including \($0.subagent)."
-        }
-        XCTAssertEqual(unknownBlind(withSubs), unknownBlind(noUnknown))
-        XCTAssertNotEqual(AutonomyFormat.countingLine(withSubs), AutonomyFormat.countingLine(noUnknown))
+    /// The classification is still DECODED and still drives the split beside
+    /// the peak (`testKindsDecode` and the panel test above) — what went is only
+    /// the prose. This pins that the two facts are independent: kinds arrive,
+    /// and no sentence reports them.
+    func testKindsStillArriveWithNoSentenceReportingThem() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_projects","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1],"panels":[],"panel_limit":5,"more_projects":0,
+         "summary":{"longest":0,"runs":15,"projects":1},
+         "earliest_span":1700000000,"total_recorded":15,
+         "kinds":{"top_level":7,"subagent":5,"unknown":3}}
+        """
+        let d = try JSONDecoder().decode(HistoryAutonomyProjectsResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(d.kinds?.subagent, 5)
+        // The provenance block below the charts names the total and the
+        // back-fill, and says nothing about the census.
+        let line = AutonomyFormat.provenance(earliest: d.earliestSpan, total: d.totalRecorded,
+                                             reconstructed: 0, timeZone: TimeZone(identifier: "UTC")!)
+        XCTAssertTrue(line.contains("15 runs recorded"), line)
+        XCTAssertFalse(line.contains("subagent"), line)
     }
 }

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -272,11 +272,16 @@ final class HistoryAutonomyTests: XCTestCase {
 
     /// The number is otherwise misread: a parent is held `working` while its
     /// subagents run, so one agent with three subagents reads as four at once.
-    func testTheCaveatSaysWhatTheNumberIsNot() {
+    /// The caveat has to name all three of those — the parent, the subagents,
+    /// and the state the parent is held in — or it never says why the figure is
+    /// bigger than the number of agents. #1905's prose cut took the "not four
+    /// independent agents" gloss with the paragraph it lived in; the mechanism
+    /// is the part a reader needs, and it is what is asserted here.
+    func testTheCaveatNamesWhatMakesTheNumberOverlap() {
         let caveat = AutonomyFormat.concurrencyCaveat
         XCTAssertTrue(caveat.contains("parent"), "got: \(caveat)")
         XCTAssertTrue(caveat.contains("subagents"), "got: \(caveat)")
-        XCTAssertTrue(caveat.contains("not four independent agents"), "got: \(caveat)")
+        XCTAssertTrue(caveat.contains("working"), "got: \(caveat)")
     }
 
     // MARK: A panel states its own two figures
@@ -528,11 +533,18 @@ final class HistoryAutonomyTests: XCTestCase {
     }
 
     func testProvenanceLineSaysWhenCollectionStarted() {
-        let empty = AutonomyFormat.provenance(earliest: 0, total: 0, timeZone: utc)
+        let empty = AutonomyFormat.provenance(earliest: 0, total: 0, reconstructed: 0, timeZone: utc)
         XCTAssertTrue(empty.contains("began measuring"), "got: \(empty)")
-        let seeded = AutonomyFormat.provenance(earliest: 1_755_000_000, total: 312, timeZone: utc)
+        let seeded = AutonomyFormat.provenance(earliest: 1_755_000_000, total: 312,
+                                               reconstructed: 0, timeZone: utc)
         XCTAssertTrue(seeded.contains("Collecting since Aug 12, 2025"), "got: \(seeded)")
         XCTAssertTrue(seeded.contains("312 runs recorded"), "got: \(seeded)")
+    }
+
+    func testOneRecordedRunIsSingular() {
+        let one = AutonomyFormat.provenance(earliest: 1_755_000_000, total: 1,
+                                            reconstructed: 0, timeZone: utc)
+        XCTAssertTrue(one.contains("1 run recorded"), "got: \(one)")
     }
 
     // MARK: Fixtures

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -801,9 +801,8 @@ export function autonomyDuration(seconds) {
   return h === 0 ? d + 'd' : d + 'd' + h + 'h';
 }
 
-// autonomyDateLabel formats a day for the two provenance sentences below. One
-// helper, so "collecting since <date>" and "everything before <date>" can
-// never render the same instant two different ways.
+// autonomyDateLabel formats the day the provenance line names. A helper of its
+// own so a caller can never render the same instant two different ways.
 function autonomyDateLabel(ts) {
   return new Date((Number(ts) || 0) * 1000)
     .toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
@@ -811,7 +810,18 @@ function autonomyDateLabel(ts) {
 
 // autonomyProvenanceLine states when collection started, so an empty or short
 // history is never read as "you did nothing" (#1905). This sentence is part of
-// the feature, not decoration.
+// the feature, not decoration — which is why it is the one line here that is
+// always drawn.
+//
+// THE RECONSTRUCTED SUFFIX IS THE LAST SURVIVOR of a three-sentence paragraph
+// (#1905 prose cut). `tools/autonomy-backfill` rebuilds pre-feature runs from
+// logs a machine already had, and a reconstructed figure rendered as a measured
+// one is exactly the "wrong number with nothing on screen saying so" this
+// section was built to prevent — so the count cannot go. What it costs the
+// reader it is written for is nothing: a machine that was never back-filled
+// sends `reconstructed: 0` and the clause never appears at all. Four words is
+// the smallest thing that still says it, and it hangs off the line that was
+// already there rather than earning a line of its own.
 export function autonomyProvenanceLine(data) {
   const earliest = Number(data?.earliest_span) || 0;
   const total = Number(data?.total_recorded) || 0;
@@ -819,94 +829,24 @@ export function autonomyProvenanceLine(data) {
     return 'No autonomous runs recorded yet. Irrlicht began measuring them with this update — '
       + 'an empty chart means "nothing recorded", not "nothing happened".';
   }
-  return 'Collecting since ' + autonomyDateLabel(earliest) + ' · ' + total + ' runs recorded.';
-}
-
-// autonomyReconstructionNote marks a view that is showing back-filled history
-// (#1905). '' when every run in view was measured as it happened, so a normal
-// install — which is every install but the one the back-fill was run on — says
-// nothing at all.
-//
-// Three facts, in the register the empty state already uses, because each
-// answers a question the reader would otherwise answer wrongly:
-//
-//   - HOW MANY of the runs in view are reconstructed, so the figures above can
-//     be weighed;
-//   - the date BEFORE WHICH everything is reconstructed, which is the boundary
-//     between a measured trend and a rebuilt one;
-//   - whether any of it came from a source that cannot say how a run ended, so
-//     a missing concurrency split reads as a limit of the source rather than as
-//     a bug.
-export function autonomyReconstructionNote(data) {
-  const p = data?.provenance || {};
-  const reconstructed = Number(p.reconstructed) || 0;
-  if (reconstructed <= 0) return '';
-  const inView = Number(data?.summary?.runs) || reconstructed;
-  const costDerived = Number(p.cost_derived) || 0;
-  const liveSince = Number(p.live_since) || 0;
-  const parts = [
-    reconstructed + ' of ' + inView + ' runs in view were reconstructed from logs this machine already had, '
-      + 'not measured as they happened.',
-    liveSince
-      ? 'Everything before ' + autonomyDateLabel(liveSince) + ' is reconstructed.'
-      : 'Nothing here was measured live — every run on record is reconstructed.',
-  ];
-  if (costDerived > 0) {
-    parts.push(costDerived + ' of them come from the cost log, which records when a session was working and '
-      + 'never why it stopped, so their end reason is unknown — not assumed.');
-  }
-  return parts.join(' ');
-}
-
-// autonomyCountingLine states, in words, WHAT the figures above it counted
-// (#1905 subagents, retargeted by #1905 recording).
-//
-// THERE IS NO MODE. Every run counts, subagent runs included, because Irrlicht
-// recorded them — so the sentence no longer reports an excluded count, and
-// there is no control whose position a reader has to remember. What it still
-// does is describe the window's MAKEUP, because "42 runs" reads differently
-// once you know how many of them were nested inside another — and because the
-// same nesting is what the concurrency figure's caveat is about.
-//
-// THE UNKNOWN CLAUSE STAYS LOAD-BEARING. A row written before Irrlicht told the
-// two apart carries no classification, and such a row is counted like the rest
-// — but counting it silently would let the panel imply a classification nobody
-// made, and it is also the reason a panel's `at once` figure sometimes carries
-// no split. So the sentence says how many.
-//
-// '' only for a payload that carries no census at all, which is a daemon older
-// than the field: absence there means "this response never said", which is not
-// the same claim as "there were none".
-export function autonomyCountingLine(payload) {
-  const k = payload?.kinds;
-  if (!k) return '';
-  const sub = Number(k.subagent) || 0;
-  const unknown = Number(k.unknown) || 0;
-  const parts = [sub > 0
-    ? 'Counting every run, including ' + sub + ' subagent run' + (sub === 1 ? '' : 's')
-      + ' — each of which happened inside its parent’s run.'
-    : 'Counting every run, subagent runs included. This window holds none.'];
-  if (unknown > 0) {
-    parts.push(unknown + ' run' + (unknown === 1 ? ' was' : 's were') + ' recorded before Irrlicht told '
-      + 'top-level and subagent runs apart, so which they were is unknown — those are counted either way, '
-      + 'and a peak one of them was alive for is shown as a total with no split.');
-  }
-  return parts.join(' ');
+  const reconstructed = Number(data?.provenance?.reconstructed) || 0;
+  return 'Collecting since ' + autonomyDateLabel(earliest)
+    + ' · ' + total + ' run' + (total === 1 ? '' : 's') + ' recorded'
+    + (reconstructed > 0 ? ' · ' + reconstructed + ' in view reconstructed' : '')
+    + '.';
 }
 
 // AUTONOMY_CONCURRENCY_CAVEAT is the sentence beside the `at once` figure, and
-// it is not optional: without it the number is read as "four independent
-// agents" and it is not that.
+// it is not optional: without it the number is read as "N independent agents"
+// and it is not that.
 //
 // The daemon deliberately holds a PARENT session in `working` while its
 // subagents run, so one agent with three subagents overlaps as four. Four things
 // really were working — the figure is not wrong — but a reader who takes it for
 // four independent agents has been misled by a true number, which is the exact
-// failure mode this section keeps writing sentences to avoid.
+// failure mode this sentence exists to prevent.
 export const AUTONOMY_CONCURRENCY_CAVEAT =
-  'A parent is held working while its subagents run, so one agent with three subagents counts as four at '
-  + 'once. Four things really were working — but not four independent agents. That is what the '
-  + '“N + M sub” split separates, and it is shown wherever every run at the peak said which it was.';
+  'A parent counts as working while its subagents run.';
 
 // AUTONOMY_ERA_LABELS describes what lies to the LEFT of a source boundary —
 // the era the data before the line came from, and at what resolution.
@@ -1205,53 +1145,42 @@ export function autonomyAxisLabel(ts, windowSeconds) {
 }
 
 // autonomyMeasurementNote marks the runs in view whose duration is a FLOOR
-// rather than a measurement (#1905 recording). '' when every run in view is
-// finished and fully measured, which is the quiet case on a machine whose
-// daemon has been up all day.
+// rather than a measurement (#1905 recording). '' when nothing is running,
+// which is the quiet case on a machine between sessions.
 //
-// Two kinds, two sentences, because they are two different limits and a reader
-// who conflated them would misread the section in opposite directions:
+// A run that has not ended has no length yet — only how long it has lasted SO
+// FAR. That floor still COUNTS towards the panel's longest (that figure is a
+// maximum, and "already lasted 3h" is true), and is deliberately not a sample
+// for the aggregate chart's percentiles, where a floor shortens the longest
+// runs hardest. Both halves are in the four words after the dash.
 //
-//   - STILL RUNNING. The run has not ended, so its length is how long it has
-//     lasted SO FAR. It COUNTS towards the panel's longest — that figure is a
-//     maximum, and "already lasted 3h" is true — and is deliberately NOT a
-//     sample for the aggregate chart's percentiles, where a floor always
-//     shortens and shortens the longest runs hardest.
-//   - STARTED BEFORE IRRLICHT WAS WATCHING. The run has finished, but its start
-//     is where Irrlicht began watching rather than where the run began; a
-//     restart re-discovers every live session this way. Dropping those is what
-//     left 5 of a day's 35 runs on the record.
+// THE SECOND SENTENCE WENT (#1905 prose cut). It named the runs already going
+// when Irrlicht started watching, whose start is a lower bound rather than a
+// beginning. That is a real limit, but it is a restart artefact a reader can do
+// nothing with, and it was the longest sentence in the section.
+// `measurement.start_lower_bound` stays on the wire; only the sentence went.
 export function autonomyMeasurementNote(payload) {
-  const m = payload?.measurement || {};
-  const running = Number(m.running) || 0;
-  const lowerBound = Number(m.start_lower_bound) || 0;
-  const parts = [];
-  if (running > 0) {
-    parts.push(running + ' run' + (running === 1 ? ' is' : 's are') + ' still going: '
-      + (running === 1 ? 'its length is' : 'their lengths are') + ' how long '
-      + (running === 1 ? 'it has' : 'they have') + ' lasted SO FAR. '
-      + (running === 1 ? 'It counts' : 'They count') + ' towards the longest run, marked "still going", '
-      + 'and ' + (running === 1 ? 'is' : 'are') + ' left out of the percentiles above.');
-  }
-  if (lowerBound > 0) {
-    parts.push(lowerBound + ' run' + (lowerBound === 1 ? '' : 's') + ' already going when Irrlicht '
-      + 'started watching — ' + (lowerBound === 1 ? 'its' : 'their') + ' start is when it started '
-      + 'watching, not when the run began, so ' + (lowerBound === 1 ? 'that length is a' : 'those lengths are')
-      + ' minimum' + (lowerBound === 1 ? '' : 's') + '.');
-  }
-  return parts.join(' ');
+  const running = Number(payload?.measurement?.running) || 0;
+  if (running <= 0) return '';
+  return running + ' run' + (running === 1 ? '' : 's') + ' still going — '
+    + (running === 1 ? 'length' : 'lengths') + ' so far.';
 }
 
 // autonomyThinNote explains the aggregate chart's thin-bucket marking, in
 // words, because a fainter plane means nothing on its own. '' when every bucket
 // in view clears the floor.
+//
+// It has to say what p95 and p5 ARE in a thin bucket, not merely that the
+// bucket is thin: with two samples they are the longest and the shortest run,
+// and a reader who takes them for percentiles reads a two-run week as a spread.
 export function autonomyThinNote(duration) {
   const buckets = duration?.buckets || [];
   const thin = buckets.filter(b => b?.thin).length;
   if (thin <= 0) return '';
-  return thin + ' of ' + buckets.length + ' buckets hold fewer than ' + (Number(duration?.sample_floor) || 0)
-    + ' runs (fainter band, dashed edges, hollow points): there p95 is that bucket’s longest run and '
-    + 'p5 its shortest — not percentiles.';
+  const floor = Number(duration?.sample_floor) || 0;
+  return thin + ' of ' + buckets.length + ' bucket' + (buckets.length === 1 ? '' : 's')
+    + (thin === 1 ? ' has' : ' have') + ' under ' + floor + ' run' + (floor === 1 ? '' : 's')
+    + ' (drawn fainter): p95 and p5 there are just the longest and shortest.';
 }
 
 // The side panel's key: FOUR entries, because the section draws four marks —
@@ -2242,22 +2171,16 @@ function renderAutonomySidePanel() {
     const thin = autonomyThinNote(duration);
     if (thin) appendHistoryEmpty(listEl, thin);
   }
-  // What these figures counted (#1905 subagents). Above the provenance line
-  // because it qualifies every number in the panel, where provenance qualifies
-  // where they came from.
-  const countingLine = autonomyCountingLine(projects);
-  if (countingLine) appendHistoryEmpty(listEl, countingLine);
-  // …and which of them are floors rather than measurements (#1905 recording).
+  // Which of the figures are floors rather than measurements (#1905 recording).
+  // Silent when nothing is running, which is most of the time.
   const measurement = autonomyMeasurementNote(projects);
   if (measurement) appendHistoryEmpty(listEl, measurement);
   // The provenance line is part of the feature: "no data" must never read as
-  // "you did nothing".
+  // "you did nothing" — and it carries the back-fill count, so a reconstructed
+  // figure is never rendered as a measured one. Always drawn; the two lines it
+  // replaced (the run census and the reconstruction paragraph) are gone (#1905
+  // prose cut).
   appendHistoryEmpty(listEl, autonomyProvenanceLine(projects));
-  // …and a back-filled view says so, for the same reason: a reconstructed
-  // figure rendered as a measured one is the wrong number with nothing on
-  // screen saying it is wrong. Silent when nothing in view was reconstructed.
-  const reconstruction = autonomyReconstructionNote(projects);
-  if (reconstruction) appendHistoryEmpty(listEl, reconstruction);
 }
 
 // --- Activity matrix (chart=state, issue #981) ---

--- a/platforms/web/irrlicht.history.autonomy.backfill.test.js
+++ b/platforms/web/irrlicht.history.autonomy.backfill.test.js
@@ -4,7 +4,7 @@ import {
   autonomyMoreProjectsLabel,
   autonomyPanelChoice,
   autonomyProjectOptions,
-  autonomyReconstructionNote,
+  autonomyProvenanceLine,
   autonomyVisibleBoundaries,
 } from './historyTab.js'
 import { readFileSync } from 'node:fs'
@@ -26,61 +26,51 @@ const durationWith = (provenance, count = 100) => ({
   provenance,
 })
 
-describe('autonomyReconstructionNote — the panel marks a back-filled view', () => {
-  // The silent case is the one every other install gets. A note about nothing
-  // would train people to skip the one that matters.
-  test('says nothing when every run in view was measured', () => {
-    expect(autonomyReconstructionNote(durationWith({ reconstructed: 0, cost_derived: 0, live_since: 1_700_000_000 })))
-      .toBe('')
+describe('the provenance line marks a back-filled view', () => {
+  // #1905's prose cut deleted the three-sentence reconstruction paragraph and
+  // kept its count as a suffix on the line that was already there. What had to
+  // survive is the CLAIM, not the paragraph: a machine whose figures were
+  // rebuilt from old logs must not read as one that measured them.
+  //
+  // Two of the paragraph's three facts moved rather than went. The boundary
+  // DATE is still on screen — it is the rule and caption the charts draw, which
+  // `autonomyBoundaryLabel` and `autonomyVisibleBoundaries` below still pin.
+  // The cost-log sentence is the one that is simply gone: it explained why a
+  // run's END REASON was unknown, and #1919 deleted the run strip, which was the
+  // only thing that ever drew an end reason.
+
+  // The silent case is the one every other install gets — the reader this cut
+  // was made for. A caveat about nothing would train people to skip the one
+  // that matters, and here it costs that reader zero characters.
+  test('says nothing about reconstruction when every run in view was measured', () => {
+    const line = autonomyProvenanceLine(
+      durationWith({ reconstructed: 0, cost_derived: 0, live_since: 1_700_000_000 }))
+    expect(line).not.toContain('reconstructed')
+    expect(line).toContain('100 runs recorded')
   })
 
-  test('says nothing when the payload carries no provenance at all', () => {
+  test('says nothing about reconstruction when the payload carries no provenance at all', () => {
     // An older daemon, or a client reading a response it did not expect.
-    expect(autonomyReconstructionNote({ summary: { runs: 12 } })).toBe('')
-    expect(autonomyReconstructionNote(null)).toBe('')
-    expect(autonomyReconstructionNote(undefined)).toBe('')
+    expect(autonomyProvenanceLine({ earliest_span: 1_700_000_000, total_recorded: 12 }))
+      .not.toContain('reconstructed')
   })
 
   test('states how many of the runs in view are reconstructed', () => {
-    const note = autonomyReconstructionNote(
+    const line = autonomyProvenanceLine(
       durationWith({ reconstructed: 40, cost_derived: 0, live_since: 1_755_000_000 }, 100))
-    expect(note).toContain('40 of 100 runs in view')
-    expect(note).toContain('not measured as they happened')
+    expect(line).toContain('40 in view reconstructed')
+    // …on the SAME line as the total it qualifies, not a second line below it.
+    expect(line).toContain('100 runs recorded · 40 in view reconstructed.')
+    expect(line.split('\n')).toHaveLength(1)
   })
 
-  test('states the date before which everything is reconstructed', () => {
-    const liveSince = 1_755_000_000
-    const note = autonomyReconstructionNote(durationWith({ reconstructed: 40, cost_derived: 0, live_since: liveSince }))
-    const label = new Date(liveSince * 1000)
-      .toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-    expect(note).toContain('Everything before ' + label + ' is reconstructed.')
-  })
-
-  // live_since 0 is "nothing has ever been measured live", which is a
-  // different claim from "measured since the epoch" — and printing Jan 1 1970
-  // would be a fabricated date, which is the exact failure mode this whole
-  // change exists to avoid.
-  test('never prints an epoch date when nothing was measured live', () => {
-    const note = autonomyReconstructionNote(durationWith({ reconstructed: 40, cost_derived: 0, live_since: 0 }))
-    expect(note).toContain('Nothing here was measured live')
-    expect(note).not.toContain('1970')
-  })
-
-  // The honesty rule for the cost era, in words: those runs' end reason is
-  // unknown, and the note says it is not assumed.
-  test('names the cost-derived runs and calls their end reason unknown', () => {
-    const note = autonomyReconstructionNote(
-      durationWith({ reconstructed: 90, cost_derived: 55, live_since: 1_755_000_000 }))
-    expect(note).toContain('55 of them come from the cost log')
-    expect(note).toContain('unknown')
-    expect(note).toContain('not assumed')
-  })
-
-  test('leaves the cost sentence out when no cost-derived run is in range', () => {
-    const note = autonomyReconstructionNote(
-      durationWith({ reconstructed: 40, cost_derived: 0, live_since: 1_755_000_000 }))
-    expect(note).not.toContain('cost log')
-    expect(note).toContain('40 of 100 runs in view')
+  // liveSince is no longer formatted into this sentence at all, which is the
+  // strongest possible form of "never prints an epoch date": there is no date
+  // in the clause to get wrong.
+  test('the reconstruction clause carries no date of its own', () => {
+    const line = autonomyProvenanceLine(durationWith({ reconstructed: 40, cost_derived: 40, live_since: 0 }))
+    expect(line).toContain('40 in view reconstructed')
+    expect(line).not.toContain('1970')
   })
 
   // The committed mutation for this check, in the idiom this suite already
@@ -99,9 +89,9 @@ describe('autonomyReconstructionNote — the panel marks a back-filled view', ()
     expect(alwaysSpeaks(allLive)).toBe(alwaysSpeaks(backfilled))
     expect(neverSpeaks(allLive)).toBe(neverSpeaks(backfilled))
 
-    expect(autonomyReconstructionNote(allLive)).not.toBe(autonomyReconstructionNote(backfilled))
-    expect(autonomyReconstructionNote(allLive)).toBe('')
-    expect(autonomyReconstructionNote(backfilled)).not.toBe('')
+    expect(autonomyProvenanceLine(allLive)).not.toBe(autonomyProvenanceLine(backfilled))
+    expect(autonomyProvenanceLine(allLive)).not.toContain('reconstructed')
+    expect(autonomyProvenanceLine(backfilled)).toContain('5 in view reconstructed')
   })
 })
 
@@ -144,6 +134,21 @@ describe('the run strip is gone from the shipped files, and the band is back', (
     expect(section).not.toContain('Math.log')
     expect(section).not.toContain('Math.exp')
     expect(section).toContain('autonomyLinearY')
+  })
+
+  // The prose #1905's cut deleted, checked out of the file for the same reason
+  // the strip's identifiers are: a helper that still parses is the one a later
+  // reader wires back up by accident, and these two produced four of the five
+  // paragraphs the cut was made to remove.
+  test('the deleted prose helpers are gone, not merely unwired', () => {
+    for (const gone of ['autonomyCountingLine', 'autonomyReconstructionNote']) {
+      expect(js).not.toContain(gone)
+    }
+    // …and the surviving four lines are all still generated somewhere.
+    for (const kept of ['AUTONOMY_CONCURRENCY_CAVEAT', 'autonomyThinNote',
+      'autonomyMeasurementNote', 'autonomyProvenanceLine']) {
+      expect(js).toContain(kept)
+    }
   })
 
   test('no run strip, end-reason colours, glyphs or legend survive', () => {

--- a/platforms/web/irrlicht.history.autonomy.measurement.test.js
+++ b/platforms/web/irrlicht.history.autonomy.measurement.test.js
@@ -5,86 +5,70 @@ import { autonomyMeasurementNote } from './historyTab.js'
 // The panel's marking for runs whose duration is a FLOOR rather than a
 // measurement (#1905 recording).
 //
-// Two kinds, and they are two different limits:
+// A run that has not ended has no length yet — only how long it has lasted SO
+// FAR. That floor COUNTS towards the panel's longest run (the section reports a
+// maximum, and "already lasted 3h" is true) and is deliberately NOT a sample
+// for the aggregate chart's percentiles, where a floor shortens the longest
+// runs hardest.
 //
-//   - STILL RUNNING — the run has not ended, so its length is how long it has
-//     lasted SO FAR. It COUNTS towards the longest run (the section reports a
-//     maximum, and "already lasted 3h" is true) and is marked "still going"
-//     rather than presented as final.
-//   - STARTED BEFORE IRRLICHT WAS WATCHING — the run has finished, but its
-//     start is where Irrlicht began watching. Those ARE samples; dropping them
-//     is what left 5 of a day's 35 runs on the record.
-//
-// A reader who conflated the two would misread the chart in opposite
-// directions, which is why the sentence never merges them.
+// THE SECOND SENTENCE WENT (#1905 prose cut). It named the runs already going
+// when Irrlicht started watching, whose start is a lower bound rather than a
+// beginning. That is a real limit, but it is a restart artefact a reader can do
+// nothing with — and `start_lower_bound` still ships on the wire, so nothing
+// about what the daemon measures changed. The tests that pinned that sentence
+// are retargeted below onto the fact that it no longer speaks.
 
 const payload = (measurement) => ({ measurement })
 
 describe('autonomyMeasurementNote', () => {
-  // The quiet case, and the one that must stay quiet: a machine whose daemon
-  // has been up all day, with every run in view finished and fully measured.
-  test('says nothing when every run in view is finished and measured', () => {
+  // The quiet case, and the one that must stay quiet: a machine between
+  // sessions, with nothing running.
+  test('says nothing when no run is still going', () => {
     expect(autonomyMeasurementNote(payload({ running: 0, start_lower_bound: 0 }))).toBe('')
     expect(autonomyMeasurementNote({})).toBe('')
     expect(autonomyMeasurementNote(null)).toBe('')
     expect(autonomyMeasurementNote(undefined)).toBe('')
   })
 
-  // A running run COUNTS towards the longest and is MARKED, and the sentence
-  // has to say both — otherwise a reader who can see "longest 3h" beside a
-  // project is left unsure whether that figure is finished.
-  test('a running run is named as still going AND as counted', () => {
+  // A running run's figure is a floor, and the sentence has to say so —
+  // otherwise a reader who can see "longest 3h" beside a project is left unsure
+  // whether that figure is finished.
+  test('a running run is named, and its length called a so-far', () => {
     const line = autonomyMeasurementNote(payload({ running: 1 }))
-    expect(line).toContain('1 run is still going')
-    expect(line).toContain('SO FAR')
-    expect(line).toContain('counts towards the longest run')
-    expect(line).toContain('still going')
-    // BOTH halves of the asymmetry, because the section now draws both figures
-    // (#1905 restore): a running run IS the panel's longest, and is NOT a
-    // sample for the aggregate chart's percentiles. A sentence that named only
-    // one of the two would be an alibi for whichever number the reader was
-    // looking at.
-    expect(line).toContain('left out of the percentiles')
+    expect(line).toBe('1 run still going — length so far.')
   })
 
-  test('an unmeasured start says which end of the run is the estimate', () => {
-    const line = autonomyMeasurementNote(payload({ start_lower_bound: 4 }))
-    expect(line).toContain('4 runs already going when Irrlicht started watching')
-    expect(line).toContain('not when the run began')
-    expect(line).toContain('minimums')
-    // It must NOT claim those runs were dropped from the figures: they are
-    // finished runs and they are counted.
-    expect(line).not.toContain('counts towards the longest run')
-  })
-
-  test('both at once read as two separate facts', () => {
-    const line = autonomyMeasurementNote(payload({ running: 2, start_lower_bound: 3 }))
-    expect(line).toContain('2 runs are still going')
-    expect(line).toContain('3 runs already going when Irrlicht started watching')
+  test('the lower-bound sentence is gone, and takes no other line with it', () => {
+    // `start_lower_bound` still arrives; it just no longer produces prose. A
+    // payload carrying ONLY that is silent, and one carrying both says exactly
+    // what the running-only payload says — which is the check that would fail
+    // if half the old sentence survived.
+    expect(autonomyMeasurementNote(payload({ start_lower_bound: 4 }))).toBe('')
+    expect(autonomyMeasurementNote(payload({ running: 2, start_lower_bound: 3 })))
+      .toBe(autonomyMeasurementNote(payload({ running: 2 })))
+    const both = autonomyMeasurementNote(payload({ running: 2, start_lower_bound: 3 }))
+    expect(both).not.toContain('minimum')
+    expect(both).not.toContain('watching')
   })
 
   test('singular and plural both read as English', () => {
-    expect(autonomyMeasurementNote(payload({ running: 1 }))).toContain('1 run is still going')
-    expect(autonomyMeasurementNote(payload({ running: 2 }))).toContain('2 runs are still going')
-    expect(autonomyMeasurementNote(payload({ start_lower_bound: 1 }))).toContain('that length is a minimum')
-    expect(autonomyMeasurementNote(payload({ start_lower_bound: 2 }))).toContain('those lengths are minimums')
+    expect(autonomyMeasurementNote(payload({ running: 1 }))).toBe('1 run still going — length so far.')
+    expect(autonomyMeasurementNote(payload({ running: 2 }))).toBe('2 runs still going — lengths so far.')
   })
 
   // COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get this wrong,
   // and each passes at least one assertion above on its own.
-  test('production tells the two limits apart, and both from silence', () => {
+  test('production tells a running window from a still one, and counts it', () => {
     const running = payload({ running: 3 })
-    const bounded = payload({ start_lower_bound: 3 })
     const clean = payload({ running: 0, start_lower_bound: 0 })
 
-    // A mutant that merges the two into one count: a run still going and a run
-    // whose start was guessed read identically, so the reader cannot tell which
-    // figure to distrust.
-    const merged = (p) => `${(p.measurement.running || 0) + (p.measurement.start_lower_bound || 0)} runs are approximate.`
-    expect(merged(running)).toBe(merged(bounded))
-    expect(autonomyMeasurementNote(running)).not.toBe(autonomyMeasurementNote(bounded))
+    // A mutant blind to HOW MANY are running: one long-running session reads
+    // exactly like a fleet of them.
+    const countBlind = () => 'Some runs are still going.'
+    expect(countBlind(running)).toBe(countBlind(payload({ running: 1 })))
+    expect(autonomyMeasurementNote(running)).not.toBe(autonomyMeasurementNote(payload({ running: 1 })))
 
-    // A mutant that never falls silent: a fully measured window carries a
+    // A mutant that never falls silent: a window with nothing running carries a
     // caveat it does not need, and the caveat stops meaning anything.
     const always = () => 'Some runs are approximate.'
     expect(always(clean)).toBe(always(running))

--- a/platforms/web/irrlicht.history.autonomy.subagents.test.js
+++ b/platforms/web/irrlicht.history.autonomy.subagents.test.js
@@ -3,23 +3,26 @@ import { join } from 'node:path'
 import { describe, test, expect } from 'vitest'
 
 import { WEB_DIR } from './shippedFiles.testutil.js'
-import { autonomyCountingLine, autonomyQuery } from './historyTab.js'
+import { AUTONOMY_CONCURRENCY_CAVEAT, autonomyQuery } from './historyTab.js'
 
 // What the Autonomy section counts (#1905 subagents), retargeted at the FIELD
 // after the control was removed (#1905 recording).
 //
 // The maintainer's decision: every run counts, subagent runs included, because
 // Irrlicht recorded them. So there is no mode, no control, and no excluded
-// count. The classification survives on every row, and the panel still
-// describes a window's MAKEUP — "42 runs" reads differently once you know how
-// many of them were nested inside another.
+// count. The classification survives on every row and on the wire.
+//
+// THE SENTENCE THAT REPORTED THE CENSUS IS GONE (#1905 prose cut). "Every run
+// counts, including 259 subagent runs" is reassurance rather than a caveat, and
+// its `unknown` clause described legacy rows a machine installing Irrlicht
+// today will never hold. What a reader still needs from the nesting is the one
+// place it changes how a NUMBER reads — the concurrency figure — and that is
+// the caveat beside it, pinned below.
 
 const state = (over = {}) => ({
   autonomyRange: '30d',
   ...over,
 })
-
-const kinds = (over = {}) => ({ top_level: 10, subagent: 0, unknown: 0, ...over })
 
 describe('autonomyQuery — no run-scope parameter reaches the daemon', () => {
   // Sending the old parameter would leave an OLD daemon serving a filtered
@@ -82,72 +85,30 @@ describe('the Runs control is gone from the markup and the wiring', () => {
   })
 })
 
-describe('autonomyCountingLine — the panel states what it counted', () => {
-  test('says nothing when the payload carries no census', () => {
-    // An older daemon. Absence is "this response never said", which is not the
-    // same claim as "there were none".
-    expect(autonomyCountingLine({})).toBe('')
-    expect(autonomyCountingLine(null)).toBe('')
-    expect(autonomyCountingLine(undefined)).toBe('')
+describe('what a reader still needs from the nesting is the concurrency caveat', () => {
+  // The census sentence is gone. The one consequence of nesting that changes
+  // how a figure READS stays, because the `at once` number is otherwise taken
+  // for a count of independent agents: a parent is held `working` while its
+  // subagents run, so one agent with three subagents overlaps as four.
+  test('the caveat names the parent, the subagents and the state', () => {
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/parent/i)
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/subagents/i)
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/working/i)
   })
 
-  test('a window with no subagent runs says so', () => {
-    const line = autonomyCountingLine({ kinds: kinds() })
-    expect(line).toContain('Counting every run')
-    expect(line).toContain('holds none')
-  })
-
-  test('it says how many of the runs were subagents', () => {
-    const line = autonomyCountingLine({ kinds: kinds({ subagent: 37 }) })
-    expect(line).toContain('37 subagent runs')
-    expect(line).toContain('inside its parent')
-    // The word that has to be gone: nothing is excluded any more, and a
-    // sentence still claiming so would describe a filter that no longer exists.
-    expect(line).not.toContain('excluded')
-  })
-
-  test('singular and plural both read as English', () => {
-    expect(autonomyCountingLine({ kinds: kinds({ subagent: 1 }) })).toContain('1 subagent run —')
-    expect(autonomyCountingLine({ kinds: kinds({ subagent: 2 }) })).toContain('2 subagent runs —')
-  })
-
-  // THE TRAP THIS CLAUSE EXISTS FOR. A row written before Irrlicht told the two
-  // apart carries no classification. It is counted like the rest — and counting
-  // it in SILENCE would let the panel imply a classification nobody made.
-  test('unknown-kind runs are named', () => {
-    const line = autonomyCountingLine({ kinds: kinds({ subagent: 3, unknown: 8148 }) })
-    expect(line).toContain('8148 runs were recorded before Irrlicht told')
-    expect(line).toContain('counted either way')
-    // …and the clause now carries its consequence for the concurrency figure:
-    // a peak one of those runs was alive for cannot be split.
-    expect(line).toContain('no split')
-  })
-
-  test('a window with no unknown runs says nothing about them', () => {
-    expect(autonomyCountingLine({ kinds: kinds({ subagent: 3 }) })).not.toContain('unknown')
-  })
-
-  test('one unknown run reads as singular', () => {
-    expect(autonomyCountingLine({ kinds: kinds({ unknown: 1 }) })).toContain('1 run was recorded before')
-  })
-
-  // COMMITTED IN-LANGUAGE MUTANTS. Each is a plausible way to get the sentence
-  // wrong and each passes at least one assertion above on its own, so the suite
-  // has to be shown to tell them apart from production.
-  test('production tells the census cases apart', () => {
-    const withSubs = { kinds: kinds({ subagent: 5, unknown: 9 }) }
-    const noSubs = { kinds: kinds({ subagent: 0, unknown: 9 }) }
-    const noUnknown = { kinds: kinds({ subagent: 5, unknown: 0 }) }
-
-    // A mutant blind to the subagent count: a window full of nested runs reads
-    // exactly like one with none.
-    const subBlind = () => 'Counting every run.'
-    expect(subBlind(withSubs)).toBe(subBlind(noSubs))
-    expect(autonomyCountingLine(withSubs)).not.toBe(autonomyCountingLine(noSubs))
-
-    // A mutant that drops the unknown clause: the silent classification.
-    const unknownBlind = (p) => `Counting every run, including ${p.kinds.subagent}.`
-    expect(unknownBlind(withSubs)).toBe(unknownBlind(noUnknown))
-    expect(autonomyCountingLine(withSubs)).not.toBe(autonomyCountingLine(noUnknown))
+  // The committed mutation: the census sentence back in the shipped file under
+  // any name. A helper that still parses is the one a later reader wires back
+  // up, so it is checked out of the file rather than merely left uncalled.
+  test('no census sentence survives in the shipped file', () => {
+    const js = readFileSync(join(WEB_DIR, 'historyTab.js'), 'utf8')
+    expect(js).toContain('AUTONOMY_CONCURRENCY_CAVEAT') // the file was actually read
+    expect(js).not.toContain('autonomyCountingLine')
+    // Fragments only ever emitted as PROSE, so a code comment restating the
+    // decision ("the section counts every run, subagent runs included") does
+    // not trip this — only the sentence itself coming back would.
+    for (const gone of ['This window holds none', 'top/sub split',
+      'happened inside its parent', 'recorded before Irrlicht told']) {
+      expect(js).not.toContain(gone)
+    }
   })
 })

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -33,6 +33,7 @@ import {
   autonomyVisibleBoundaries,
   autonomyDuration,
   autonomyProvenanceLine,
+  autonomyThinNote,
   autonomyAxisLabel,
   autonomyKeyColor,
   autonomyKeyEntries,
@@ -263,12 +264,17 @@ describe('the concurrency figure, and the split it may not invent', () => {
     expect(autonomyConcurrencyLabel(0, 0, 0, true)).toBe('')
   })
 
-  test('the caveat is on screen, and says what the number is not', () => {
+  test('the caveat is on screen, and names what makes the number overlap', () => {
     // The number is otherwise misread: a parent is held `working` while its
     // subagents run, so one agent with three subagents reads as four at once.
+    // The caveat has to name all three of those — the parent, the subagents,
+    // and the state the parent is held in — or it never says why the figure is
+    // bigger than the number of agents. #1905's prose cut took the "not four
+    // independent agents" gloss away with the paragraph it lived in; what is
+    // asserted here is the mechanism, which is the part a reader needs.
     expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/parent/i)
     expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/subagents/i)
-    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/not four independent agents/i)
+    expect(AUTONOMY_CONCURRENCY_CAVEAT).toMatch(/working/i)
   })
 })
 
@@ -382,6 +388,45 @@ describe('the window vocabulary stays distinct from chart=state’s', () => {
   })
 })
 
+describe('a thin bucket is marked, and the marking is explained in words', () => {
+  // A fainter plane means nothing on its own, and the note has to say what p95
+  // and p5 ARE in a thin bucket rather than only that the bucket is thin: with
+  // two samples they are the longest and the shortest run, and a reader who
+  // takes them for percentiles reads a two-run week as a spread.
+  const withThin = (thinCount, total, floor = 5) => ({
+    sample_floor: floor,
+    buckets: Array.from({ length: total }, (_, i) => ({ ts: i, thin: i < thinCount })),
+  })
+
+  test('says nothing when every bucket in view clears the floor', () => {
+    expect(autonomyThinNote(withThin(0, 12))).toBe('')
+    expect(autonomyThinNote({ buckets: [] })).toBe('')
+    expect(autonomyThinNote(null)).toBe('')
+    expect(autonomyThinNote(undefined)).toBe('')
+  })
+
+  test('names the count, the total, the floor, and what the two marks become', () => {
+    expect(autonomyThinNote(withThin(3, 12)))
+      .toBe('3 of 12 buckets have under 5 runs (drawn fainter): '
+        + 'p95 and p5 there are just the longest and shortest.')
+  })
+
+  test('singular and plural both read as English', () => {
+    expect(autonomyThinNote(withThin(1, 12))).toContain('1 of 12 buckets has under 5 runs')
+    expect(autonomyThinNote(withThin(1, 1))).toContain('1 of 1 bucket has under 5 runs')
+    expect(autonomyThinNote(withThin(1, 4, 1))).toContain('under 1 run (')
+  })
+
+  // The committed mutation: a note that always speaks. It passes "explains the
+  // marking" and fails the thing that matters, which is that a chart with no
+  // thin bucket carries no caveat at all.
+  test('production tells a thin window from a dense one', () => {
+    const always = () => 'some buckets here are thin'
+    expect(always(withThin(0, 12))).toBe(always(withThin(3, 12)))
+    expect(autonomyThinNote(withThin(0, 12))).not.toBe(autonomyThinNote(withThin(3, 12)))
+  })
+})
+
 describe('“no data” never reads as “you did nothing”', () => {
   test('an empty log says collection just started', () => {
     const line = autonomyProvenanceLine({ earliest_span: 0, total_recorded: 0 })
@@ -393,6 +438,11 @@ describe('“no data” never reads as “you did nothing”', () => {
     const line = autonomyProvenanceLine({ earliest_span: 1_700_000_000, total_recorded: 312 })
     expect(line).toMatch(/Collecting since/)
     expect(line).toMatch(/312 runs recorded/)
+  })
+
+  test('one recorded run is singular', () => {
+    expect(autonomyProvenanceLine({ earliest_span: 1_700_000_000, total_recorded: 1 }))
+      .toMatch(/1 run recorded/)
   })
 })
 


### PR DESCRIPTION
The maintainer, on the Autonomy section: *"simplify the descriptions
underneath the charts — only generally useful and on point infos"*, then
*"think about a user that has no back-fill. what is really relevant for
this user. delete the rest."*

Five paragraphs became four lines, and only two of them are always on
screen.

## What the section says now

| when | line |
|---|---|
| always | `A parent counts as working while its subagents run.` |
| a bucket is thin | `<n> of <m> buckets have under <f> runs (drawn fainter): p95 and p5 there are just the longest and shortest.` |
| something is running | `<n> runs still going — lengths so far.` |
| always | `Collecting since <date> · <n> runs recorded` + ` · <n> in view reconstructed` when there is a back-fill |

Rendered from this machine's live 30d payload (`/api/v1/history`), read
back out of the DOM in Chrome at `127.0.0.1:7837`:

```
A parent counts as working while its subagents run.
3 of 28 buckets have under 20 runs (drawn fainter): p95 and p5 there are just the longest and shortest.
1 run still going — length so far.
Collecting since 18. Apr. 2026 · 10015 runs recorded · 2640 in view reconstructed.
```

| machine | before | after |
|---|---|---|
| with a back-fill (this one) | 263 words, 6 lines | **51 words, 4 lines** |
| without a back-fill | 208 words, 5 lines | **46 words, 4 lines** |
| without, nothing running, no thin bucket | 152 words, 3 lines | **18 words, 2 lines** |

Counts are `node` over the shipped `historyTab.js` (before: the same
file at `origin/main`) against the same captured payload, with
`provenance` / `measurement` / `thin` zeroed for the hypothetical rows —
not typed by hand.

## What was deleted

- **`autonomyCountingLine` / `AutonomyFormat.countingLine`** — every
  word. "Every run counts, including 269 subagent runs" is reassurance,
  not a caveat, and line 1 already tells a reader subagents are in the
  figures. Its `unknown` / "no top/sub split" clause described legacy
  rows a machine installing Irrlicht today will never hold.
- **The lower-bound half of the measurement note.** A run whose start is
  where Irrlicht began watching is a real limit, but it is a restart
  artefact a reader can do nothing with — and it was the longest
  sentence in the section.
- **`autonomyReconstructionNote` / `AutonomyFormat.reconstructionNote`**
  — the whole three-sentence paragraph, including the cost-log sentence
  about a run's end reason. **That sentence's subject no longer exists on
  screen**: #1919 deleted the run strip, which was the only thing that
  ever drew an end reason. Verified before removing it — `git grep` for a
  live (non-comment) `reason` read across `platforms/web/*.js` and
  `platforms/macos/Irrlicht/**/*.swift` returns only `permissionsWizard`
  / `BannerStrip` / `DaemonHealth` (permission and daemon errors,
  unrelated) and the two sentences being deleted. The only remaining
  autonomy hit is a doc comment on `HistoryAutonomyProvenance.costDerived`.

## Why four words of that paragraph stayed

` · <n> in view reconstructed` is the one judgement call here. A machine
with no back-fill sends `reconstructed: 0` and the clause renders as
nothing at all, so it costs the reader this cut was made for exactly
zero characters. On a back-filled machine — the maintainer's own —
dropping it entirely would show reconstructed figures as measured ones
with nothing on screen saying so, which is the failure the whole section
was built to prevent. It is a suffix on the line that was already there,
not a line of its own.

The boundary **date** did not go with it: the source-boundary rule and
its `← cost log · 60s resolution` caption still mark where the
reconstructed era ends, on the charts themselves.

## For the maintainer to decide later, not changed here

Three wire fields now ship with nothing rendering them:

- `kinds` — `top_level` / `subagent` / `unknown`. Still **decoded**, and
  `unknown` still drives whether a concurrency peak shows its `N + M sub`
  split, so the field is not dead — only the sentence reporting the
  census is.
- `measurement.start_lower_bound` — nothing reads it on either client now.
- `provenance.cost_derived` — likewise.

The span `Reason` field is untouched in the domain, the store and the
wire; only the sentence about it went.

## Verification

`tools/preflight.sh --only web` / `--only swift` / `--only go` /
`--only tools`, each a separate foreground run — all PASS
(`state-vocabulary lint` included: 1233 files scanned, 48 waived sites,
none new).

**Tests are retargeted, not deleted.** Where a test asserted a *fact*
rather than a string, the assertion moved to whichever line now carries
it: the caveat still has to name the parent, the subagents and
`working`; the back-fill count is still stated and still on one line
with the total; the "production tells the two fixtures apart" committed
mutants still run in both suites. Four mutations were **run red before
the green** (each restored afterwards):

| mutation | caught by |
|---|---|
| thin note loses its `has`/`have` agreement | `singular and plural both read as English` |
| provenance line always speaks about reconstruction | 3 tests in the back-fill suite |
| the lower-bound sentence comes back | `the lower-bound sentence is gone, and takes no other line with it` |
| the caveat drops the state that makes the number overlap | 2 tests, both surfaces' web twin |

Two new guards are checked out of the shipped file rather than merely
left uncalled, in the idiom the run-strip removal already uses: the two
deleted helper names, and the four sentence fragments that only ever
appeared as prose (a code *comment* restating the counting decision
deliberately does not trip them).

### One note on the cross-surface check

The web/macOS parity test that reads the Swift source
(`the two surfaces name the key the same way`, `autonomyLayout.test.js`)
compares the four **key labels**, which this change does not touch — it
still passes and still compares four real strings. There is no automated
parity check over the *prose*; the four surviving strings are kept in
step by `SAME WORDING AS THE WEB's …` doc comments on each macOS twin
plus per-surface tests asserting the same literals, which is the
convention this file already used. Worth knowing that the thin note is
the weakest of the four — it is inline in the SwiftUI view rather than
in `AutonomyFormat`, so it has no macOS-side unit test at all. Say the
word and I'll lift it into `AutonomyFormat` and pin it.

Closes nothing on its own — this is the prose half of #1905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
