### PR TITLE
feat(onboard): apply a cell's settings under the Desktop profile

### DIFF
--- a/replaydata/agents/claudecode/driver-desktop.sh
+++ b/replaydata/agents/claudecode/driver-desktop.sh
@@ -40,6 +40,10 @@ DRIVE_SLASH_REQUIRES_STEP_TYPE=true
 
 STAGING="$1"
 TIMEOUT_S="$3"
+# Argument 4 is the cell settings blob. It was accepted and DROPPED until
+# #1888 follow-up: Desktop takes no --settings launch flag, so the Go driver
+# writes it into the workspace as .claude/settings.json instead.
+SETTINGS_PATH="$4"
 DRIVER_INPUT="$5"
 DRIVER_LOG="$STAGING/driver.log"
 PROMPT_FILE="$STAGING/desktop-prompt.txt"
@@ -71,6 +75,7 @@ set +e
   --repo-root "$IRRLICHT_REPO_ROOT" \
   --staging "$STAGING" \
   --workspace "$STAGING/cwd" \
+  --settings "$SETTINGS_PATH" \
   "${INPUT_FLAG[@]}" \
   --helper "$IRRLICHT_DESKTOP_HELPER_BIN" \
   --daemon-address "$IRRLICHT_BIND_ADDR" \

