### PR TITLE
docs(process): load-bearing comments carry the evidence for what they assert (#1822)

### DIFF
--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -110,7 +110,8 @@ Defects first — this skill hunts bugs. Quality cleanups are secondary here
   by reading it, and flag one that cites no evidence and is not phrased as an
   intention. Check a comment describing a mutation against the mutation as run.
   Epic #1796 shipped at least 13 wrong ones (a floor for the ones *found*,
-  counted from the agents' own hand-back reports), every one caught this way.
+  counted from the agents' hand-back reports and the review of #1813), every one
+  caught this way.
 - **Efficiency** — needless O(n²) over a hot path, repeated work in a loop,
   redundant I/O or process scans.
 - **Simplification / altitude** — only when the diff reimplements something

--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -104,6 +104,13 @@ Defects first — this skill hunts bugs. Quality cleanups are secondary here
   review pass is where three of the four incidents behind that rule were
   caught, each time by a mutation nobody had asked for — AGENTS.md's Testing
   section has the rule and the categories.)
+- **Comment claims** — a comment asserting a mechanism (a tier, a guard, an
+  ordering, an invariant, "X cannot happen", "this is enforced by Y") is a
+  claim, not commentary. Check it by running or grepping what it names, never
+  by reading it, and flag one that cites no evidence and is not phrased as an
+  intention. Check a comment describing a mutation against the mutation as run.
+  Epic #1796 shipped at least 13 wrong ones (a floor for the ones *found*,
+  counted from the agents' own hand-back reports), every one caught this way.
 - **Efficiency** — needless O(n²) over a hot path, repeated work in a loop,
   redundant I/O or process scans.
 - **Simplification / altitude** — only when the diff reimplements something

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -107,6 +107,13 @@ For a new guard, linter, schema rule, migration, rewriter, or contract check,
 mutate what it protects and require the check to fail. Commit reusable mutation
 fixtures when practical.
 
+Write every comment that asserts a mechanism from what you ran or read. A
+comment naming a tier, a guard, an ordering, an invariant, or "X cannot happen"
+states the check behind it, or reads as an intention rather than a fact. Write a
+comment describing a mutation from the mutation as run, not as planned. Verify
+each such comment by grepping or running what it names, not by reading it. Do
+this before the commit.
+
 If the fix already exists, commit before mutating with
 `git add -A && git commit -m wip`. Capture the checkpoint SHA and confirm
 `git status --porcelain` is empty right after the commit. Restore *only* by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,15 @@ history in [docs/testing-philosophy.md](docs/testing-philosophy.md):
 - A figure that documents behaviour states the command that produces it, or
   says plainly that it's an estimate and how it was arrived at — a number
   typed once and repeated by hand drifts silently away from what it measured.
+- A comment asserting a mechanism (a tier, a guard, an ordering, an invariant,
+  "X cannot happen", "this is enforced by Y") is a *dismissal* in the sense
+  above — it tells the next reader the question is settled — so it states what
+  was run or read to confirm it, or is written as an intention rather than a
+  fact. A comment describing a mutation is written from the mutation as **run**,
+  not as planned. These are found by running or grepping what the comment
+  describes, never by reading it: epic #1796 shipped at least 13 wrong ones
+  across four PRs (a floor for the ones *found*; `ir:exec`'s "Prove and verify"
+  section carries the execution-time form).
 - **A verification mechanism must fail loudly when it cannot run.** Absence
   of a finding and inability to look must never produce the same output —
   wherever a check greps, matches, mutates, shells out, or waits on a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,9 @@ history in [docs/testing-philosophy.md](docs/testing-philosophy.md):
   above — it tells the next reader the question is settled — so it states what
   was run or read to confirm it, or is written as an intention rather than a
   fact. A comment describing a mutation is written from the mutation as **run**,
-  not as planned. These are found by running or grepping what the comment
-  describes, never by reading it: epic #1796 shipped at least 13 wrong ones
-  across four PRs (a floor for the ones *found*; `ir:exec`'s "Prove and verify"
-  section carries the execution-time form).
+  not as planned. Check one by running or grepping what it names, never by
+  reading it (`ir:exec`'s "Prove and verify" and `ir:code-review` carry the
+  execution- and review-time forms).
 - **A verification mechanism must fail loudly when it cannot run.** Absence
   of a finding and inability to look must never produce the same output —
   wherever a check greps, matches, mutates, shells out, or waits on a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,9 @@ than retyping it.
 Keep SwiftUI views small and composable; use previews for visual tests.
 
 **General.** Don't add abstractions ahead of need. Delete unused code rather
-than commenting it out. Comments explain *why*, not *what*. Prefer editing
-existing files over creating new ones.
+than commenting it out. Comments explain *why*, not *what*, and one that
+asserts a mechanism carries evidence for it — see AGENTS.md's Testing section.
+Prefer editing existing files over creating new ones.
 
 ## Reporting bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,10 @@ than retyping it.
 Keep SwiftUI views small and composable; use previews for visual tests.
 
 **General.** Don't add abstractions ahead of need. Delete unused code rather
-than commenting it out. Comments explain *why*, not *what*, and one that
-asserts a mechanism carries evidence for it — see AGENTS.md's Testing section.
-Prefer editing existing files over creating new ones.
+than commenting it out. Comments explain *why*, not *what*, and one that asserts a
+mechanism carries evidence for it or reads as an intention — see
+[AGENTS.md](AGENTS.md#testing). Prefer editing existing files over creating new
+ones.
 
 ## Reporting bugs
 

--- a/docs/testing-philosophy.md
+++ b/docs/testing-philosophy.md
@@ -91,29 +91,35 @@ invariant, "X cannot happen" or "this is enforced by Y" tells the next reader th
 question is settled — it is a dismissal in [AGENTS.md](../AGENTS.md)'s sense and
 gets that rule's bar: state what was run or read to confirm it, or write it as an
 intention rather than as a fact. Wrong, it is worse than absent, because it is the
-one kind of error that stops anyone from checking: #1798's `session_error` comment
+one kind of error that stops anyone from checking: PR #1809's `session_error` comment
 said a defect was "unreachable in this phase", and two later agents each had to
 re-derive whether that was still true. **And a comment describing a mutation is
 written from the mutation as RUN, not as planned** — the gap the "prefer committing
 that mutation" paragraph above leaves open, since a committed fixture and the
-sentence describing it can still disagree. #1797 shipped two comments claiming
+sentence describing it can still disagree. PR #1806 shipped two comments claiming
 mutations its tests had actually survived.
 
 Epic #1796 is where the rate was measured, and it is a house-style problem rather
-than one agent's slip — every agent working that epic shipped some. Counted from the
-agents' own hand-back reports and the high-effort review of #1813, **a floor for
-wrong comments *found*, not an independently re-verified total**: 13 across four PRs
-(#1806 two, #1809 four, #1813 six, #1810 at least one). Two of #1813's contradicted
-themselves inside one comment block — one said "everything below this point is
-transcript tier" directly above a paragraph correctly describing two hook-tier rules
-below it; another said the guards "are restated where the invariant can see them"
-while lines above in the same block said they had been removed. All were corrected
-before merge, which is why the total cannot be recomputed from `main` and stays a
-floor: `git grep` finds none of those three phrases in the tree today.
+than one agent's slip — every agent whose epic PRs were reviewed for it shipped
+some. Counted from those agents' own hand-back reports and the high-effort review of
+#1813, **a floor for wrong comments *found*, not an independently re-verified
+total**: 13 across four PRs (#1806 two, #1809 four, #1813 six, #1810 at least one).
+Two of #1813's contradicted themselves inside one comment block — one said
+"everything below this point is transcript tier" directly above a paragraph
+correctly describing two hook-tier rules below it; another said the guards "are
+restated where the invariant can see them" while lines above in the same block said
+they had been removed. All three have since been corrected — #1813's two before
+merge, #1809's by #1811 — which is why the total cannot be recomputed from `main` and stays
+a floor. Note what that costs: quoting a wrong comment to write it up puts the
+phrase back in the tree, so the grep that would answer "does this still exist in
+code?" now hits this paragraph. Scope it past the write-up — `git grep -F
+"<phrase>" -- ':!docs/'` returns nothing for all three, while the same grep for
+`transcript tier` returns 7 files, so the empty result is a real absence and not a
+broken command.
 
 **Every one was found by RUNNING or GREPPING what the comment described, never by
 reading it.** Reading a load-bearing comment is how it earns trust; going to look is
-the only way to withdraw that trust. The coordinator caught two more the same way,
+the only way to withdraw that trust. The coordinator caught more the same way,
 by checking `consumeOnce: true` (`core/domain/session/signal_hold.go`) and the
 `ClearedByTurnBoundary` call sites rather than the prose around them. The cheapest
 mechanical version — a lint asserting that every identifier a comment names

--- a/docs/testing-philosophy.md
+++ b/docs/testing-philosophy.md
@@ -1,9 +1,9 @@
 # Testing Philosophy — House Style for What Counts as Evidence
 
 Referenced from [AGENTS.md](../AGENTS.md)'s Testing section. These are the
-repo's general rules for what makes a test (or any other verification
-mechanism) trustworthy — they apply everywhere, not just to one gate or one
-package. The `ir:exec` skill (`.claude/skills/ir:exec/SKILL.md`, "Prove and
+repo's general rules for what makes a test, any other verification mechanism,
+or a claim written *about* one trustworthy — they apply everywhere, not just to
+one gate or one package. The `ir:exec` skill (`.claude/skills/ir:exec/SKILL.md`, "Prove and
 verify") enforces the red-first and mutation rules mechanically; this file is
 where the full rationale and incident history live.
 
@@ -83,6 +83,42 @@ five. Neither figure had a command behind it — both were typed from memory
 under the same pressure the rule exists to catch. The fix is the same shape
 either way: derive the number in code and print the literal, or say in the
 same sentence that the figure is an estimate and how it was arrived at.
+
+**A comment that asserts a mechanism carries the same evidence as any other
+claim.** The rule above is a *number* drifting away from what it once measured; this
+is the same failure in prose. A comment naming a tier, a guard, an ordering, an
+invariant, "X cannot happen" or "this is enforced by Y" tells the next reader the
+question is settled — it is a dismissal in [AGENTS.md](../AGENTS.md)'s sense and
+gets that rule's bar: state what was run or read to confirm it, or write it as an
+intention rather than as a fact. Wrong, it is worse than absent, because it is the
+one kind of error that stops anyone from checking: #1798's `session_error` comment
+said a defect was "unreachable in this phase", and two later agents each had to
+re-derive whether that was still true. **And a comment describing a mutation is
+written from the mutation as RUN, not as planned** — the gap the "prefer committing
+that mutation" paragraph above leaves open, since a committed fixture and the
+sentence describing it can still disagree. #1797 shipped two comments claiming
+mutations its tests had actually survived.
+
+Epic #1796 is where the rate was measured, and it is a house-style problem rather
+than one agent's slip — every agent working that epic shipped some. Counted from the
+agents' own hand-back reports and the high-effort review of #1813, **a floor for
+wrong comments *found*, not an independently re-verified total**: 13 across four PRs
+(#1806 two, #1809 four, #1813 six, #1810 at least one). Two of #1813's contradicted
+themselves inside one comment block — one said "everything below this point is
+transcript tier" directly above a paragraph correctly describing two hook-tier rules
+below it; another said the guards "are restated where the invariant can see them"
+while lines above in the same block said they had been removed. All were corrected
+before merge, which is why the total cannot be recomputed from `main` and stays a
+floor: `git grep` finds none of those three phrases in the tree today.
+
+**Every one was found by RUNNING or GREPPING what the comment described, never by
+reading it.** Reading a load-bearing comment is how it earns trust; going to look is
+the only way to withdraw that trust. The coordinator caught two more the same way,
+by checking `consumeOnce: true` (`core/domain/session/signal_hold.go`) and the
+`ClearedByTurnBoundary` call sites rather than the prose around them. The cheapest
+mechanical version — a lint asserting that every identifier a comment names
+resolves — is deliberately **not** part of this rule; #1822 files it as separate,
+larger work, so until it exists the check is a person or an agent running the grep.
 
 **A fixture that waits by SLEEPING has not observed what it waits for, and the
 assertion after the sleep is not evidence that it has.** Poll the condition to a


### PR DESCRIPTION
Closes #1822.

Epic #1796 shipped **at least 13** comments asserting mechanisms the code did not have. That figure is a **floor for the ones *found***, counted from the agents' own hand-back reports and the high-effort review of #1813 — not an independently re-verified total, and it cannot be recomputed from `main`, because all three of the comments the issue quotes have since been corrected (#1813's two before merge, #1809's by #1811).

AGENTS.md already sets the matching rule for findings — *"Dismissals carry evidence"* — and a long explanatory comment is exactly such a claim: it tells the next reader the question is settled. The second half of that rule was simply not being applied to comments. This PR states the rule once and points every enforcement surface at it.

## What changed

| File | Role |
|---|---|
| `docs/testing-philosophy.md` | **Canonical statement**, rationale and incident history. Placed immediately after the "a figure states the command that produces it" rule, which it mirrors: that one is a *number* drifting from what it measured, this is the same failure in *prose*. |
| `AGENTS.md` (Testing house style) | Short form + pointer. One bullet, next to the figures bullet, same order as the doc. |
| `.claude/skills/ir:exec/SKILL.md` (§4 Prove and verify) | Execution-time imperative. |
| `.claude/skills/ir:code-review/SKILL.md` | Reviewer-side check — see deviation 1. |
| `CONTRIBUTING.md` | One-clause pointer beside the existing `Comments explain *why*, not *what*` rule. |

The rule, in one sentence: **a comment asserting a mechanism (a tier, a guard, an ordering, an invariant, "X cannot happen", "this is enforced by Y") states what was run or read to confirm it, or is written as an intention rather than a fact; and a comment describing a mutation is written from the mutation as *run*, not as planned.** It is verified by running or grepping what it names, never by reading it.

The four restatements are deliberately short forms that defer to the canonical one, so there is one rule in five places rather than five rules — the drift the triage note bounds this work with. The review below checked that clause by clause.

**Explicitly not built:** the lint from the issue's third bullet (assert that identifiers cited in comments resolve). Both the issue body and its triage file it as separate, larger work. The canonical statement says so in the text, so the next reader does not have to re-derive that it was a decision rather than an oversight.

## Evidence

This change **adds a rule, so it has no red-first "before the fix"**. Per AGENTS.md, the proof is a mutation of what the checks protect, and locks are named as locks rather than presented as red-first proof.

### Mutation 1 — the AGENTS.md budget gate really reads the file I edited

Appended filler to `AGENTS.md` to take it from 256 to **401** lines, then ran the gate:

```
$ tools/preflight.sh --only tools           # → exit 1
shell-lib-suite: tools/lib — found 40, skipped 0 (none), ran 40, failed 1
shell-lib-suite: FAILED: agents-md-lint_test.sh
  tools/lib shell-lib tests                                  FAIL

$ bash tools/lib/agents-md-lint_test.sh     # → exit 1
FAIL: the repo's real, current AGENTS.md passes its own budget:
  expected exit 0, got 1 (output: FAIL: AGENTS.md is 401 lines — over the
  400-line budget (#1742). …)
```

It went red through that self-test's **vacuity guard** ("the repo's real, current AGENTS.md passes its own budget") — i.e. through the assertion that exists precisely so the fixtures cannot pass while the check is wired to nothing. Restored with `git show <ckpt>:AGENTS.md > AGENTS.md`; the same self-test then returns exit 0 with all 7 cases PASS.

### Mutation 2 — the skills gate really reads both skill files I edited

Two mutations placed *inside the text this PR adds*: an unmatched code fence in `ir:exec`'s new paragraph, and `{{TOKEN}}` in `ir:code-review`'s new bullet.

```
$ tools/preflight.sh --only skills          # → exit 1
.claude/skills/ir:code-review/SKILL.md:108: ERROR unfilled template token {{TOKEN}} [template-token]
.claude/skills/ir:exec/SKILL.md:1: ERROR odd number of code-fence delimiters … [unbalanced-fence]
skill-lint: 23 file(s), 2 error(s), 0 warning(s)
  skill-file lint                                            FAIL
```

Both errors land on the exact file and line of the added text. Restored from the checkpoint; the gate then reports `23 file(s), 0 error(s), 0 warning(s)`, exit 0.

No mutation fixture is committed: `tools/lib/testdata/agents-md-lint/` already carries the 350/400/401/401-no-trailing-newline corpus and `agents-md-lint_test.sh` already carries the real-file vacuity guard, and `skill-lint`'s corpus already covers `template-token` and `unbalanced-fence`. A new fixture would duplicate an existing one rather than protect anything new.

### Locks — these pass by construction and are **not** red-first evidence

A text-only diff cannot change them; they are here to show it did not.

| Gate | Result |
|---|---|
| `tools/preflight.sh --only go` | PASS (gofmt, go vet ×2, core module tests, onboarding-factory tests, elfdans-drive, seed-autonomy-spans, autonomy-backfill, Claude Desktop helper, replaydata validate, recording-rig smoke, replay fixtures) |
| `tools/preflight.sh --only arch` | PASS — ARS composite 7.933227856022059 → 7.933227856022059, no category regression |
| `tools/preflight.sh --only tools` | PASS (40 shell-lib tests; state-vocabulary lint: 1235 files, 48 sites, all waived) — re-run after the review fixes |
| `tools/preflight.sh --only skills` | PASS (23 files, 0 errors, 0 warnings) — re-run after the review fixes |
| `tools/preflight.sh --only posix` | PASS |
| `tools/preflight.sh --only bash` | PASS |

`--only swift`, `--only web` and `--only security` were not run: no `platforms/macos/`, no `web/` tree and no Go or npm dependency is in the diff. The pre-push hook's `--changed` run reported them `SKIP` ("this diff cannot break it"), not `NOT RUN`.

Two guards that anchor on the section I edited also still pass inside `--only tools`: `tools/lib/checkpoint-idiom-guard_test.sh` (which greps `## 4. Prove and verify` and fails loudly if it cannot find it) and `tools/lib/preflight-groups-skill_test.sh` (which asserts the skill's `--only` list matches `preflight.sh`'s `VALID_GROUPS`).

## Review

Effort **medium**, raised from triage's `low`. Reason: the diff is tiny and prose-only, but two of the five files are executable instructions that every future `ir:exec` and review run loads, so a wrong clause propagates rather than sitting still. Delegated to a subagent running `.claude/skills/ir:code-review/SKILL.md` against `origin/main...HEAD`.

It returned **8 findings, all valid, all fixed in 31fde52b**. Three of them were this PR's own text failing the rule it introduces — found, as the rule says, by *running* the claims rather than reading them:

1. **CONFIRMED — "All were corrected before merge" was false.** #1809's `session_error` comment merged and was removed later by #1811. `git log origin/main -S "unreachable in this phase" -- core/` shows `32ec3efb` (#1809) adding it and `6bb5d1cc` (#1811) removing it. It also contradicted the same paragraph's next clause — "two later agents each had to re-derive whether that was still true" is only possible *because* it merged. Now scoped to the three quoted comments, attributed per PR.
2. **CONFIRMED — the `git grep` claim was falsified by running it.** Quoting a wrong comment in order to write it up puts the phrase back in the tree, so the grep that was supposed to demonstrate absence hit this very document. Fixed by naming the scoped command (`git grep -F "<phrase>" -- ':!docs/'`, which returns nothing for all three) *and* the control that proves the empty result is a real absence rather than a broken command (`transcript tier` → 7 files). The write-up now also names this trap, since it will recur for anyone documenting a wrong comment.
3. **CONFIRMED — issue numbers used where the adjacent tally used PR numbers.** #1797/#1798 are issues; `gh pr view 1797` does not resolve. Both prose citations now use the PR number (#1806, #1809).
4. **PLAUSIBLE — "every agent working that epic shipped some"** is a universal over ≥11 epic PRs, from evidence covering 4. Hedged to the population the evidence covers.
5. **PLAUSIBLE — "caught two more" did not reconcile** with the tally of exactly 13. The ambiguity is inherited from the issue; the unsupported count is now dropped rather than guessed.
6. **PLAUSIBLE — rule drift in CONTRIBUTING.md**: it stated the evidence branch as absolute, dropping the "or reads as an intention" alternative every other statement keeps. Restored.
7. **CONFIRMED — CONTRIBUTING.md's pointer was bare text** where the file's five other AGENTS.md pointers are links. Now `[AGENTS.md](AGENTS.md#testing)`.
8. **CONFIRMED (minor) — `ir:code-review` trimmed the count's provenance** to the hand-back reports, dropping "and the review of #1813" — which is where the largest slice (6 of 13) came from. Restored.

The review explicitly cleared: rule drift clause-by-clause across all five statements (one rule, not five — `ir:exec` adds only a legitimate execution-time specialisation); every positional `above`/`below` cross-reference in `docs/testing-philosophy.md` re-resolved after the insertion; `checkpoint-idiom-guard_test.sh` and `preflight-groups-skill_test.sh` both still green; and the AGENTS.md budget.

**Inline simplify pass**, all four angles named. *Reuse* — the rule defers to the existing "Dismissals carry evidence" statement by reference rather than restating it; the four short forms follow the pattern AGENTS.md already uses for every other testing bullet. *Simplification* — no change; the canonical statement is the only long form. *Efficiency* — the one real cost here is context: AGENTS.md is force-injected into every session via `CLAUDE.md`'s `@AGENTS.md`, so bytes there are paid every time. Dropped the figure and its floor marking from that bullet in favour of a pointer to the two skills; that also matches the section's convention of keeping issue numbers out of the house-style bullets. **256 → 255 lines** against the 400-line budget. *Altitude* — canonical statement in `docs/` (loaded on demand), short form in AGENTS.md (always loaded), imperatives in the two skills (loaded when they run), pointer in CONTRIBUTING.md (the human entry point); that is the repo's existing layering, unchanged.

## Design deviations

**1. Added a bullet to `.claude/skills/ir:code-review/SKILL.md`.** The issue names AGENTS.md and `ir:exec`; triage's `Flags` line names the same two artifacts. Repository evidence for extending it: the issue's own central finding is that *every* wrong comment was caught by running or grepping what it described, and in three of the four PRs the finder was the review pass (#1806 "caught only because a reviewer *ran* them"; #1809's agent reporting the reviewer's rate; the high-effort review of #1813). `ir:code-review` is the skill `ir:exec` delegates its review gate to, and it already restates red-first and the mutation rule at the same spot, noting that "three of the four incidents behind that rule were caught" in that pass. Putting an execution-time rule in `ir:exec` while leaving the surface where every instance was actually caught silent would have documented the wrong half of the mechanism. This PR's own review is the first run of that bullet, and findings 1–3 above are what it produced.

**2. Added a one-clause pointer to `CONTRIBUTING.md`.** `CONTRIBUTING.md` holds the repo's only other comment rule (`Comments explain *why*, not *what*`), so it is where a human contributor looks first. It is a pointer, not a sixth statement — CONTRIBUTING.md already defers to AGENTS.md in five other places rather than restating.

**3. Widened `docs/testing-philosophy.md`'s scope sentence.** Its preamble said the file covers "what makes a test (or any other verification mechanism) trustworthy". A comment is neither. Leaving it would have left the file asserting a scope it no longer has — the exact defect class this PR is about.

**4. Placement, the decision triage delegated.** Both surfaces, with the canonical statement in `docs/testing-philosophy.md` and a pointer from AGENTS.md — the pattern every other testing bullet already follows (AGENTS.md points at the doc once for the whole list). `AGENTS.md` is **255 lines** against its 400-line budget (`tools/agents-md-lint.sh`, output quoted above), so the short form did not have to displace anything.

## Process deviation, flagged rather than buried

The triage comment on #1822 (2026-08-26) predates `fe701f3f refactor(skills): simplify triage and execution flow (#1873)` (2026-09-04), which renamed `**Run plan:**` to `**Process:**` and added the `## High-level design`, `## Testing strategy` and `**Estimate:**` sections that `ir:exec` §1 now requires. It is therefore a **legacy-format** triage record, which §1 says not to accept. It was executed anyway because the maintainer named this issue for execution in-session and restated the run plan and the delegated placement bounds. Substantively the record carries everything §1 asks for except `Estimate` — verdict `ready-for-agent`, the `ready-for-agent` label, the delegated design decision with bounds, the testing strategy under its `Verifiability` axis, and the process as `Run plan: full · investigation 1 Explore (medium) · review low · inline glance`. Re-triaging #1822 would refresh the format if that matters.

## Risk

The rule reaches every future session (AGENTS.md is force-injected via `CLAUDE.md`'s `@AGENTS.md`), which is wide while it stands but one commit to revert. Nothing mechanical enforces the rule itself — `docs/*.md` is checked by no gate, and the checks exercised above only prove the *text is legal and present*, not that agents follow it. That gap is the issue's own third bullet, filed as separate work.

One residual, worth naming because this PR just demonstrated it: `docs/testing-philosophy.md` now carries sentences whose truth changes as the tree changes (the scoped-grep result and its control count). They state the command that produces them, which is what the house rule requires, but nothing re-runs them. The reviewer's suggestion — a small `tools/lib/` tripwire asserting the doc's own greps still return what it claims, which would have gone red on the first commit of this PR — is a cheaper and more honest version of the parked lint, and is offered as a follow-up rather than filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
