### PR TITLE
fix(herdr): resolve a pane for agents that hide their own environment (#1934)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/herdrpane.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrpane.go
@@ -172,7 +172,7 @@ func herdrSocketPaths() []string {
 func candidatePanes(panes []herdrPane, cwd string) []herdrPane {
 	var out []herdrPane
 	for _, p := range panes {
-		if cwd != "" && p.CWD != cwd && p.ForegroundCWD != cwd {
+		if !paneMatchesCWD(p, cwd) {
 			continue
 		}
 		out = append(out, p)
@@ -181,6 +181,24 @@ func candidatePanes(panes []herdrPane, cwd string) []herdrPane {
 		}
 	}
 	return out
+}
+
+// paneMatchesCWD reports whether a pane is worth asking about for a session in
+// cwd.
+//
+// Both of the pane's directories count, because they answer different
+// questions and either can be the match: `cwd` is where the pane's shell sits,
+// `foreground_cwd` where its running process does. They agree for an agent
+// started in place and diverge when it was started after a cd.
+//
+// An unknown cwd matches everything rather than nothing. A session whose
+// directory irrlicht cannot read is exactly the case where a bounded scan is
+// still better than giving up, and the pid match downstream decides either way.
+func paneMatchesCWD(p herdrPane, cwd string) bool {
+	if cwd == "" {
+		return true
+	}
+	return p.CWD == cwd || p.ForegroundCWD == cwd
 }
 
 // processInfoNames reports whether pid is the pane's foreground process or its

--- a/core/adapters/inbound/agents/processlifecycle/herdrpane.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrpane.go
@@ -99,24 +99,41 @@ func herdrPaneForPID(ctx context.Context, pid int, cwd string) (paneID, socketPa
 		return "", "", false
 	}
 	for _, sock := range herdrSocketPaths() {
-		panes, ok := herdrPanes(ctx, sock)
-		if !ok {
+		pane, answered := paneOnSocket(ctx, sock, pid, cwd)
+		if !answered {
 			// This socket did not answer. Others still might, so keep going
 			// rather than reporting a failed probe for the whole lookup.
 			continue
 		}
 		probed = true
-		for _, pane := range candidatePanes(panes, cwd) {
-			info, ok := herdrPaneProcessInfo(ctx, sock, pane.PaneID)
-			if !ok {
-				continue
-			}
-			if processInfoNames(info, pid) {
-				return pane.PaneID, sock, true
-			}
+		if pane != "" {
+			return pane, sock, true
 		}
 	}
 	return "", "", probed
+}
+
+// paneOnSocket asks one herdr server which of its panes holds pid, and reports
+// whether that server answered at all.
+//
+// The two returns are independent on purpose: ("", true) is a server that
+// answered and does not hold the process, which is evidence; ("", false) is a
+// server that could not be reached, which is not.
+func paneOnSocket(ctx context.Context, socketPath string, pid int, cwd string) (paneID string, answered bool) {
+	panes, ok := herdrPanes(ctx, socketPath)
+	if !ok {
+		return "", false
+	}
+	for _, pane := range candidatePanes(panes, cwd) {
+		info, ok := herdrPaneProcessInfo(ctx, socketPath, pane.PaneID)
+		if !ok {
+			continue
+		}
+		if processInfoNames(info, pid) {
+			return pane.PaneID, true
+		}
+	}
+	return "", true
 }
 
 // herdrSocketPaths lists the control sockets of every herdr server with state
@@ -190,7 +207,7 @@ func herdrPanes(ctx context.Context, socketPath string) ([]herdrPane, bool) {
 	var payload struct {
 		Panes []herdrPane `json:"panes"`
 	}
-	if !herdrRequest(ctx, socketPath, "pane.list", nil, &payload) {
+	if !herdrRequest(ctx, socketPath, herdrCall{method: "pane.list"}, &payload) {
 		return nil, false
 	}
 	return payload.Panes, true
@@ -200,51 +217,78 @@ func herdrPaneProcessInfo(ctx context.Context, socketPath, paneID string) (herdr
 	var payload struct {
 		ProcessInfo herdrProcessInfo `json:"process_info"`
 	}
-	params := map[string]any{"pane_id": paneID}
-	if !herdrRequest(ctx, socketPath, "pane.process_info", params, &payload) {
+	call := herdrCall{method: "pane.process_info", params: map[string]any{"pane_id": paneID}}
+	if !herdrRequest(ctx, socketPath, call, &payload) {
 		return herdrProcessInfo{}, false
 	}
 	return payload.ProcessInfo, true
 }
 
-// herdrRequest sends one JSON-RPC request and decodes the `result` member of
-// the single line that comes back.
+// herdrCall is one request's method and parameters, kept together so the
+// request path takes a subject rather than a list of loose arguments.
+type herdrCall struct {
+	method string
+	params map[string]any
+}
+
+// herdrRequest sends one JSON-RPC call and decodes the `result` member of the
+// single line that comes back.
 //
 // Returns false for every failure — no such socket, nothing listening, a
 // timeout, a protocol error, an error member instead of a result. The caller
 // distinguishes only "answered" from "did not", because none of those failures
 // is evidence about which pane a process is in.
-func herdrRequest(ctx context.Context, socketPath, method string, params map[string]any, out any) bool {
+func herdrRequest(ctx context.Context, socketPath string, call herdrCall, out any) bool {
+	conn, ok := dialHerdr(ctx, socketPath)
+	if !ok {
+		return false
+	}
+	defer func() { _ = conn.Close() }()
+
+	if !writeCall(conn, call) {
+		return false
+	}
+	return readResult(conn, out)
+}
+
+// dialHerdr opens the control socket with a deadline already applied to the
+// whole exchange, so neither the connect nor the read can outlive it.
+func dialHerdr(ctx context.Context, socketPath string) (net.Conn, bool) {
 	deadline := time.Now().Add(herdrDialTimeout)
 	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
 		deadline = ctxDeadline
 	}
-
 	dialer := net.Dialer{Deadline: deadline}
 	conn, err := dialer.DialContext(ctx, "unix", socketPath)
 	if err != nil {
-		return false
+		return nil, false
 	}
-	defer func() { _ = conn.Close() }()
 	if err := conn.SetDeadline(deadline); err != nil {
-		return false
+		_ = conn.Close()
+		return nil, false
 	}
+	return conn, true
+}
 
-	request := map[string]any{"id": "irrlicht:" + method, "method": method}
-	if params != nil {
-		request["params"] = params
+func writeCall(conn net.Conn, call herdrCall) bool {
+	request := map[string]any{"id": "irrlicht:" + call.method, "method": call.method}
+	if call.params != nil {
+		request["params"] = call.params
 	}
 	body, err := json.Marshal(request)
 	if err != nil {
 		return false
 	}
-	if _, err := conn.Write(append(body, '\n')); err != nil {
-		return false
-	}
+	_, err = conn.Write(append(body, '\n'))
+	return err == nil
+}
 
-	// One request, one response line. A streaming decoder rather than a
-	// read-to-EOF because the server keeps the connection open for further
-	// requests, so EOF would only arrive at the deadline.
+// readResult decodes one response envelope and unmarshals its result into out.
+//
+// A streaming decoder rather than a read-to-EOF because the server keeps the
+// connection open for further requests, so EOF would only arrive at the
+// deadline.
+func readResult(conn net.Conn, out any) bool {
 	var envelope struct {
 		Result json.RawMessage `json:"result"`
 	}

--- a/core/adapters/inbound/agents/processlifecycle/herdrpane.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrpane.go
@@ -1,0 +1,295 @@
+// herdrpane.go resolves a herdr pane for an agent process whose own
+// environment cannot be read (#1934).
+//
+// launcherFromEnv takes HERDR_PANE_ID from the agent process's environment,
+// which on darwin comes from sysctl(kern.procargs2). A Node-based agent that
+// sets process.title overwrites the contiguous argv+env region that call
+// exposes, so the read comes back empty and the session gets no pane — while
+// the same session's state, cwd and adapter are observed normally. Measured on
+// herdr 0.8.0 with pi (a `/usr/bin/env node` script): `ps eww` shows 0
+// environment variables for the pi process and a full environment for a
+// compiled agent (claude, opencode) in a neighbouring pane.
+//
+// The ancestry fallback cannot recover it either. Walking up from such a
+// process reaches the pane's shell, whose environment is equally unreadable,
+// and then the herdr *server*, which knows the session but not the pane.
+//
+// So the pane is asked for, from the one process that certainly knows it.
+// herdr's control socket speaks the same newline-delimited JSON-RPC its own
+// pi extension uses (~/.pi/agent/extensions/herdr-agent-state.ts sends
+// {"id","method":"pane.report_agent","params":{...}} over HERDR_SOCKET_PATH),
+// and answers `pane.list` and `pane.process_info` on the same connection.
+//
+// This is a socket read rather than a shellout on purpose: it needs no herdr
+// binary on the daemon's PATH, and it does not consume the probe budget that
+// probecount.go accounts for.
+package processlifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// herdrSessionsDirFn locates herdr's per-session state directories. A variable
+// so tests can point it at a fixture tree; production takes the documented
+// layout, which herdrClientLogPath already assumes elsewhere in this package.
+var herdrSessionsDirFn = defaultHerdrSessionsDir
+
+func defaultHerdrSessionsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "herdr", "sessions")
+}
+
+// herdrDialTimeout bounds one request end to end. The socket is local and the
+// server answers from memory, so this is a liveness bound rather than a
+// latency budget: a herdr that has stopped leaves its socket file behind, and
+// without a deadline the connect would block on it.
+const herdrDialTimeout = 2 * time.Second
+
+// maxPaneCandidates bounds how many panes are asked for their process list
+// after the cwd filter has narrowed them.
+//
+// The filter is what makes this small: `pane.list` returns every pane on the
+// server (19 on the machine where #1934 was measured), and the ones sharing a
+// working directory with the session are typically one to three. The cap is
+// the guard for the case the filter cannot narrow — many panes opened in one
+// directory — and its cost when it truncates is a session that keeps no pane,
+// which is exactly today's behaviour.
+//
+// cwd is used ONLY to choose which panes to ask about. It is never the answer:
+// two sessions can share a working directory, so the pane is decided by an
+// exact pid match against pane.process_info. That distinction is the whole
+// reason this resolves rather than guesses.
+const maxPaneCandidates = 8
+
+// herdrPane is the subset of herdr's `pane.list` entries this file reads.
+type herdrPane struct {
+	PaneID        string `json:"pane_id"`
+	CWD           string `json:"cwd"`
+	ForegroundCWD string `json:"foreground_cwd"`
+}
+
+// herdrProcessInfo is the subset of `pane.process_info` this file reads.
+type herdrProcessInfo struct {
+	ShellPID            int `json:"shell_pid"`
+	ForegroundProcesses []struct {
+		PID int `json:"pid"`
+	} `json:"foreground_processes"`
+}
+
+// herdrPaneForPID returns the pane displaying pid and the socket it was found
+// on, plus whether the lookup actually ran.
+//
+// The third return is #1485's distinction applied here: "no herdr is running"
+// and "herdr is running and this process is not in one of its panes" are both
+// legitimate no-answers, but "the socket refused us" is not evidence of
+// either, and a caller that overwrites a known launcher must be able to tell
+// them apart. probed is true only when at least one socket answered.
+func herdrPaneForPID(ctx context.Context, pid int, cwd string) (paneID, socketPath string, probed bool) {
+	if pid <= 0 {
+		return "", "", false
+	}
+	for _, sock := range herdrSocketPaths() {
+		panes, ok := herdrPanes(ctx, sock)
+		if !ok {
+			// This socket did not answer. Others still might, so keep going
+			// rather than reporting a failed probe for the whole lookup.
+			continue
+		}
+		probed = true
+		for _, pane := range candidatePanes(panes, cwd) {
+			info, ok := herdrPaneProcessInfo(ctx, sock, pane.PaneID)
+			if !ok {
+				continue
+			}
+			if processInfoNames(info, pid) {
+				return pane.PaneID, sock, true
+			}
+		}
+	}
+	return "", "", probed
+}
+
+// herdrSocketPaths lists the control sockets of every herdr server with state
+// on this machine, in a stable order.
+//
+// Sorted because filepath.Glob's order is documented as sorted and the result
+// feeds a first-match loop: an unstable order would make which pane is found
+// depend on directory iteration when two servers somehow claim one pid, and a
+// non-deterministic answer is worse than a wrong one because it cannot be
+// reproduced from a bug report.
+func herdrSocketPaths() []string {
+	dir := herdrSessionsDirFn()
+	if dir == "" {
+		return nil
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*", "herdr.sock"))
+	if err != nil {
+		// Only ErrBadPattern, which the literal above cannot produce.
+		return nil
+	}
+	return matches
+}
+
+// candidatePanes narrows the panes worth asking about to those whose working
+// directory matches the session's, capped at maxPaneCandidates.
+//
+// Both cwd fields are compared because they answer different questions and
+// either can be the match: `cwd` is where the pane's shell sits, and
+// `foreground_cwd` is where its running process does. They agree for an agent
+// started in place and diverge when the agent was started after a cd.
+//
+// An empty cwd disables the filter rather than matching nothing: a session
+// whose directory Irrlicht does not know is exactly the case where asking a
+// bounded number of panes is still better than giving up, and the pid match
+// downstream is what decides either way.
+func candidatePanes(panes []herdrPane, cwd string) []herdrPane {
+	var out []herdrPane
+	for _, p := range panes {
+		if cwd != "" && p.CWD != cwd && p.ForegroundCWD != cwd {
+			continue
+		}
+		out = append(out, p)
+		if len(out) == maxPaneCandidates {
+			break
+		}
+	}
+	return out
+}
+
+// processInfoNames reports whether pid is the pane's foreground process or its
+// shell.
+//
+// The shell is included because a pane whose agent has exited leaves the shell
+// in the foreground, and a session observed in that instant still belongs to
+// that pane. Matching only the foreground process would drop the pane exactly
+// while the session is ending, which is when its identity is most likely to be
+// read.
+func processInfoNames(info herdrProcessInfo, pid int) bool {
+	if info.ShellPID == pid {
+		return true
+	}
+	for _, p := range info.ForegroundProcesses {
+		if p.PID == pid {
+			return true
+		}
+	}
+	return false
+}
+
+func herdrPanes(ctx context.Context, socketPath string) ([]herdrPane, bool) {
+	var payload struct {
+		Panes []herdrPane `json:"panes"`
+	}
+	if !herdrRequest(ctx, socketPath, "pane.list", nil, &payload) {
+		return nil, false
+	}
+	return payload.Panes, true
+}
+
+func herdrPaneProcessInfo(ctx context.Context, socketPath, paneID string) (herdrProcessInfo, bool) {
+	var payload struct {
+		ProcessInfo herdrProcessInfo `json:"process_info"`
+	}
+	params := map[string]any{"pane_id": paneID}
+	if !herdrRequest(ctx, socketPath, "pane.process_info", params, &payload) {
+		return herdrProcessInfo{}, false
+	}
+	return payload.ProcessInfo, true
+}
+
+// herdrRequest sends one JSON-RPC request and decodes the `result` member of
+// the single line that comes back.
+//
+// Returns false for every failure — no such socket, nothing listening, a
+// timeout, a protocol error, an error member instead of a result. The caller
+// distinguishes only "answered" from "did not", because none of those failures
+// is evidence about which pane a process is in.
+func herdrRequest(ctx context.Context, socketPath, method string, params map[string]any, out any) bool {
+	deadline := time.Now().Add(herdrDialTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+
+	dialer := net.Dialer{Deadline: deadline}
+	conn, err := dialer.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetDeadline(deadline); err != nil {
+		return false
+	}
+
+	request := map[string]any{"id": "irrlicht:" + method, "method": method}
+	if params != nil {
+		request["params"] = params
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return false
+	}
+	if _, err := conn.Write(append(body, '\n')); err != nil {
+		return false
+	}
+
+	// One request, one response line. A streaming decoder rather than a
+	// read-to-EOF because the server keeps the connection open for further
+	// requests, so EOF would only arrive at the deadline.
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.NewDecoder(conn).Decode(&envelope); err != nil {
+		return false
+	}
+	if len(envelope.Result) == 0 {
+		return false
+	}
+	return json.Unmarshal(envelope.Result, out) == nil
+}
+
+// adoptHerdrPane fills in a launcher's herdr pane when the environment read
+// could not, leaving everything else alone.
+//
+// A no-op unless the pane is genuinely missing, so a session whose environment
+// WAS readable never pays for this and never has its own answer second-guessed:
+// the environment is the more direct evidence, and this is the fallback.
+//
+// The socket path is adopted alongside the pane id because they are one fact.
+// clientHostFor needs both to reach the herdr client, and a pane id without its
+// socket would name the pane while leaving #1350's focus path unable to use it.
+func adoptHerdrPane(l *session.Launcher, pid int) {
+	if l == nil || l.HerdrPaneID != "" {
+		return
+	}
+	pane, socketPath, probed := herdrPaneForPID(context.Background(), pid, cwdForPaneMatch(pid))
+	if !probed || pane == "" {
+		return
+	}
+	l.HerdrPaneID = pane
+	l.HerdrSocketPath = socketPath
+}
+
+// cwdForPaneMatch reads the process's working directory to narrow which panes
+// are asked about, and returns "" when it cannot.
+//
+// "" is not a failure here: candidatePanes treats it as "do not filter" and
+// falls back to the bounded scan, which still decides by pid. Reading through
+// the osProc seam rather than shelling out keeps this off the probe budget,
+// matching how discovery.go reads a pid's directory.
+func cwdForPaneMatch(pid int) string {
+	dir, err := osProc.CWDOf(pid)
+	if err != nil {
+		return ""
+	}
+	return dir
+}

--- a/core/adapters/inbound/agents/processlifecycle/herdrpane_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrpane_test.go
@@ -1,0 +1,350 @@
+package processlifecycle
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// fakeHerdr serves herdr's newline-delimited JSON-RPC on a unix socket, so
+// these tests exercise the real dial/encode/decode path rather than a stub of
+// it. The wire format is copied from a live herdr 0.8.0: a request is
+// {"id","method","params"} and a reply is {"id","result":{...}}.
+type fakeHerdr struct {
+	t *testing.T
+
+	panes map[string]fakePane // pane id -> its processes
+
+	mu    sync.Mutex
+	calls []string // methods served, in order, so a test can assert cost
+}
+
+type fakePane struct {
+	cwd           string
+	foregroundCWD string
+	shellPID      int
+	foreground    []int
+}
+
+// start listens on <dir>/<session>/herdr.sock and points herdrSessionsDirFn at
+// dir for the duration of the test.
+func (f *fakeHerdr) start(dir, sessionName string) string {
+	f.t.Helper()
+	sessionDir := filepath.Join(dir, sessionName)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		f.t.Fatalf("mkdir session dir: %v", err)
+	}
+	sock := filepath.Join(sessionDir, "herdr.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		f.t.Fatalf("listen on %s: %v", sock, err)
+	}
+	f.t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go f.serve(conn)
+		}
+	}()
+	return sock
+}
+
+func (f *fakeHerdr) serve(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		var req struct {
+			ID     string         `json:"id"`
+			Method string         `json:"method"`
+			Params map[string]any `json:"params"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &req); err != nil {
+			return
+		}
+		f.mu.Lock()
+		f.calls = append(f.calls, req.Method)
+		f.mu.Unlock()
+
+		result, ok := f.result(req.Method, req.Params)
+		if !ok {
+			return
+		}
+		body, err := json.Marshal(map[string]any{"id": req.ID, "result": result})
+		if err != nil {
+			return
+		}
+		if _, err := conn.Write(append(body, '\n')); err != nil {
+			return
+		}
+	}
+}
+
+func (f *fakeHerdr) result(method string, params map[string]any) (any, bool) {
+	switch method {
+	case "pane.list":
+		panes := make([]map[string]any, 0, len(f.panes))
+		for _, id := range f.sortedPaneIDs() {
+			p := f.panes[id]
+			panes = append(panes, map[string]any{
+				"pane_id":        id,
+				"cwd":            p.cwd,
+				"foreground_cwd": p.foregroundCWD,
+			})
+		}
+		return map[string]any{"type": "pane_list", "panes": panes}, true
+	case "pane.process_info":
+		id, _ := params["pane_id"].(string)
+		p, ok := f.panes[id]
+		if !ok {
+			return nil, false
+		}
+		procs := make([]map[string]any, 0, len(p.foreground))
+		for _, pid := range p.foreground {
+			procs = append(procs, map[string]any{"pid": pid, "name": "node", "argv0": "pi"})
+		}
+		return map[string]any{
+			"type": "pane_process_info",
+			"process_info": map[string]any{
+				"pane_id":              id,
+				"shell_pid":            p.shellPID,
+				"foreground_processes": procs,
+			},
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+// sortedPaneIDs keeps pane.list deterministic, so a test asserting which pane
+// was asked about first is asserting the code's ordering rather than Go's map
+// iteration.
+func (f *fakeHerdr) sortedPaneIDs() []string {
+	ids := make([]string, 0, len(f.panes))
+	for id := range f.panes {
+		ids = append(ids, id)
+	}
+	for i := range ids {
+		for j := i + 1; j < len(ids); j++ {
+			if ids[j] < ids[i] {
+				ids[i], ids[j] = ids[j], ids[i]
+			}
+		}
+	}
+	return ids
+}
+
+func (f *fakeHerdr) methodCalls(method string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, m := range f.calls {
+		if m == method {
+			n++
+		}
+	}
+	return n
+}
+
+// shortTempDir returns a directory short enough to hold a unix socket path.
+//
+// Not t.TempDir(): a sockaddr_un's sun_path is 104 bytes on darwin, and
+// t.TempDir() builds its path from the test's own name under a long
+// /var/folders/... prefix, so a socket inside it fails to bind with EINVAL.
+// The test name is exactly what makes it too long, so the limit is reached
+// sooner the more descriptive the test is named.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "irrherdr")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// useSessionsDir points the production socket lookup at a fixture tree.
+func useSessionsDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := herdrSessionsDirFn
+	herdrSessionsDirFn = func() string { return dir }
+	t.Cleanup(func() { herdrSessionsDirFn = prev })
+}
+
+// #1934's defect test. Before adoptHerdrPane existed this returned no pane for
+// a process whose environment could not be read, which is the whole bug.
+func TestHerdrPaneForPIDResolvesByExactPID(t *testing.T) {
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w1:p1": {cwd: "/work/a", foregroundCWD: "/work/a", shellPID: 100, foreground: []int{101}},
+		"w1:p2": {cwd: "/work/b", foregroundCWD: "/work/b", shellPID: 200, foreground: []int{201}},
+	}}
+	sock := f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	pane, gotSock, probed := herdrPaneForPID(context.Background(), 201, "/work/b")
+	if !probed {
+		t.Fatal("probed=false, but the fake socket answered")
+	}
+	if pane != "w1:p2" {
+		t.Errorf("pane = %q, want w1:p2", pane)
+	}
+	if gotSock != sock {
+		t.Errorf("socket = %q, want %q", gotSock, sock)
+	}
+}
+
+// The pane must be decided by pid, never by the working directory used to
+// narrow candidates. Two sessions in one directory is the case that made
+// cwd-based correlation unusable in the first place.
+func TestHerdrPaneForPIDDoesNotGuessFromCWD(t *testing.T) {
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w2:p1": {cwd: "/shared", foregroundCWD: "/shared", shellPID: 300, foreground: []int{301}},
+		"w2:p2": {cwd: "/shared", foregroundCWD: "/shared", shellPID: 400, foreground: []int{401}},
+	}}
+	f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	for pid, want := range map[int]string{301: "w2:p1", 401: "w2:p2"} {
+		pane, _, probed := herdrPaneForPID(context.Background(), pid, "/shared")
+		if !probed {
+			t.Fatalf("pid %d: probed=false", pid)
+		}
+		if pane != want {
+			t.Errorf("pid %d resolved to %q, want %q", pid, pane, want)
+		}
+	}
+}
+
+// A pane whose agent has exited still belongs to the session observed in that
+// instant, so the shell pid counts as a match.
+func TestHerdrPaneForPIDMatchesTheShell(t *testing.T) {
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w3:p1": {cwd: "/work", foregroundCWD: "/work", shellPID: 500, foreground: nil},
+	}}
+	f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	pane, _, probed := herdrPaneForPID(context.Background(), 500, "/work")
+	if !probed || pane != "w3:p1" {
+		t.Errorf("pane=%q probed=%v, want w3:p1 true", pane, probed)
+	}
+}
+
+// "Nothing answered" and "answered, no match" must not look alike: the first is
+// not evidence that the process has no pane. This is #1485's distinction, which
+// this file inherits because the same consumers overwrite a known launcher.
+func TestHerdrPaneForPIDUnansweredSocketIsNotEvidence(t *testing.T) {
+	dir := shortTempDir(t)
+	sessionDir := filepath.Join(dir, "dead")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A socket file with nothing listening — what a stopped herdr leaves.
+	if err := os.WriteFile(filepath.Join(sessionDir, "herdr.sock"), nil, 0o600); err != nil {
+		t.Fatalf("write stale socket: %v", err)
+	}
+	useSessionsDir(t, dir)
+
+	pane, _, probed := herdrPaneForPID(context.Background(), 999, "/work")
+	if pane != "" {
+		t.Errorf("pane = %q, want empty", pane)
+	}
+	if probed {
+		t.Error("probed = true, but no socket answered — a failed probe is not evidence of absence")
+	}
+}
+
+// A session that answered and genuinely has no pane must report probed=true,
+// because that IS evidence, unlike the case above.
+func TestHerdrPaneForPIDAnsweredWithNoMatchIsEvidence(t *testing.T) {
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w4:p1": {cwd: "/work", foregroundCWD: "/work", shellPID: 600, foreground: []int{601}},
+	}}
+	f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	pane, _, probed := herdrPaneForPID(context.Background(), 77777, "/work")
+	if pane != "" {
+		t.Errorf("pane = %q, want empty", pane)
+	}
+	if !probed {
+		t.Error("probed = false, but the socket answered — that is evidence of absence")
+	}
+}
+
+// The cwd filter is what keeps the cost of this bounded. Without it every pane
+// on the server would be asked for its process list.
+func TestHerdrPaneForPIDAsksOnlyAboutMatchingDirectories(t *testing.T) {
+	dir := shortTempDir(t)
+	panes := map[string]fakePane{}
+	for i := range 12 {
+		id := string(rune('a'+i)) + ":p1"
+		panes[id] = fakePane{cwd: "/elsewhere", foregroundCWD: "/elsewhere", shellPID: 1000 + i, foreground: []int{2000 + i}}
+	}
+	panes["z:p1"] = fakePane{cwd: "/target", foregroundCWD: "/target", shellPID: 900, foreground: []int{901}}
+	f := &fakeHerdr{t: t, panes: panes}
+	f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	pane, _, _ := herdrPaneForPID(context.Background(), 901, "/target")
+	if pane != "z:p1" {
+		t.Fatalf("pane = %q, want z:p1", pane)
+	}
+	if got := f.methodCalls("pane.process_info"); got != 1 {
+		t.Errorf("pane.process_info called %d times, want 1 — the cwd filter should have excluded the other 12 panes", got)
+	}
+}
+
+func TestCandidatePanesCapsUnfilterableInput(t *testing.T) {
+	var panes []herdrPane
+	for i := range maxPaneCandidates + 5 {
+		panes = append(panes, herdrPane{PaneID: string(rune('a' + i)), CWD: "/same", ForegroundCWD: "/same"})
+	}
+	if got := len(candidatePanes(panes, "/same")); got != maxPaneCandidates {
+		t.Errorf("candidates = %d, want the cap %d", got, maxPaneCandidates)
+	}
+	// An unknown cwd disables the filter but not the cap.
+	if got := len(candidatePanes(panes, "")); got != maxPaneCandidates {
+		t.Errorf("candidates with empty cwd = %d, want the cap %d", got, maxPaneCandidates)
+	}
+}
+
+// The environment is the more direct evidence, so a launcher that already
+// carries a pane must not be second-guessed — and must cost nothing.
+func TestAdoptHerdrPaneLeavesAKnownPaneAlone(t *testing.T) {
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w5:p1": {cwd: "/work", foregroundCWD: "/work", shellPID: 700, foreground: []int{701}},
+	}}
+	f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	l := &session.Launcher{HerdrPaneID: "from:env", HerdrSocketPath: "/env/sock"}
+	adoptHerdrPane(l, 701)
+
+	if l.HerdrPaneID != "from:env" || l.HerdrSocketPath != "/env/sock" {
+		t.Errorf("launcher was overwritten: %+v", l)
+	}
+	if got := f.methodCalls("pane.list"); got != 0 {
+		t.Errorf("pane.list called %d times for a launcher that already had a pane, want 0", got)
+	}
+}
+
+func TestAdoptHerdrPaneTolerNilLauncher(t *testing.T) {
+	useSessionsDir(t, shortTempDir(t))
+	adoptHerdrPane(nil, 1) // must not panic
+}

--- a/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
@@ -30,7 +30,7 @@ func LauncherPermissionDeclaration() agent.Agent {
 			Kind:            permission.KindObserve,
 			Title:           "Capture terminal identity",
 			FeatureUnlocked: "Click-to-focus: jump from a session row or notification straight to the terminal window that runs it",
-			Touches:         "Reads a fixed whitelist of environment variables from detected agent processes (TERM_PROGRAM, KITTY_*, TMUX, HERDR_*, …), and for a herdr pane from the herdr client displaying it",
+			Touches:         "Reads a fixed whitelist of environment variables from detected agent processes (TERM_PROGRAM, KITTY_*, TMUX, HERDR_*, …), and for a herdr pane from the herdr client displaying it, or from herdr itself when the process hides its own environment",
 			Detail: "When a session is linked to its process, irrlicht reads only " +
 				"these variables from that process's environment: TERM_PROGRAM, " +
 				"ITERM_SESSION_ID, TERM_SESSION_ID, TMUX, TMUX_PANE, VSCODE_PID, " +
@@ -39,7 +39,11 @@ func LauncherPermissionDeclaration() agent.Agent {
 				"never the full environment. A session running in a herdr pane is " +
 				"displayed by a separate herdr client process, so for those the same " +
 				"whitelist is also read from that client (found via the session's own " +
-				"socket path) — without it there is no window to jump to. Focusing " +
+				"socket path) — without it there is no window to jump to. Some agents " +
+				"overwrite their own environment as they start, so nothing above can be " +
+				"read from them at all; for those, irrlicht asks the local herdr server " +
+				"over its control socket which pane holds the process, and reads no " +
+				"other pane's contents (#1934). Focusing " +
 				"itself only happens when you " +
 				"click a session (kitty remote control / AppleScript, additionally " +
 				"gated by macOS automation prompts). Toggling off stops the capture " +

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -247,6 +247,17 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	l, _ = hostIdentity(noAggregateBudget(), pid)
 	hostKnown = true
 
+	// #1934: an agent that sets process.title overwrites the contiguous
+	// argv+env region sysctl(kern.procargs2) exposes, so the read above found
+	// no HERDR_PANE_ID for it even though the session is in a herdr pane. Ask
+	// herdr, which certainly knows. See herdrpane.go for why the ancestry
+	// fallback cannot recover it and why this is a socket read.
+	//
+	// Placed before clientHostFor deliberately: it consumes HerdrPaneID and
+	// HerdrSocketPath, so recovering them here is also what makes #1350's
+	// click-to-focus reach these sessions rather than only their pane id.
+	adoptHerdrPane(l, pid)
+
 	// A multiplexer pane's window belongs to the attached client, so its host
 	// identity is resolved from that process instead — one indirection past
 	// the ancestry walk (#1350 for herdr, #1501 for tmux). Runs after the TTY


### PR DESCRIPTION
Closes #1934.

## What was wrong

`launcherFromEnv` takes `HERDR_PANE_ID` from the agent process's environment,
which on darwin comes from `sysctl(kern.procargs2)`. A Node-based agent that
sets `process.title` overwrites the contiguous argv+env region that call
exposes, so the read comes back empty — the session is observed normally
(state, cwd, adapter) but gets no pane, and #1350's click-to-focus has nothing
to jump to.

Measured on herdr 0.8.0, one machine, from `/api/v1/sessions`:

| adapter | sessions | pane resolved |
|---|---:|---:|
| `claude-code` | 4 | 4 |
| `codex` | 2 | 2 |
| `opencode` | 1 | 1 |
| **`pi`** | **3** | **0** |

`ps eww -p <pid>` shows 0 environment variables for the pi process and a full
environment for a compiled agent in a neighbouring pane. `file $(which pi)`
reports a `/usr/bin/env node` script; `ps -o args=` shows the padded argv a
`process.title` write leaves behind.

The ancestry fallback cannot recover it: walking up reaches the pane's shell,
equally unreadable, then the herdr **server**, which knows the session but not
the pane.

## What this does

Asks herdr. Its control socket already speaks newline-delimited JSON-RPC — the
pi extension herdr installs reports state over it — and answers `pane.list` and
`pane.process_info`.

A socket read rather than a shellout, deliberately: no herdr binary need be on
the daemon's PATH, and it does not consume the probe budget `probecount.go`
accounts for.

**cwd narrows; pid decides.** The working directory only chooses which panes are
worth asking about. The pane is selected by an exact pid match against
`pane.process_info`, because two sessions can share a directory — which is what
made cwd-based correlation unusable in the first place. On the measured machine
`pane.list` returns 19 panes and the filter leaves one.

Placed before `clientHostFor` so it also feeds `HerdrSocketPath`, which is what
lets click-to-focus reach these sessions rather than only learning their pane id.

## Prove and verify

The code is new, so there is no before-the-fix red to run. Each protected
property was mutated instead, and the mutation confirmed to go red:

| Mutation | Test that went red |
|---|---|
| take the first candidate regardless of the pid match | `TestHerdrPaneForPIDDoesNotGuessFromCWD` — *"pid 401 resolved to w2:p1, want w2:p2"* |
| report `probed=true` when no socket answered | `TestHerdrPaneForPIDUnansweredSocketIsNotEvidence` |
| drop the guard that leaves an env-derived pane alone | `TestAdoptHerdrPaneLeavesAKnownPaneAlone` |
| neutralise the cwd filter | `TestHerdrPaneForPIDAsksOnlyAboutMatchingDirectories` — *"pane = \"\", want z:p1"* |

All four were re-run after the CodeScene refactor, not carried over from before
it. One caveat worth recording: the first mutation has to be written as
`|| true` rather than replacing the call outright — doing that leaves `info` and
`pid` unused, so it does not compile and produces **no test result at all**,
which is not the same as a test that passed. I nearly recorded that as a
verification.

All green again on restore. `go test ./... -count=1` in `core/`: 67 packages
ok, 0 failures. `gofmt -l` clean, `go vet` clean on the package.

The tests run a real unix-socket server speaking the recorded wire format, so
the dial/encode/decode path is exercised rather than stubbed.

`TestHerdrPaneForPIDAsksOnlyAboutMatchingDirectories` pins the cost: 12 panes in
another directory and one in the session's, exactly one `pane.process_info`
call.

Neutralising the filter turned out to do more than raise that count. With 13
panes and a cap of 8, the pane that actually holds the process falls outside the
cap and the lookup returns **nothing** — so the filter is load-bearing for
correctness at that pane count, not only for cost. `maxPaneCandidates`' doc says
truncation costs "a session that keeps no pane"; this is that sentence observed
rather than reasoned about.

## CodeScene

The first push failed the quality gate: *Bumpy Road Ahead* in `herdrPaneForPID`
(critical) and *Complex Method / Complex Conditional / Excess Number of Function
Arguments* in `herdrRequest` (advisory). Both are fixed rather than suppressed —
the nested loops became `paneOnSocket`, and the request path split into
`dialHerdr` / `writeCall` / `readResult` with `herdrCall` carrying method and
params.

A second round removed the last advisory — *Complex Conditional* in
`candidatePanes` — by naming the predicate `paneMatchesCWD`. Code health on the
file moved 9.03 → 9.69 across the two refactors.

Splitting the lookup also improved it: `paneOnSocket` returns
`(pane, answered)`, which puts the evidence distinction in a signature instead
of a comment.

## Consent

The `launcher`/`env` permission text is extended rather than a new key added:
the user-visible capability and the consent decision are unchanged, only the
mechanism is new. Its `Detail` already described reading the whitelist from the
herdr client via the session's socket path — a path that comes from the same
unreadable environment, so it cannot fire for these sessions either.

**That is a maintainer's call and I would rather be corrected than assume.** If
this should be its own key, say so and I will split it.

## Not verified

- **Whether other Node-based adapters are affected.** Only `pi` is installed
  here among the Node-shipped ones, so the generalisation is reasoning from the
  mechanism, not a measurement.
- **Whether `pane_id` survives a herdr restart.** Not tested. It decides whether
  a resolved pane should be cached across restarts; nothing here caches.
- **Linux.** The file is platform-neutral Go and the root cause (`process.title`
  overwriting the argv/env region) is not darwin-specific, but the measurements
  above are all darwin. `/proc/<pid>/environ` may behave differently.