--- a/tools/onboarding-factory/cmd/desktop-driver/main.go
+++ b/tools/onboarding-factory/cmd/desktop-driver/main.go
@@ -24,6 +24,7 @@ type options struct {
 	repoRoot        string
 	staging         string
 	workspace       string
+	settingsFile    string
 	promptFile      string
 	scriptFile      string
 	helper          string
@@ -91,12 +92,17 @@ func run(ctx context.Context, args []string) error {
 // driveRequest reads whichever input form was given. Exactly one of them is
 // accepted, so a caller that passes both never silently gets one of them.
 func driveRequest(options options) (desktopdriver.RunRequest, error) {
+	settings, err := readWorkspaceSettings(options.settingsFile)
+	if err != nil {
+		return desktopdriver.RunRequest{}, err
+	}
 	request := desktopdriver.RunRequest{
-		Workspace:      options.workspace,
-		EvidenceDir:    filepath.Join(options.staging, "desktop-evidence"),
-		OverallTimeout: options.timeout,
-		StepTimeout:    min(options.timeout/3, 90*time.Second),
-		CleanupTimeout: 45 * time.Second,
+		Workspace:         options.workspace,
+		WorkspaceSettings: settings,
+		EvidenceDir:       filepath.Join(options.staging, "desktop-evidence"),
+		OverallTimeout:    options.timeout,
+		StepTimeout:       min(options.timeout/3, 90*time.Second),
+		CleanupTimeout:    45 * time.Second,
 	}
 	if options.scriptFile != "" {
 		steps, err := readRecipe(options.scriptFile)
@@ -176,6 +182,7 @@ func parseOptions(args []string) (options, error) {
 	flags.StringVar(&value.repoRoot, "repo-root", "", "absolute repository root")
 	flags.StringVar(&value.staging, "staging", "", "absolute staging directory")
 	flags.StringVar(&value.workspace, "workspace", "", "absolute staging workspace")
+	flags.StringVar(&value.settingsFile, "settings", "", "cell settings blob written into the workspace")
 	flags.StringVar(&value.promptFile, "prompt-file", "", "prompt file under staging")
 	flags.StringVar(&value.scriptFile, "script-file", "", "recipe script JSON file under staging")
 	flags.StringVar(&value.helper, "helper", "", "absolute helper executable")
@@ -352,4 +359,22 @@ func userHome() string {
 		return ""
 	}
 	return home
+}
+
+// readWorkspaceSettings reads the cell's settings blob. run-cell.sh writes this
+// file for EVERY cell — the four-byte literal `null` when the cell declares no
+// settings — so a missing path and an absent block are both ordinary, and only
+// an unreadable existing file is an error.
+func readWorkspaceSettings(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read settings file: %w", err)
+	}
+	return data, nil
 }

--- a/tools/onboarding-factory/internal/desktopdriver/driver.go
+++ b/tools/onboarding-factory/internal/desktopdriver/driver.go
@@ -1,9 +1,13 @@
 package desktopdriver
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -71,6 +75,10 @@ type Baseline struct {
 
 type RunRequest struct {
 	Workspace string
+	// WorkspaceSettings is the cell's `settings` block, written into the
+	// workspace as .claude/settings.json before Desktop is pointed at it.
+	// Empty means the cell declared none.
+	WorkspaceSettings []byte
 	// Prompt drives the one-turn form. Exactly one of Prompt and Script is set.
 	Prompt string
 	// Script drives the recipe form. Its grammar is recipe.go's.
@@ -156,6 +164,12 @@ func Run(ctx context.Context, runtime Runtime, request RunRequest) (result RunRe
 	// the cell asked for. A bare prompt keeps the no-tool safety boundary.
 	if teller, ok := runtime.(interface{ ExpectTools(bool) }); ok {
 		teller.ExpectTools(len(request.Script) > 0)
+	}
+	// Before anything opens the workspace. Claude Code reads project settings
+	// when the session starts, so a write after the deep link is the same as
+	// no write at all.
+	if err := writeWorkspaceSettings(request); err != nil {
+		return result, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, request.OverallTimeout)
 	defer cancel()
@@ -604,6 +618,47 @@ func runStep(
 				name, timeout, step.Err(), err)
 		}
 		return fmt.Errorf("wait for %s: %w", name, err)
+	}
+	return nil
+}
+
+// writeWorkspaceSettings puts the cell's `settings` block into the run's own
+// workspace as .claude/settings.json.
+//
+// This is the Desktop equivalent of the CLI driver's `claude --settings
+// <path>`. Desktop launches its own session and takes no such flag, but it
+// DOES read project-scoped settings — measured live on 2026-09-06: a
+// PreToolUse hook placed this way fired, and permissions.defaultMode "plan"
+// held a turn back from writing a file it was explicitly told to write.
+//
+// The write is confined to the workspace the run created and throws away. It
+// never touches ~/.claude/settings.json, which the Desktop profile depends on
+// for its hook wiring and which desktop_profile_validate_cell still refuses to
+// let a cell modify.
+//
+// An empty block is ABSENT, not empty: run-cell.sh produces the four-byte
+// literal `null` for a cell that declares no settings, and writing that would
+// hand Claude Code a project config the cell never asked for. A block that is
+// not a JSON object is an authoring error and stops the run, because handing
+// it over unread would surface as an unexplained session failure instead.
+func writeWorkspaceSettings(request RunRequest) error {
+	blob := bytes.TrimSpace(request.WorkspaceSettings)
+	if len(blob) == 0 || string(blob) == "null" {
+		return nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(blob, &fields); err != nil {
+		return fmt.Errorf("cell settings are not a JSON object: %w", err)
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	dir := filepath.Join(request.Workspace, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create the workspace .claude directory: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), blob, 0o644); err != nil {
+		return fmt.Errorf("write the workspace settings: %w", err)
 	}
 	return nil
 }

--- a/tools/onboarding-factory/internal/desktopdriver/driver_settings_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/driver_settings_test.go
@@ -1,0 +1,124 @@
+package desktopdriver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A cell's `settings` block reaches the CLI driver as `claude --settings
+// <path>`, a LAUNCH FLAG. Claude Desktop launches its own session and takes no
+// such flag, so the equivalent is a settings file inside the run's own
+// throwaway workspace.
+//
+// Measured live on 2026-09-06 before this existed, driving the real app with a
+// hand-placed workspace file:
+//
+//	{"hooks":{"PreToolUse":[{"matcher":"Bash",...}]}}   → the hook FIRED
+//	{"permissions":{"defaultMode":"plan"}}              → the turn refused to
+//	                                                      write, 7x ExitPlanMode
+//
+// So Desktop honours workspace-scoped settings. What it did NOT have was any
+// way for the harness to put them there: driver-desktop.sh has accepted a
+// <settings-path> argument since it was written and never used it, which is
+// why desktop_profile_validate_cell had to refuse the whole class — without
+// the refusal a cell would have run WITHOUT its settings and reported a pass.
+
+// settingsProbe records whether the workspace settings file existed at the
+// moment Desktop was pointed at the workspace. Writing it after the deep link
+// would be indistinguishable from not writing it at all, because Claude Code
+// reads project settings when the session starts.
+type settingsProbe struct {
+	fakeRuntime
+	settingsPath   string
+	existedAtOpen  bool
+	checkedAtOpen  bool
+	contentsAtOpen string
+}
+
+func (runtime *settingsProbe) OpenComposer(ctx context.Context, workspace string) error {
+	runtime.checkedAtOpen = true
+	if data, err := os.ReadFile(runtime.settingsPath); err == nil {
+		runtime.existedAtOpen = true
+		runtime.contentsAtOpen = string(data)
+	}
+	return runtime.fakeRuntime.OpenComposer(ctx, workspace)
+}
+
+func settingsRequest(t *testing.T, settings string) (RunRequest, string) {
+	t.Helper()
+	workspace := t.TempDir()
+	request := validRunRequest()
+	request.Workspace = workspace
+	if settings != "" {
+		request.WorkspaceSettings = []byte(settings)
+	}
+	return request, filepath.Join(workspace, ".claude", "settings.json")
+}
+
+// RED-FIRST: before RunRequest carried WorkspaceSettings this failed with the
+// file absent at open, because nothing wrote it.
+func TestRunWritesWorkspaceSettingsBeforeOpeningDesktop(t *testing.T) {
+	const blob = `{"permissions":{"defaultMode":"plan"}}`
+	request, settingsPath := settingsRequest(t, blob)
+	runtime := &settingsProbe{settingsPath: settingsPath}
+
+	if _, err := Run(context.Background(), runtime, request); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !runtime.checkedAtOpen {
+		t.Fatal("the probe never ran — Desktop was never pointed at the workspace, so this test proved nothing")
+	}
+	if !runtime.existedAtOpen {
+		t.Fatal("workspace settings did not exist when Desktop opened the workspace; Claude Code reads project settings at session start, so a later write is the same as none")
+	}
+	if runtime.contentsAtOpen != blob {
+		t.Errorf("workspace settings = %q, want the cell's blob verbatim %q", runtime.contentsAtOpen, blob)
+	}
+}
+
+// LOCK (passes by construction): a cell with no settings block must leave the
+// workspace exactly as it found it. run-cell.sh writes `null` into
+// settings.json when a cell declares none, so "absent" has to mean absent.
+func TestRunWithoutWorkspaceSettingsLeavesTheWorkspaceClean(t *testing.T) {
+	request, settingsPath := settingsRequest(t, "")
+	runtime := &settingsProbe{settingsPath: settingsPath}
+
+	if _, err := Run(context.Background(), runtime, request); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(settingsPath)); !os.IsNotExist(err) {
+		t.Fatalf("a .claude directory appeared in a workspace whose cell declared no settings (stat err = %v)", err)
+	}
+}
+
+// `jq '.settings'` emits the four-byte literal `null` for a cell with no
+// settings block, and `{}` for an empty one. Neither is a settings file, and
+// writing either would hand Claude Code a project config the cell never asked
+// for.
+func TestRunTreatsEmptySettingsBlobsAsAbsent(t *testing.T) {
+	for _, blob := range []string{"null", "{}", "  null\n", "", "   "} {
+		request, settingsPath := settingsRequest(t, blob)
+		runtime := &settingsProbe{settingsPath: settingsPath}
+		if _, err := Run(context.Background(), runtime, request); err != nil {
+			t.Fatalf("Run(%q) error = %v", blob, err)
+		}
+		if _, err := os.Stat(settingsPath); !os.IsNotExist(err) {
+			t.Errorf("blob %q produced a settings file; it carries no settings", blob)
+		}
+	}
+}
+
+// A blob that is not a JSON object is an authoring error. Handing it to Claude
+// Code unread would surface as an unexplained session failure rather than as
+// the malformed cell it is.
+func TestRunRejectsSettingsThatAreNotAJSONObject(t *testing.T) {
+	for _, blob := range []string{`[1,2]`, `"text"`, `{`, `3`} {
+		request, _ := settingsRequest(t, blob)
+		runtime := &settingsProbe{}
+		if _, err := Run(context.Background(), runtime, request); err == nil {
+			t.Errorf("blob %q was accepted; it is not a settings object", blob)
+		}
+	}
+}

--- a/tools/onboarding-factory/scripts/lib/desktop-profile.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile.sh
@@ -84,11 +84,29 @@ desktop_profile_validate_cell() {
   # A `script` recipe is no longer refused outright (#1888) — which step types
   # the Desktop driver can drive is decided by desktop_recipe_gaps below, from
   # the driver's own declaration, rather than by a blanket "prompt only".
-  if [[ "$(jq -c '.settings // {}' <<<"$cell_json")" != "{}" ]] ||
-     [[ "$(jq -c '.env // {}' <<<"$cell_json")" != "{}" ]] ||
+  # `settings` is NOT in this list, and that is a measured decision rather than
+  # an oversight. A cell's settings blob reaches the CLI driver as `claude
+  # --settings <path>` — a launch FLAG that writes nothing. Desktop takes no
+  # such flag, so the blob is written into the run's own throwaway workspace as
+  # .claude/settings.json, which Claude Desktop was measured to honour on
+  # 2026-09-06 (a PreToolUse hook placed there fired; permissions.defaultMode
+  # "plan" held a turn back from writing). That write cannot reach anything
+  # outside the run.
+  #
+  # The refusal had to cover `settings` until the driver actually applied it:
+  # driver-desktop.sh accepted a <settings-path> argument and DROPPED it, so a
+  # settings cell would have run without its settings and reported a pass. The
+  # two changes belong together — do not relax this guard again without
+  # checking the driver still writes the file.
+  #
+  # `env`, `mock` and `bare_mode` stay refused. None of them is
+  # workspace-scoped: Desktop authenticates through its own OAuth and the
+  # driver has no env path, and bare mode is a CLI launch shape Desktop has no
+  # equivalent for.
+  if [[ "$(jq -c '.env // {}' <<<"$cell_json")" != "{}" ]] ||
      [[ "$(jq -c '.mock // empty' <<<"$cell_json")" != "" ]] ||
      [[ "$(jq -r '.bare_mode // false' <<<"$cell_json")" == "true" ]]; then
-    echo "desktop-local refuses settings, env, mock, and bare-mode changes" >&2
+    echo "desktop-local refuses env, mock, and bare-mode changes" >&2
     return 1
   fi
   return 0

--- a/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
+++ b/tools/onboarding-factory/scripts/lib/desktop-profile_test.sh
@@ -18,12 +18,22 @@ desktop_profile_validate_cell desktop-local claudecode 0 '{"prompt":"ok","settin
 assert_eq "basic Claude Code cell passes" 0 "$?"
 desktop_profile_validate_cell desktop-local claudecode 0 '{"script":[{"type":"send","text":"ok"}],"settings":{}}'
 assert_eq "a recipe cell reaches the recipe lint (#1888)" 0 "$?"
+# Measured live 2026-09-06: Claude Desktop DOES honour a workspace-scoped
+# .claude/settings.json — a PreToolUse hook placed there fired, and
+# permissions.defaultMode "plan" held a turn back from writing a file it was
+# told to write. The driver now writes the blob into the run's own throwaway
+# workspace, so a settings cell is no longer one that would run WITHOUT its
+# settings and report a pass.
+desktop_profile_validate_cell desktop-local claudecode 0 '{"prompt":"ok","settings":{"permissions":{"defaultMode":"plan"}}}'
+assert_eq "a workspace-scoped settings cell is accepted" 0 "$?"
+desktop_profile_validate_cell desktop-local claudecode 0 '{"prompt":"ok","settings":{"hooks":{"PreToolUse":[]}}}'
+assert_eq "a workspace-scoped hooks cell is accepted" 0 "$?"
 for mutation in \
   'codex|0|{"prompt":"ok"}' \
   'claudecode|1|{"prompt":"ok"}' \
-  'claudecode|0|{"prompt":"ok","settings":{"model":"x"}}' \
   'claudecode|0|{"prompt":"ok","env":{"TOKEN":"x"}}' \
-  'claudecode|0|{"prompt":"ok","mock":{"package":"./x"}}'; do
+  'claudecode|0|{"prompt":"ok","mock":{"package":"./x"}}' \
+  'claudecode|0|{"prompt":"ok","bare_mode":true}'; do
   IFS='|' read -r adapter attach json <<<"$mutation"
   if desktop_profile_validate_cell desktop-local "$adapter" "$attach" "$json" 2>/dev/null; then
     fail "unsafe cell is refused" "$mutation passed"


### PR DESCRIPTION
`desktop_profile_validate_cell` refused any cell carrying a `settings` block, which held 2-18 and 2-19 out of the campaign.

The refusal was correct — but not for the reason I recorded on #1892. I had written that the write was "ordinary file I/O into the driver-owned staging workspace". **It is not.** A cell's settings blob reaches the CLI driver as `claude --settings <path>`, a **launch flag**. The harness never writes a settings file at all.

Desktop takes no such flag. So the real question was: does Claude Desktop read a workspace-scoped `.claude/settings.json`?

## Measured against the live app

Driving the real app on 2026-09-06 with a hand-placed workspace file:

| Workspace setting | Result |
| --- | --- |
| `{"hooks":{"PreToolUse":[{"matcher":"Bash",…}]}}` | **the hook fired** |
| `{"permissions":{"defaultMode":"plan"}}` | **the turn refused to write** |

For the hook: the marker path appears **zero** times in `~/.claude/settings.json`, so the workspace file was the only possible source.

For plan mode: the turn genuinely ran — 5 assistant messages, `ExitPlanMode` 7 times — and did **not** create the file it was explicitly ordered to create. I checked that it ran, because an absent file on its own would not have told me whether plan mode worked or the turn never happened.

It works. So the blob now goes into the run's own throwaway workspace, and the guard stops refusing the class.

## Why both halves ship together

`driver-desktop.sh` has accepted a `<settings-path>` argument since it was written and **silently dropped it**. Relaxing the guard alone would have let a settings cell run *without its settings* and report a pass — a worse failure than being refused. The guard's comment now says this next to the check, for whoever relaxes it next.

`env`, `mock` and `bare_mode` stay refused. None of them is workspace-scoped.

## Evidence

**Red first:**
- `TestRunWritesWorkspaceSettingsBeforeOpeningDesktop` — failed with the file absent at the moment Desktop was pointed at the workspace. The probe asserts it actually ran (`checkedAtOpen`) before judging absence, so "never opened" cannot masquerade as "written".
- `TestRunRejectsSettingsThatAreNotAJSONObject` — failed for all four malformed shapes before the check existed.
- The two guard-acceptance cases — `expected [0], got [1]` before the guard was narrowed.

**Locks** (pass by construction): `env`, `mock` and `bare_mode` stay refused — `bare_mode` was uncovered before this and is now pinned. A cell with no settings leaves no `.claude` directory. `null`, `{}` and whitespace are treated as **absent**, because `run-cell.sh` emits the literal `null` for every cell that declares none.

**Ordering is tested, not assumed.** Claude Code reads project settings when the session starts, so a write after the deep link is the same as no write. The file lands before `Preflight`.

Local gates: `go` (12/12), `tools`, `bash` — all PASS.

## What this does not do

It unblocks 2-18 and 2-19; it does not record them. Both still need a live run, and my probes suggest they will meet the `wait_turn` hook timeout that already blocks 2-16.

Refs #1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc