### PR TITLE
feat(pi): let a pi session report its own herdr pane (#1936)

### DIFF
--- a/core/adapters/inbound/agents/pi/agent.go
+++ b/core/adapters/inbound/agents/pi/agent.go
@@ -78,7 +78,8 @@ func Agent() agent.Agent {
 				// rather than leaving it to Detail — the wizard row is what
 				// most users read.
 				Touches: "Writes 1 hook entry to " + displayExtensionPath +
-					" — a small JavaScript file that pi loads and runs",
+					" — a small JavaScript file that pi loads and runs, which also " +
+					"reads the two variables naming the herdr pane it runs in",
 				Detail: "pi has no hooks section in its settings: the only way to observe " +
 					"its lifecycle is an extension, so this permission installs one. That " +
 					"is a single JavaScript file at " + displayExtensionPath + ", which pi " +
@@ -89,7 +90,15 @@ func Agent() agent.Agent {
 					"node:child_process, subscribes to exactly one pi event (agent_settled, " +
 					"which fires when pi will not continue running on its own) and does one " +
 					"thing with it: runs `irrlichd hook-post pi`, a tiny command irrlicht " +
-					"ships, handing it the session's transcript path. That command reads the " +
+					"ships, handing it the session's transcript path. Alongside that path it " +
+					"sends two values read from its own environment, HERDR_PANE_ID and " +
+					"HERDR_SOCKET_PATH — nothing else from the environment, and nothing at " +
+					"all unless you run pi inside herdr. They name the terminal pane the " +
+					"session sits in, which irrlicht cannot see from the outside for pi: pi " +
+					"is a Node program, and a Node program that sets its process title " +
+					"overwrites the region macOS lets other processes read. Storing them is " +
+					"gated separately by the \"Terminal focus\" permission, so with that " +
+					"turned off they are dropped on arrival. That command reads the " +
 					"daemon's own published address at the moment the hook fires, so nothing " +
 					"in the file names a host or a port and it cannot go stale; it also never " +
 					"blocks pi, even when the daemon is not running. The file deliberately " +

--- a/core/adapters/inbound/agents/pi/extension.js
+++ b/core/adapters/inbound/agents/pi/extension.js
@@ -13,9 +13,21 @@
 // Everything in here is deliberate and narrow:
 //
 //   - It subscribes to exactly ONE event, agent_settled, and does exactly one
-//     thing with it: hand the session's transcript path to the beacon on
-//     stdin. It registers no tool, no command, no provider, no UI, and reads
-//     nothing.
+//     thing with it: hand the session's transcript path — and, when herdr set
+//     them, the two variables that name this pane — to the beacon on stdin. It
+//     registers no tool, no command, no provider and no UI.
+//
+//   - Those two variables are the ONLY thing it reads from the process it runs
+//     in, they are read by literal name, and it reads them for a reason no
+//     amount of work on the daemon side removes (#1936). The daemon reads a
+//     process's environment from outside, which on darwin means
+//     sysctl(kern.procargs2); a Node agent that sets process.title overwrites
+//     the argv+env region that call exposes, so for pi the daemon reads an
+//     empty environment and the session gets no pane (#1934). Inside the
+//     process the same values are still in process.env. This extension is
+//     therefore the one vantage point from which they can be seen at all.
+//     Nothing else about the process is read, and nothing is sent that the
+//     daemon would not have read for a non-Node agent.
 //
 //   - It never subscribes to `tool_call`. That is not a style preference:
 //     pi's own runner dispatches every OTHER event inside a try/catch and
@@ -65,8 +77,34 @@ export default function (pi) {
 			return;
 		}
 		if (!transcriptPath) return;
-		post({ hook_event_name: IRRLICHT_EVENT, transcript_path: transcriptPath });
+		post({
+			hook_event_name: IRRLICHT_EVENT,
+			transcript_path: transcriptPath,
+			herdr_pane_id: herdrVar("HERDR_PANE_ID"),
+			herdr_socket_path: herdrVar("HERDR_SOCKET_PATH"),
+		});
 	});
+}
+
+// herdrVar returns one herdr environment variable, or undefined when it is
+// unset, empty or not a string. JSON.stringify drops an undefined value, so a
+// session running outside herdr sends byte-for-byte the payload it sent
+// before this was added.
+//
+// The two names are literal arguments at the single call site above rather
+// than a prefix scan, so what this function can return is fixed at read time
+// and readable here: no other variable is reachable through it.
+//
+// Wrapped in try/catch for the same reason everything else here is — pi awaits
+// this handler, and a monitoring extension must not be able to fail the
+// agent's turn. `process` is a Node global, so this needs no import.
+function herdrVar(name) {
+	try {
+		const value = process.env[name];
+		return typeof value === "string" && value !== "" ? value : undefined;
+	} catch {
+		return undefined;
+	}
 }
 
 // post hands one payload to the beacon on stdin and forgets about it. Every

--- a/core/adapters/inbound/agents/pi/extension_test.go
+++ b/core/adapters/inbound/agents/pi/extension_test.go
@@ -39,7 +39,14 @@ var piOnCallRE = regexp.MustCompile(`pi\.on\(\s*([A-Za-z_][A-Za-z0-9_]*|"[^"]*")
 // jsPayloadKeyRE finds the keys of the object literal extension.js hands to
 // JSON.stringify — the wire contract between the shipped JavaScript and
 // piHookPayload's json tags.
-var jsPayloadKeyRE = regexp.MustCompile(`(?m)^\s*post\(\{ (.*) \}\);$`)
+//
+// It spans lines (`(?s)`, non-greedy up to the first `});`) because the
+// literal outgrew one line when #1936 added the two herdr fields. The property
+// checked is unchanged; only the shape the guard can read widened. It is still
+// anchored on `post({`, so it reads the literal that is actually sent rather
+// than any object elsewhere in the file, and it still fails loudly when it
+// matches nothing.
+var jsPayloadKeyRE = regexp.MustCompile(`(?s)post\(\{(.*?)\}\);`)
 
 // importRE finds every module specifier the extension imports.
 var importRE = regexp.MustCompile(`from "([^"]+)"`)

--- a/core/adapters/inbound/agents/pi/herdrhint.go
+++ b/core/adapters/inbound/agents/pi/herdrhint.go
@@ -149,23 +149,59 @@ func validHerdrPaneID(s string) bool {
 // an attacker's tree. Reaching that already requires write access inside
 // ~/.config/herdr, and an attacker with that access owns herdr's real socket
 // too, so the hint is no longer the weakest way in.
+// One predicate per property rather than one function with four guards: each
+// answers a question of a different kind — how the string is written, where it
+// points, and what is actually there — and they are worth naming separately
+// because only the last one touches the filesystem.
 func confinedHerdrSocketPath(p string) string {
-	if p == "" || !filepath.IsAbs(p) || filepath.Clean(p) != p {
+	if !herdrSocketNamed(p) {
 		return ""
 	}
-	if filepath.Base(p) != herdrSocketName {
+	if !underHerdrConfigRoot(p) {
 		return ""
 	}
-	root := herdrConfigDirFn()
-	if root == "" {
-		return ""
-	}
-	if !strings.HasPrefix(p, filepath.Clean(root)+string(filepath.Separator)) {
-		return ""
-	}
-	info, err := os.Lstat(p)
-	if err != nil || info.Mode()&os.ModeSocket == 0 {
+	if !isSocketFile(p) {
 		return ""
 	}
 	return p
+}
+
+// herdrSocketNamed reports whether p is written the way a captured
+// $HERDR_SOCKET_PATH is: absolute, already clean, and named herdr.sock.
+//
+// Sequential guards rather than one disjunction, because each names a distinct
+// way a path can be wrong and a reader looking for one of them should not have
+// to parse the other two first.
+func herdrSocketNamed(p string) bool {
+	if p == "" {
+		return false
+	}
+	if !filepath.IsAbs(p) {
+		return false
+	}
+	if filepath.Clean(p) != p {
+		return false
+	}
+	return filepath.Base(p) == herdrSocketName
+}
+
+// underHerdrConfigRoot reports whether p lies inside herdr's configuration
+// root. Tested against root + separator so a sibling directory that merely
+// shares the root's prefix does not pass.
+func underHerdrConfigRoot(p string) bool {
+	root := herdrConfigDirFn()
+	if root == "" {
+		return false
+	}
+	return strings.HasPrefix(p, filepath.Clean(root)+string(filepath.Separator))
+}
+
+// isSocketFile reports whether p is itself a socket. Lstat, so a symlink is
+// judged as the link it is rather than as whatever it points at.
+func isSocketFile(p string) bool {
+	info, err := os.Lstat(p)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSocket != 0
 }

--- a/core/adapters/inbound/agents/pi/herdrhint.go
+++ b/core/adapters/inbound/agents/pi/herdrhint.go
@@ -1,0 +1,171 @@
+// herdrhint.go validates the herdr pane a pi session's own extension reports
+// about itself (issue #1936).
+//
+// # Why the hint exists at all
+//
+// A session's launcher identity is normally read from OUTSIDE the process:
+// processlifecycle.ReadLauncherEnv pulls a fixed whitelist of variables out of
+// the agent's environment, which on darwin means sysctl(kern.procargs2). A
+// Node-based agent that sets process.title overwrites the contiguous argv+env
+// region that call exposes, so for pi the read comes back empty and the
+// session gets no pane — measured in #1934 against herdr 0.8.0: `ps eww` shows
+// zero variables for the pi process and a full environment for a compiled
+// agent in a neighbouring pane.
+//
+// Inside the process the values are still there. irrlicht already ships an
+// extension into pi (extension.js), so the one process that can read
+// $HERDR_PANE_ID is already running irrlicht's code — it just was not looking.
+//
+// # Why it is confined rather than trusted
+//
+// The hint arrives on the same local, unauthenticated endpoint hooks.go's
+// header already reasons about, and its conclusion applies here verbatim: "our
+// own extension wrote it" buys nothing, because any local process can post the
+// same body. What is new is the CONSEQUENCE. A transcript path is read; a
+// socket path is *acted on* — herdrClientLogPath derives the client log beside
+// it and the darwin host probe scans for whoever holds that file open, then
+// adopts that process's terminal as the session's host window. An unconfined
+// path would therefore let any local process choose which window irrlicht's
+// click-to-focus raises.
+//
+// So the path is confined to herdr's own tree before it is stored, by the four
+// properties below, and a hint failing any of them is dropped in silence: the
+// session keeps no pane, which is exactly what it has today.
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// herdrSocketName is the file name every herdr control socket has, for the
+// default session (<config>/herdr.sock) and for named ones
+// (<config>/sessions/<name>/herdr.sock) alike. Stated once here and once in
+// processlifecycle's herdrClientLogName comment, both from the same
+// live-verified layout (herdr 0.8.0).
+const herdrSocketName = "herdr.sock"
+
+// maxHerdrPaneIDLen bounds the pane address. herdr's is "w<n>:p<n>" — five or
+// six bytes in practice — so this is a sanity ceiling on untrusted input, not
+// a real limit; nothing downstream would be harmed by a longer one, and
+// nothing legitimate produces it.
+const maxHerdrPaneIDLen = 64
+
+// herdrConfigDirFn locates herdr's configuration root. A variable so tests can
+// point it at a fixture tree; production takes the documented layout.
+//
+// $XDG_CONFIG_HOME is deliberately NOT consulted. Whether herdr honours it is
+// not something this issue measured, and guessing has an asymmetric cost:
+// honouring a variable herdr ignores would move the accepted root away from
+// the real one and reject every genuine hint. A user whose herdr lives
+// elsewhere loses the pane and keeps today's behaviour, which is the safe
+// direction to be wrong in.
+var herdrConfigDirFn = defaultHerdrConfigDir
+
+func defaultHerdrConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "herdr")
+}
+
+// herdrPaneHint is a validated pane address together with the server socket it
+// belongs to.
+//
+// Both halves are required, and the socket is the half that does the work: a
+// pane address like "w1:p1" exists on every running herdr server, so the
+// socket is what says WHICH server was meant. It is the socket the daemon
+// confirms the report on before believing it, and afterwards the one
+// clientHostFor reaches the attached client through. A pane id on its own
+// would name a pane that cannot be confirmed and cannot be focused — the
+// macOS HerdrActivator requires both for the same reason and says so.
+type herdrPaneHint struct {
+	paneID     string
+	socketPath string
+}
+
+// herdrPaneHintFrom validates a reported pane, returning ok=false when it must
+// not be stored. An absent hint (both fields empty) is not an error — it is
+// every session that is not running under herdr — and reports ok=false without
+// distinction, because the caller does the same thing either way.
+func herdrPaneHintFrom(paneID, socketPath string) (herdrPaneHint, bool) {
+	if !validHerdrPaneID(paneID) {
+		return herdrPaneHint{}, false
+	}
+	confined := confinedHerdrSocketPath(socketPath)
+	if confined == "" {
+		return herdrPaneHint{}, false
+	}
+	return herdrPaneHint{paneID: paneID, socketPath: confined}, true
+}
+
+// validHerdrPaneID reports whether s is shaped like a herdr pane address.
+//
+// An allowlist rather than a denylist, and byte-wise rather than a regexp,
+// because the value ends up in persisted session state that the macOS app
+// renders and that a future caller may put in a request: what may appear in it
+// should be readable in one line rather than inferred from what was thought of
+// to exclude.
+func validHerdrPaneID(s string) bool {
+	if s == "" || len(s) > maxHerdrPaneIDLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == ':', c == '_', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// confinedHerdrSocketPath returns p when it is a herdr control socket inside
+// herdr's own configuration root, and "" otherwise.
+//
+// Four properties, each closing a different way in:
+//
+//   - Absolute and already clean. Rejecting rather than cleaning is the point:
+//     a path needing normalisation is not one this extension produced, since
+//     it forwards $HERDR_SOCKET_PATH verbatim, and normalising a hostile path
+//     into an acceptable one is the classic way a confinement check becomes a
+//     confinement bypass.
+//   - Named herdr.sock, so the accepted set is one file per directory rather
+//     than any file under the root.
+//   - Under the configuration root, tested against root + separator so that a
+//     sibling directory sharing the root's prefix ("…/herdr-evil/herdr.sock")
+//     does not pass a bare string prefix.
+//   - Actually a socket, by Lstat. Lstat and not Stat, deliberately: Stat
+//     follows symlinks, so a link named herdr.sock placed inside the root and
+//     pointing at a socket outside it would satisfy every other property.
+//     Lstat sees the link itself, which is not a socket, and rejects.
+//
+// What this does NOT defend against, stated rather than implied: a symlinked
+// DIRECTORY component inside the root — say sessions/ replaced by a link into
+// an attacker's tree. Reaching that already requires write access inside
+// ~/.config/herdr, and an attacker with that access owns herdr's real socket
+// too, so the hint is no longer the weakest way in.
+func confinedHerdrSocketPath(p string) string {
+	if p == "" || !filepath.IsAbs(p) || filepath.Clean(p) != p {
+		return ""
+	}
+	if filepath.Base(p) != herdrSocketName {
+		return ""
+	}
+	root := herdrConfigDirFn()
+	if root == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, filepath.Clean(root)+string(filepath.Separator)) {
+		return ""
+	}
+	info, err := os.Lstat(p)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		return ""
+	}
+	return p
+}

--- a/core/adapters/inbound/agents/pi/herdrhint.go
+++ b/core/adapters/inbound/agents/pi/herdrhint.go
@@ -101,23 +101,37 @@ func herdrPaneHintFrom(paneID, socketPath string) (herdrPaneHint, bool) {
 	return herdrPaneHint{paneID: paneID, socketPath: confined}, true
 }
 
+// herdrPaneIDAlphabet is every character a herdr pane address may contain.
+// herdr's own is "w<n>:p<n>"; the letters and the two separators leave room for
+// a naming scheme without admitting anything structural.
+//
+// Spelled out rather than expressed as ranges, because this constant IS the
+// rule: an allowlist is only an improvement on a denylist if a reader can see
+// the whole of it at once.
+const herdrPaneIDAlphabet = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+	"0123456789" +
+	":_-"
+
 // validHerdrPaneID reports whether s is shaped like a herdr pane address.
 //
-// An allowlist rather than a denylist, and byte-wise rather than a regexp,
-// because the value ends up in persisted session state that the macOS app
-// renders and that a future caller may put in a request: what may appear in it
-// should be readable in one line rather than inferred from what was thought of
-// to exclude.
+// An allowlist rather than a denylist, because the value ends up in persisted
+// session state that the macOS app renders and that a future caller may put in
+// a request: what may appear in it should be readable rather than inferred from
+// what somebody thought to exclude.
+//
+// Ranging over runes rather than bytes is what rejects a multi-byte character:
+// no rune outside the alphabet above is in it, and invalid UTF-8 decodes to
+// RuneError, which is not in it either.
 func validHerdrPaneID(s string) bool {
-	if s == "" || len(s) > maxHerdrPaneIDLen {
+	if s == "" {
 		return false
 	}
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
-		case c == ':', c == '_', c == '-':
-		default:
+	if len(s) > maxHerdrPaneIDLen {
+		return false
+	}
+	for _, r := range s {
+		if !strings.ContainsRune(herdrPaneIDAlphabet, r) {
 			return false
 		}
 	}

--- a/core/adapters/inbound/agents/pi/herdrhint.go
+++ b/core/adapters/inbound/agents/pi/herdrhint.go
@@ -213,6 +213,13 @@ func underHerdrConfigRoot(p string) bool {
 // isSocketFile reports whether p is itself a socket. Lstat, so a symlink is
 // judged as the link it is rather than as whatever it points at.
 func isSocketFile(p string) bool {
+	// herdrSocketNamed already rejects parent traversal because such a path is
+	// not clean. Keep this stricter check beside Lstat because CodeQL does not
+	// carry that validation through the helper calls above. No measured herdr
+	// path contains "..", so rejecting the wider spelling fails closed.
+	if strings.Contains(p, "..") {
+		return false
+	}
 	info, err := os.Lstat(p)
 	if err != nil {
 		return false

--- a/core/adapters/inbound/agents/pi/herdrhint_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhint_test.go
@@ -148,10 +148,13 @@ func TestValidHerdrPaneID(t *testing.T) {
 		{"pane_1", true},
 		{"pane-1", true},
 		{"", false},
-		{"w1 p2", false},            // whitespace
-		{"w1;p2", false},            // shell metacharacter
-		{"../../etc/passwd", false}, // path-shaped
-		{"w1:p2\n", false},          // the JSON-RPC framing is newline-delimited
+		{"w1 p2", false},                    // whitespace
+		{"w1;p2", false},                    // shell metacharacter
+		{"../../etc/passwd", false},         // path-shaped
+		{"w1:p2\n", false},                  // the JSON-RPC framing is newline-delimited
+		{"w1:p2/../x", false},               // separators that mean something to a path
+		{"w1:pä", false},                    // a multi-byte rune is not in the alphabet
+		{string([]byte{0xff, 0xfe}), false}, // invalid UTF-8 decodes to RuneError
 		{string(make([]byte, maxHerdrPaneIDLen)), false}, // NULs, and at the ceiling
 		{"w" + string(bytesOf('1', maxHerdrPaneIDLen)), false},
 	} {

--- a/core/adapters/inbound/agents/pi/herdrhint_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhint_test.go
@@ -80,6 +80,11 @@ func TestConfinedHerdrSocketPathRejects(t *testing.T) {
 	// confinement written as a bare string prefix.
 	sibling := listenAt(t, filepath.Join(filepath.Dir(root), "herdrevil", "herdr.sock"))
 
+	// CodeQL recognizes an inline ".." check as the taint barrier for the
+	// Lstat sink. Pin that deliberately narrower accepted alphabet here so the
+	// static-analysis guard cannot disappear as an apparent no-op.
+	doubleDot := listenAt(t, filepath.Join(root, "sessions", "named..session", "herdr.sock"))
+
 	link := filepath.Join(root, "sessions", "linked", "herdr.sock")
 	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -105,6 +110,7 @@ func TestConfinedHerdrSocketPathRejects(t *testing.T) {
 			"an unclean path must be rejected rather than normalised into an acceptable one"},
 		{"outside the root", outside, "a real socket is not a herdr socket"},
 		{"sibling prefix", sibling, "…/herdrevil/ is not inside …/herdr/"},
+		{"double dot", doubleDot, "a sink-local traversal guard rejects every double-dot spelling"},
 		{"symlink out", link, "Lstat, not Stat: the link itself is not a socket"},
 		{"not a socket", plainFile, "a regular file named herdr.sock"},
 		{"wrong name", filepath.Join(root, "sessions", "f", "other.sock"), "one accepted file per directory"},

--- a/core/adapters/inbound/agents/pi/herdrhint_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhint_test.go
@@ -1,0 +1,188 @@
+// herdrhint_test.go grades the confinement, not the plumbing. The hint
+// arrives on a local, unauthenticated endpoint and the socket it names is
+// afterwards dialed and scanned for the process that holds the pane's client
+// log open, so "which paths are accepted" is the whole security surface of
+// #1936 — every case below is one way a local process could otherwise choose
+// which window irrlicht's click-to-focus raises.
+package pi
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// shortHerdrRoot returns a herdr config root short enough that a unix socket
+// can be bound inside it.
+//
+// Not t.TempDir(): sun_path is 104 bytes on darwin and t.TempDir() builds its
+// path from the test's own name under /var/folders/..., so the more
+// descriptively a test is named the sooner binding fails with EINVAL. The same
+// constraint processlifecycle's shortTempDir documents, met the same way.
+func shortHerdrRoot(t *testing.T) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "irrpihint")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	root := filepath.Join(base, "herdr")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	prev := herdrConfigDirFn
+	herdrConfigDirFn = func() string { return root }
+	t.Cleanup(func() { herdrConfigDirFn = prev })
+	return root
+}
+
+// listenAt binds a unix socket at path, creating its parent, and returns path.
+func listenAt(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	return path
+}
+
+// TestConfinedHerdrSocketPathAcceptsHerdrsOwnLayout covers both spellings the
+// layout has — the default session's socket in the root itself, and a named
+// session's one directory down. Rejecting either would make the confinement a
+// silent disable of the feature for half the users rather than a guard.
+func TestConfinedHerdrSocketPathAcceptsHerdrsOwnLayout(t *testing.T) {
+	root := shortHerdrRoot(t)
+	for _, path := range []string{
+		listenAt(t, filepath.Join(root, "herdr.sock")),
+		listenAt(t, filepath.Join(root, "sessions", "f", "herdr.sock")),
+	} {
+		if got := confinedHerdrSocketPath(path); got != path {
+			t.Errorf("confinedHerdrSocketPath(%q) = %q, want it accepted", path, got)
+		}
+	}
+}
+
+func TestConfinedHerdrSocketPathRejects(t *testing.T) {
+	root := shortHerdrRoot(t)
+	good := listenAt(t, filepath.Join(root, "sessions", "f", "herdr.sock"))
+
+	// A socket that is real, and outside the root. The symlink case below
+	// points here, which is what makes that case a genuine escape attempt
+	// rather than a broken link.
+	outside := listenAt(t, filepath.Join(filepath.Dir(root), "elsewhere", "herdr.sock"))
+
+	// A directory whose name merely starts with the root's. Catches a
+	// confinement written as a bare string prefix.
+	sibling := listenAt(t, filepath.Join(filepath.Dir(root), "herdrevil", "herdr.sock"))
+
+	link := filepath.Join(root, "sessions", "linked", "herdr.sock")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	plainFile := filepath.Join(root, "sessions", "plain", "herdr.sock")
+	if err := os.MkdirAll(filepath.Dir(plainFile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(plainFile, nil, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, path, why string
+	}{
+		{"empty", "", "nothing to confine"},
+		{"relative", "herdr.sock", "a relative path is resolved against whatever the daemon's cwd happens to be"},
+		{"traversal", filepath.Join(root, "sessions", "..", "..", "elsewhere", "herdr.sock"),
+			"an unclean path must be rejected rather than normalised into an acceptable one"},
+		{"outside the root", outside, "a real socket is not a herdr socket"},
+		{"sibling prefix", sibling, "…/herdrevil/ is not inside …/herdr/"},
+		{"symlink out", link, "Lstat, not Stat: the link itself is not a socket"},
+		{"not a socket", plainFile, "a regular file named herdr.sock"},
+		{"wrong name", filepath.Join(root, "sessions", "f", "other.sock"), "one accepted file per directory"},
+		{"missing", filepath.Join(root, "sessions", "nope", "herdr.sock"), "nothing is there"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := confinedHerdrSocketPath(tc.path); got != "" {
+				t.Errorf("confinedHerdrSocketPath(%q) = %q, want rejected — %s", tc.path, got, tc.why)
+			}
+		})
+	}
+
+	// The guard reads something rather than rejecting everything: if this
+	// stopped passing, every case above would still pass and mean nothing.
+	if confinedHerdrSocketPath(good) != good {
+		t.Fatal("the control case was rejected too, so the rejections above are not " +
+			"evidence of anything")
+	}
+}
+
+// TestConfinedHerdrSocketPathWithoutARoot pins the degradation direction: a
+// machine whose home directory cannot be determined accepts nothing rather
+// than falling back to a bare-name check.
+func TestConfinedHerdrSocketPathWithoutARoot(t *testing.T) {
+	prev := herdrConfigDirFn
+	herdrConfigDirFn = func() string { return "" }
+	t.Cleanup(func() { herdrConfigDirFn = prev })
+
+	if got := confinedHerdrSocketPath("/anywhere/herdr.sock"); got != "" {
+		t.Errorf("accepted %q with no root to confine to", got)
+	}
+}
+
+func TestValidHerdrPaneID(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"w1:p2", true},
+		{"w10:p3", true},
+		{"pane_1", true},
+		{"pane-1", true},
+		{"", false},
+		{"w1 p2", false},            // whitespace
+		{"w1;p2", false},            // shell metacharacter
+		{"../../etc/passwd", false}, // path-shaped
+		{"w1:p2\n", false},          // the JSON-RPC framing is newline-delimited
+		{string(make([]byte, maxHerdrPaneIDLen)), false}, // NULs, and at the ceiling
+		{"w" + string(bytesOf('1', maxHerdrPaneIDLen)), false},
+	} {
+		if got := validHerdrPaneID(tc.in); got != tc.want {
+			t.Errorf("validHerdrPaneID(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestHerdrPaneHintFromNeedsBothHalves pins that neither half is usable alone:
+// the socket says which server was meant, the pane says which pane on it.
+func TestHerdrPaneHintFromNeedsBothHalves(t *testing.T) {
+	root := shortHerdrRoot(t)
+	sock := listenAt(t, filepath.Join(root, "herdr.sock"))
+
+	if _, ok := herdrPaneHintFrom("w1:p1", ""); ok {
+		t.Error("accepted a pane with no socket; the address exists on every running server")
+	}
+	if _, ok := herdrPaneHintFrom("", sock); ok {
+		t.Error("accepted a socket with no pane")
+	}
+	hint, ok := herdrPaneHintFrom("w1:p1", sock)
+	if !ok || hint.paneID != "w1:p1" || hint.socketPath != sock {
+		t.Errorf("herdrPaneHintFrom = %+v, %v; want the pair accepted", hint, ok)
+	}
+}
+
+func bytesOf(c byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = c
+	}
+	return b
+}

--- a/core/adapters/inbound/agents/pi/herdrhint_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhint_test.go
@@ -174,8 +174,14 @@ func TestHerdrPaneHintFromNeedsBothHalves(t *testing.T) {
 		t.Error("accepted a socket with no pane")
 	}
 	hint, ok := herdrPaneHintFrom("w1:p1", sock)
-	if !ok || hint.paneID != "w1:p1" || hint.socketPath != sock {
-		t.Errorf("herdrPaneHintFrom = %+v, %v; want the pair accepted", hint, ok)
+	if !ok {
+		t.Fatal("refused a pane and a socket that are both valid")
+	}
+	if hint.paneID != "w1:p1" {
+		t.Errorf("paneID = %q, want w1:p1", hint.paneID)
+	}
+	if hint.socketPath != sock {
+		t.Errorf("socketPath = %q, want %q", hint.socketPath, sock)
 	}
 }
 

--- a/core/adapters/inbound/agents/pi/herdrhintdispatch_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhintdispatch_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -70,10 +71,8 @@ func TestHerdrPaneIsDispatchedBeforeTheTurnEnd(t *testing.T) {
 
 	post(t, h, herdrPayload(tp, HookEventAgentSettled, "w1:p1", sock))
 
-	got := target.dispatchOrder()
-	want := []string{"pane", "stop"}
-	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
-		t.Errorf("dispatch order %v, want %v", got, want)
+	if got := strings.Join(target.dispatchOrder(), ","); got != "pane,stop" {
+		t.Errorf("dispatch order %q, want \"pane,stop\"", got)
 	}
 }
 

--- a/core/adapters/inbound/agents/pi/herdrhintdispatch_test.go
+++ b/core/adapters/inbound/agents/pi/herdrhintdispatch_test.go
@@ -1,0 +1,141 @@
+// herdrhintdispatch_test.go covers the receiver's half of #1936: which
+// payloads reach HandleHerdrPaneHint, and what a rejected one does to the
+// turn-end signal riding in the same request.
+//
+// The confinement itself is graded in herdrhint_test.go. What is asserted here
+// is that the receiver applies it, and that failing it is quiet rather than
+// fatal — a bad pane must never cost the session its lifecycle signal, which
+// is the whole reason the two are separate dispatches instead of one payload.
+package pi
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+)
+
+// herdrPayload renders a body with the two extra fields the extension sends
+// when it is running inside herdr.
+func herdrPayload(transcriptPath, event, paneID, socketPath string) string {
+	body, err := json.Marshal(piHookPayload{
+		HookEventName:   event,
+		TranscriptPath:  transcriptPath,
+		HerdrPaneID:     paneID,
+		HerdrSocketPath: socketPath,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+func TestAgentSettledHook_DispatchesAConfinedHerdrPane(t *testing.T) {
+	root := piSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-herdr")
+	sock := listenAt(t, filepath.Join(shortHerdrRoot(t), "sessions", "f", "herdr.sock"))
+	h, target := newReceiver(t)
+
+	rec := post(t, h, herdrPayload(tp, HookEventAgentSettled, "w1:p2", sock))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	panes := target.panes()
+	if len(panes) != 1 {
+		t.Fatalf("HandleHerdrPaneHint called %d times, want 1", len(panes))
+	}
+	if panes[0].sessionID != "sess-herdr" {
+		t.Errorf("sessionID = %q, want the transcript filename stem — the pane is "+
+			"attributed the same way every other pi hook is", panes[0].sessionID)
+	}
+	if panes[0].paneID != "w1:p2" || panes[0].socketPath != sock {
+		t.Errorf("dispatched %q on %q, want w1:p2 on %q", panes[0].paneID, panes[0].socketPath, sock)
+	}
+	if len(target.stops()) != 1 {
+		t.Errorf("HandleStopHook called %d times, want 1 — the pane rides along with "+
+			"the turn-end signal, it does not replace it", len(target.stops()))
+	}
+}
+
+// TestHerdrPaneIsDispatchedBeforeTheTurnEnd pins the ordering serveHookRequest
+// documents. HandleStopHook drives a classify pass that pushes the session, so
+// a pane adopted after it would not be in that push and the app would show the
+// repair one turn late.
+func TestHerdrPaneIsDispatchedBeforeTheTurnEnd(t *testing.T) {
+	root := piSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-order")
+	sock := listenAt(t, filepath.Join(shortHerdrRoot(t), "herdr.sock"))
+	h, target := newReceiver(t)
+
+	post(t, h, herdrPayload(tp, HookEventAgentSettled, "w1:p1", sock))
+
+	got := target.dispatchOrder()
+	want := []string{"pane", "stop"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("dispatch order %v, want %v", got, want)
+	}
+}
+
+// TestRejectedHerdrPaneStillDeliversTheTurnEnd is the failure-mode assertion.
+// Every reason a pane can be refused is a reason to store nothing, and none of
+// them is a reason to drop the lifecycle event the same request carries.
+func TestRejectedHerdrPaneStillDeliversTheTurnEnd(t *testing.T) {
+	confinedRoot := shortHerdrRoot(t)
+	outside := listenAt(t, filepath.Join(filepath.Dir(confinedRoot), "elsewhere", "herdr.sock"))
+	good := listenAt(t, filepath.Join(confinedRoot, "herdr.sock"))
+
+	for _, tc := range []struct {
+		name, paneID, socketPath string
+	}{
+		{"no herdr at all", "", ""},
+		{"socket outside herdr's tree", "w1:p1", outside},
+		{"socket that is not there", "w1:p1", filepath.Join(confinedRoot, "gone", "herdr.sock")},
+		{"pane that is not pane-shaped", "w1:p1; rm -rf /", good},
+		{"pane with no socket", "w1:p1", ""},
+		{"socket with no pane", "", good},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := piSessionRoot(t)
+			tp := writeSessionTranscript(t, root, "sess-rejected")
+			h, target := newReceiver(t)
+
+			rec := post(t, h, herdrPayload(tp, HookEventAgentSettled, tc.paneID, tc.socketPath))
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 — a refused pane is not a bad request, "+
+					"it is a session that has none", rec.Code)
+			}
+			if n := len(target.panes()); n != 0 {
+				t.Errorf("HandleHerdrPaneHint called %d times for %q on %q", n, tc.paneID, tc.socketPath)
+			}
+			if n := len(target.stops()); n != 1 {
+				t.Errorf("HandleStopHook called %d times, want 1: refusing the pane must "+
+					"not cost the session its turn-end signal", n)
+			}
+		})
+	}
+}
+
+// TestHerdrPaneNeedsTheHooksConsent pins that the pane goes through the same
+// gates the rest of the payload does rather than around them. It is dispatched
+// from inside the event switch, so a receiver that is not allowed to act on
+// the request cannot act on the pane either.
+func TestHerdrPaneNeedsTheHooksConsent(t *testing.T) {
+	root := piSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-denied")
+	sock := listenAt(t, filepath.Join(shortHerdrRoot(t), "herdr.sock"))
+
+	target := &mockTarget{}
+	denied := keyedGate{PermissionKeyHooks: false, PermissionKeyTranscripts: true}
+	h := NewHookHandler(target, denied, mockLogger{})
+
+	rec := post(t, h, herdrPayload(tp, HookEventAgentSettled, "w1:p1", sock))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want a quiet 200", rec.Code)
+	}
+	if n := len(target.panes()); n != 0 {
+		t.Errorf("HandleHerdrPaneHint called %d times without the hooks consent", n)
+	}
+}

--- a/core/adapters/inbound/agents/pi/hooks.go
+++ b/core/adapters/inbound/agents/pi/hooks.go
@@ -104,14 +104,42 @@ type piHookPayload struct {
 	// TranscriptPath is confined and then overwritten with the confined
 	// spelling by DecodeConfined — see NewHookHandler.
 	TranscriptPath string `json:"transcript_path"`
+
+	// HerdrPaneID and HerdrSocketPath are the pane the extension read out of
+	// its OWN process environment (#1936) — the only place they are legible
+	// for a Node agent, see herdrhint.go. Both are omitempty because the
+	// extension omits them for a session that is not running under herdr,
+	// which is the common case and must keep sending today's body exactly.
+	//
+	// Neither is confined by DecodeConfined: that confiner is built for the
+	// transcript tree this adapter owns (ConfinerForSource), and a herdr
+	// socket is neither under it nor a .jsonl. herdrPaneHintFrom is their
+	// confinement, and serveHookRequest applies it before the values leave
+	// this package.
+	HerdrPaneID     string `json:"herdr_pane_id,omitempty"`
+	HerdrSocketPath string `json:"herdr_socket_path,omitempty"`
 }
 
 // HookTarget is the interface the handler calls into. Satisfied by
 // *services.SessionDetector without importing the services package — the
-// same agent-agnostic surface every other receiver uses, narrowed to the one
-// method this adapter's single installed event needs.
+// same agent-agnostic surface every other receiver uses, narrowed to the
+// methods this adapter's single installed event needs.
+//
+// It is the one receiver interface with a second method, and that asymmetry
+// is the point rather than drift: HandleStopHook is the lifecycle signal every
+// sibling receiver sends, while HandleHerdrPaneHint carries a fact about the
+// process that only pi can observe. Folding the pane into HandleStopHook's
+// signature would put two parameters no other adapter can ever fill onto the
+// shared surface, and lose the distinction that the daemon gates them on
+// different consents.
 type HookTarget interface {
 	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+
+	// HandleHerdrPaneHint records the herdr pane the session reported for
+	// itself. Both arguments are already validated and confined; the target
+	// gates the capture on the launcher consent and decides whether the
+	// session still needs a pane.
+	HandleHerdrPaneHint(sessionID, paneID, socketPath string)
 }
 
 // ConsentGranter is the shared consent check every JSON-hook receiver gates
@@ -193,6 +221,12 @@ func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.
 	switch payload.HookEventName {
 	case HookEventAgentSettled:
 		log.LogInfo(logComponentHookReceiver, sessionID, "received agent_settled")
+		// Before the lifecycle signal, so that the classify pass
+		// HandleStopHook kicks off already sees the repaired launcher and the
+		// push it produces carries it. Ordered rather than concurrent because
+		// both touch the same session, and the cost is one bounded
+		// load-modify-save that runs only for a session actually inside herdr.
+		dispatchHerdrPaneHint(target, sessionID, payload)
 		target.HandleStopHook(sessionID, transcriptPath, "", false)
 	default:
 		// Unrecognized hook event — accept but ignore, counted per name and
@@ -203,6 +237,23 @@ func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.
 		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+// dispatchHerdrPaneHint forwards a validated pane to the target, and does
+// nothing at all when the payload carries none or carries one that does not
+// confine.
+//
+// Split out of serveHookRequest so that function keeps one line per step, and
+// so the "a bad hint is silently no hint" rule lives in one place: there is no
+// log line and no error either way, because the overwhelmingly common reason
+// both fields are empty is a pi session not running under herdr, and a
+// receiver that logged that would log it once per turn for every such session.
+func dispatchHerdrPaneHint(target HookTarget, sessionID string, payload piHookPayload) {
+	hint, ok := herdrPaneHintFrom(payload.HerdrPaneID, payload.HerdrSocketPath)
+	if !ok {
+		return
+	}
+	target.HandleHerdrPaneHint(sessionID, hint.paneID, hint.socketPath)
 }
 
 // sessionIDFromTranscriptPath derives the session ID the SAME way

--- a/core/adapters/inbound/agents/pi/hooks_test.go
+++ b/core/adapters/inbound/agents/pi/hooks_test.go
@@ -20,17 +20,46 @@ type stopCall struct {
 	waitingCue                                   bool
 }
 
+// paneCall records one HandleHerdrPaneHint dispatch (#1936).
+type paneCall struct {
+	sessionID, paneID, socketPath string
+}
+
 type mockTarget struct {
 	mu        sync.Mutex
 	stopCalls []stopCall
+	paneCalls []paneCall
+	// order names each dispatch as it happens. One request drives both
+	// methods, and which runs first is load-bearing rather than incidental —
+	// see serveHookRequest — so the sequence has to be observable.
+	order []string
 }
 
 func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+	m.order = append(m.order, "stop")
 }
 
+func (m *mockTarget) HandleHerdrPaneHint(sessionID, paneID, socketPath string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.paneCalls = append(m.paneCalls, paneCall{sessionID, paneID, socketPath})
+	m.order = append(m.order, "pane")
+}
+
+func (m *mockTarget) dispatchOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.order...)
+}
+
+// totalCalls counts the LIFECYCLE dispatches only. The pane report rides along
+// on the same request and is not one: every existing contract that asserts a
+// dispatch count is asserting how many turn-end signals a body produced, and
+// folding a second kind into that number would silently change what those
+// contracts test.
 func (m *mockTarget) totalCalls() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -41,6 +70,12 @@ func (m *mockTarget) stops() []stopCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]stopCall(nil), m.stopCalls...)
+}
+
+func (m *mockTarget) panes() []paneCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]paneCall(nil), m.paneCalls...)
 }
 
 // keyedGate pins a fixed permission combination for a one-off test. For a

--- a/core/adapters/inbound/agents/processlifecycle/herdrpane.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrpane.go
@@ -329,11 +329,32 @@ func readResult(conn net.Conn, out any) bool {
 // The socket path is adopted alongside the pane id because they are one fact.
 // clientHostFor needs both to reach the herdr client, and a pane id without its
 // socket would name the pane while leaving #1350's focus path unable to use it.
+//
+// Two sources, tried in order of how directly each knows the answer (#1936):
+//
+//   - What the process reported about ITSELF, if it can. That is the pane
+//     rather than a pane whose process list matches, and confirming it is one
+//     request against a known socket and pane. See herdrselfreport.go.
+//   - Otherwise the scan, which asks every herdr server for its panes and
+//     narrows by working directory. It is what covers every agent that runs no
+//     irrlicht extension, which today is every Node agent except pi.
+//
+// Only pi can take the first branch, so the second is not a fallback in the
+// sense of a rare path — it stays the ordinary one. What the first removes is
+// the scan's two failure modes for the one agent that can avoid them: a
+// working directory that no longer matches the pane's, and more panes sharing
+// a directory than maxPaneCandidates admits.
 func adoptHerdrPane(l *session.Launcher, pid int) {
 	if l == nil || l.HerdrPaneID != "" {
 		return
 	}
-	pane, socketPath, probed := herdrPaneForPID(context.Background(), pid, cwdForPaneMatch(pid))
+	ctx := context.Background()
+	if pane, socketPath, ok := selfReportedPane(ctx, pid); ok {
+		l.HerdrPaneID = pane
+		l.HerdrSocketPath = socketPath
+		return
+	}
+	pane, socketPath, probed := herdrPaneForPID(ctx, pid, cwdForPaneMatch(pid))
 	if !probed || pane == "" {
 		return
 	}

--- a/core/adapters/inbound/agents/processlifecycle/herdrselfreport.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrselfreport.go
@@ -73,19 +73,43 @@ var rememberedHerdrPanes = struct {
 // Both fields are required and are stored as one: they are the pair
 // clientHostFor needs, and half of it addresses nothing.
 func RememberHerdrPane(pid int, paneID, socketPath string) {
-	if pid <= 0 || paneID == "" || socketPath == "" {
+	if !completeHerdrReport(pid, paneID, socketPath) {
 		return
 	}
 	rememberedHerdrPanes.mu.Lock()
 	defer rememberedHerdrPanes.mu.Unlock()
-	if _, known := rememberedHerdrPanes.entries[pid]; !known &&
-		len(rememberedHerdrPanes.entries) >= maxRememberedPanes {
-		dropDeadHerdrReportsLocked()
-		if len(rememberedHerdrPanes.entries) >= maxRememberedPanes {
-			return
-		}
+	if !roomForHerdrReportLocked(pid) {
+		return
 	}
 	rememberedHerdrPanes.entries[pid] = herdrSelfReport{paneID: paneID, socketPath: socketPath}
+}
+
+// completeHerdrReport reports whether a report names everything it needs to.
+func completeHerdrReport(pid int, paneID, socketPath string) bool {
+	if pid <= 0 {
+		return false
+	}
+	if paneID == "" {
+		return false
+	}
+	return socketPath != ""
+}
+
+// roomForHerdrReportLocked reports whether pid's entry can be written, evicting
+// dead processes first if the map is at its cap. Callers hold the mutex.
+//
+// A pid already in the map always has room — it is an update, not growth, and
+// the extension re-reports at every turn end, so the ordinary case must not
+// walk the map toward its cap on its own.
+func roomForHerdrReportLocked(pid int) bool {
+	if _, known := rememberedHerdrPanes.entries[pid]; known {
+		return true
+	}
+	if len(rememberedHerdrPanes.entries) < maxRememberedPanes {
+		return true
+	}
+	dropDeadHerdrReportsLocked()
+	return len(rememberedHerdrPanes.entries) < maxRememberedPanes
 }
 
 // dropDeadHerdrReportsLocked removes every entry whose process is gone. Called

--- a/core/adapters/inbound/agents/processlifecycle/herdrselfreport.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrselfreport.go
@@ -1,0 +1,153 @@
+// herdrselfreport.go holds the herdr pane a process reported about ITSELF,
+// for the read that cannot see it from outside (#1936).
+//
+// # Why a process can know something the daemon cannot
+//
+// herdrpane.go's header states the constraint this file relaxes: for a Node
+// agent that sets process.title, sysctl(kern.procargs2) returns an empty
+// environment, so $HERDR_PANE_ID is invisible from outside the process. It is
+// not invisible from INSIDE — irrlicht already runs code there, because the
+// only way to observe pi's lifecycle at all is an extension module
+// (agents/pi/extension.js). That extension now reads the two herdr variables
+// out of its own process.env and posts them with the turn-end payload it was
+// already sending.
+//
+// # Why it is still verified rather than believed
+//
+// A self-report is better evidence than herdrPaneForPID's scan — it is the
+// pane, not a pane whose process list happens to name this pid — but it is
+// evidence about a MOMENT, and this map is keyed by pid, which the kernel
+// reuses. So the rule herdrpane.go established is kept exactly: cwd narrows,
+// pid decides. A remembered pane is confirmed with one pane.process_info call
+// against the remembered socket before it is used, and that is also what makes
+// eviction a non-problem — a stale entry cannot be believed, it can only be
+// dropped.
+//
+// The confirmation is one request on a known socket for a known pane, against
+// herdrPaneForPID's pane.list plus up to maxPaneCandidates process_info calls.
+// That difference, and not the correctness, is the reason to prefer the
+// self-report: the answer is the same, the work to reach it is not.
+package processlifecycle
+
+import (
+	"context"
+	"sync"
+)
+
+// maxRememberedPanes bounds the map. Entries are one per agent process
+// currently reporting itself, so the steady state is the number of live pi
+// sessions — single digits on the machine #1936 was measured on. The cap is a
+// guard against unbounded growth if eviction were ever to stop working, not a
+// budget anyone is expected to reach, and reaching it costs a self-report
+// rather than a pane: adoptHerdrPane falls through to the scan.
+const maxRememberedPanes = 512
+
+// herdrSelfReport is one process's own answer to "which pane am I in".
+type herdrSelfReport struct {
+	paneID     string
+	socketPath string
+}
+
+// rememberedHerdrPanes is the pid → self-report map. Package-level mutable
+// state with its own mutex, matching clientHostMemo in osutil_darwin.go: the
+// writer is the hook receiver's goroutine and the readers are PID discovery
+// and the liveness sweep, so it is reached from several goroutines by
+// construction.
+//
+// It carries no TTL, and that is the difference from clientHostMemo rather
+// than an omission. #1544's rule is that a memo's lifetime follows its
+// subject's: an attached client changes by the second, so that memo expires,
+// while the pane a process is in is fixed for that process's life. Expiring
+// this one would drop a valid pane between two turns of a quiet session, which
+// is exactly the session that has nothing else to re-report it.
+var rememberedHerdrPanes = struct {
+	mu      sync.Mutex
+	entries map[int]herdrSelfReport
+}{entries: map[int]herdrSelfReport{}}
+
+// RememberHerdrPane records the pane pid reported for itself. Exported because
+// the caller is the daemon wiring (cmd/irrlichd), which routes it here from
+// the pi hook receiver under the launcher consent — the same gate every other
+// launcher-identity read is taken under.
+//
+// Both fields are required and are stored as one: they are the pair
+// clientHostFor needs, and half of it addresses nothing.
+func RememberHerdrPane(pid int, paneID, socketPath string) {
+	if pid <= 0 || paneID == "" || socketPath == "" {
+		return
+	}
+	rememberedHerdrPanes.mu.Lock()
+	defer rememberedHerdrPanes.mu.Unlock()
+	if _, known := rememberedHerdrPanes.entries[pid]; !known &&
+		len(rememberedHerdrPanes.entries) >= maxRememberedPanes {
+		dropDeadHerdrReportsLocked()
+		if len(rememberedHerdrPanes.entries) >= maxRememberedPanes {
+			return
+		}
+	}
+	rememberedHerdrPanes.entries[pid] = herdrSelfReport{paneID: paneID, socketPath: socketPath}
+}
+
+// dropDeadHerdrReportsLocked removes every entry whose process is gone. Called
+// only when the map is at its cap, because IsAlive is a signal-0 syscall per
+// entry and the ordinary path must not pay a scan.
+//
+// Liveness rather than age is the right eviction key for the same reason the
+// map has no TTL: an entry is stale when its process ends, and nothing else
+// about elapsed time says so.
+func dropDeadHerdrReportsLocked() {
+	for pid := range rememberedHerdrPanes.entries {
+		if !IsAlive(pid) {
+			delete(rememberedHerdrPanes.entries, pid)
+		}
+	}
+}
+
+// forgetHerdrPane drops pid's entry. Called when a report is CONTRADICTED —
+// the server answered and the pane does not hold this pid — never when it
+// merely could not be checked.
+func forgetHerdrPane(pid int) {
+	rememberedHerdrPanes.mu.Lock()
+	defer rememberedHerdrPanes.mu.Unlock()
+	delete(rememberedHerdrPanes.entries, pid)
+}
+
+// rememberedHerdrPane returns pid's self-report, if any.
+func rememberedHerdrPane(pid int) (herdrSelfReport, bool) {
+	rememberedHerdrPanes.mu.Lock()
+	defer rememberedHerdrPanes.mu.Unlock()
+	report, ok := rememberedHerdrPanes.entries[pid]
+	return report, ok
+}
+
+// selfReportedPane returns the pane pid reported for itself, confirmed against
+// the herdr server, or ok=false when there is nothing usable.
+//
+// The three outcomes are deliberately not two:
+//
+//   - No report: this process never told us, so there is nothing to confirm.
+//   - Reported and confirmed: the pane holds this pid. Used.
+//   - Reported and CONTRADICTED — the server answered, and the pane's process
+//     list does not name pid. That is the pid-reuse case, and the entry is
+//     dropped so it cannot be offered again.
+//
+// A server that does not answer is none of those: the report keeps its entry
+// and this returns ok=false, so the caller falls through to the scan exactly
+// as it would have without a report at all. Forgetting on an unanswered probe
+// would discard good evidence on the strength of a probe that never ran, which
+// is #1485's mistake in a different map.
+func selfReportedPane(ctx context.Context, pid int) (paneID, socketPath string, ok bool) {
+	report, known := rememberedHerdrPane(pid)
+	if !known {
+		return "", "", false
+	}
+	info, answered := herdrPaneProcessInfo(ctx, report.socketPath, report.paneID)
+	if !answered {
+		return "", "", false
+	}
+	if !processInfoNames(info, pid) {
+		forgetHerdrPane(pid)
+		return "", "", false
+	}
+	return report.paneID, report.socketPath, true
+}

--- a/core/adapters/inbound/agents/processlifecycle/herdrselfreport_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrselfreport_test.go
@@ -1,0 +1,214 @@
+package processlifecycle
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// resetHerdrSelfReports empties the package-level map around one test, both
+// before and after. Before as well as after, because a test that fails partway
+// leaves entries behind and the next one would then be reading state it did
+// not write — the failure mode a shared map introduces, and the only reason
+// this helper exists.
+func resetHerdrSelfReports(t *testing.T) {
+	t.Helper()
+	clear := func() {
+		rememberedHerdrPanes.mu.Lock()
+		defer rememberedHerdrPanes.mu.Unlock()
+		rememberedHerdrPanes.entries = map[int]herdrSelfReport{}
+	}
+	clear()
+	t.Cleanup(clear)
+}
+
+// deadPID is above darwin's default pid ceiling (kern.maxproc caps pids at
+// 99999), so IsAlive's signal-0 probe answers ESRCH for it without the test
+// having to spawn and reap anything.
+const deadPID = 4_000_000
+
+// TestSelfReportedPaneSkipsTheScan is #1936's point, stated as cost rather
+// than as correctness: both routes reach the same pane, and only one of them
+// enumerates every pane on the server to get there.
+func TestSelfReportedPaneSkipsTheScan(t *testing.T) {
+	resetHerdrSelfReports(t)
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w1:p1": {cwd: "/work/a", foregroundCWD: "/work/a", shellPID: 100, foreground: []int{101}},
+		"w1:p2": {cwd: "/work/b", foregroundCWD: "/work/b", shellPID: 200, foreground: []int{201}},
+	}}
+	sock := f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	RememberHerdrPane(201, "w1:p2", sock)
+
+	l := &session.Launcher{}
+	adoptHerdrPane(l, 201)
+
+	if l.HerdrPaneID != "w1:p2" || l.HerdrSocketPath != sock {
+		t.Fatalf("adopted pane %q on %q, want w1:p2 on %q", l.HerdrPaneID, l.HerdrSocketPath, sock)
+	}
+	if n := f.methodCalls("pane.list"); n != 0 {
+		t.Errorf("pane.list called %d times — a confirmed self-report names the pane, "+
+			"so enumerating the server's panes is exactly the work it exists to avoid", n)
+	}
+	if n := f.methodCalls("pane.process_info"); n != 1 {
+		t.Errorf("pane.process_info called %d times, want exactly 1: the report is "+
+			"confirmed on the pane it names and no other", n)
+	}
+}
+
+// TestSelfReportedPaneIsConfirmedNotBelieved is the invariant herdrpane.go
+// established — cwd narrows, pid decides — applied to a source that could
+// otherwise bypass it. A report whose pane no longer holds the process must
+// not be used, however authoritative its origin was when it was made.
+func TestSelfReportedPaneIsConfirmedNotBelieved(t *testing.T) {
+	resetHerdrSelfReports(t)
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w1:p1": {cwd: "/work/a", foregroundCWD: "/work/a", shellPID: 100, foreground: []int{101}},
+		"w1:p2": {cwd: "/work/b", foregroundCWD: "/work/b", shellPID: 200, foreground: []int{201}},
+	}}
+	sock := f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	// pid 101 lives in w1:p1; the stale entry claims w1:p2. This is the shape
+	// pid reuse produces: the report was true for whoever held 101 before.
+	RememberHerdrPane(101, "w1:p2", sock)
+
+	pane, gotSock, ok := selfReportedPane(context.Background(), 101)
+	if ok {
+		t.Fatalf("used a contradicted report (%q on %q); the pane's process list does "+
+			"not name this pid", pane, gotSock)
+	}
+	if _, still := rememberedHerdrPane(101); still {
+		t.Error("a report the server actively contradicted is still remembered — it " +
+			"would be re-offered, and re-rejected, on every read for this pid")
+	}
+}
+
+// TestSelfReportedPaneKeepsAReportItCouldNotCheck is the other half of the
+// same tri-state, and the half that is easy to get wrong: a socket that does
+// not answer is not evidence against the report. Dropping the entry here would
+// discard good information on the strength of a probe that never ran — #1485's
+// defect, in a different map.
+func TestSelfReportedPaneKeepsAReportItCouldNotCheck(t *testing.T) {
+	resetHerdrSelfReports(t)
+	dir := shortTempDir(t)
+	useSessionsDir(t, dir)
+
+	// A path with no listener behind it: dialing fails, so no server answers.
+	sock := filepath.Join(dir, "gone", "herdr.sock")
+	RememberHerdrPane(201, "w1:p2", sock)
+
+	if _, _, ok := selfReportedPane(context.Background(), 201); ok {
+		t.Fatal("reported a pane on the strength of a probe that could not run")
+	}
+	report, still := rememberedHerdrPane(201)
+	if !still {
+		t.Fatal("dropped the report because the server was unreachable; the next " +
+			"read, when it is reachable again, now has nothing to confirm")
+	}
+	if report.paneID != "w1:p2" || report.socketPath != sock {
+		t.Errorf("kept %+v, want the report as made", report)
+	}
+}
+
+// TestSelfReportedPaneFallsBackToTheScan pins that a contradicted report costs
+// the session nothing: adoptHerdrPane still resolves the pane the ordinary
+// way, so the self-report can only ever add an answer, never remove one.
+func TestSelfReportedPaneFallsBackToTheScan(t *testing.T) {
+	resetHerdrSelfReports(t)
+	dir := shortTempDir(t)
+	f := &fakeHerdr{t: t, panes: map[string]fakePane{
+		"w1:p1": {cwd: "/work/a", foregroundCWD: "/work/a", shellPID: 100, foreground: []int{101}},
+		"w1:p2": {cwd: "/work/b", foregroundCWD: "/work/b", shellPID: 200, foreground: []int{201}},
+	}}
+	sock := f.start(dir, "factory")
+	useSessionsDir(t, dir)
+
+	RememberHerdrPane(101, "w1:p2", sock) // wrong pane for this pid
+
+	l := &session.Launcher{}
+	adoptHerdrPane(l, 101)
+
+	if l.HerdrPaneID != "w1:p1" {
+		t.Fatalf("adopted %q, want w1:p1 — the scan should have found the pane the "+
+			"discarded report failed to name", l.HerdrPaneID)
+	}
+}
+
+func TestRememberHerdrPaneRejectsHalfAReport(t *testing.T) {
+	resetHerdrSelfReports(t)
+	for _, tc := range []struct {
+		name               string
+		pid                int
+		paneID, socketPath string
+	}{
+		{"no pid", 0, "w1:p1", "/tmp/herdr.sock"},
+		{"negative pid", -1, "w1:p1", "/tmp/herdr.sock"},
+		{"no pane", 42, "", "/tmp/herdr.sock"},
+		{"no socket", 42, "w1:p1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			RememberHerdrPane(tc.pid, tc.paneID, tc.socketPath)
+			if _, ok := rememberedHerdrPane(tc.pid); ok {
+				t.Errorf("stored %+v; a pane and its socket are one fact and half of "+
+					"it addresses nothing", tc)
+			}
+		})
+	}
+}
+
+// TestRememberHerdrPaneEvictsDeadProcessesAtTheCap pins the one path on which
+// the map is allowed to spend syscalls, and that reaching the cap does not
+// wedge it: entries whose process is gone make room for a live report.
+func TestRememberHerdrPaneEvictsDeadProcessesAtTheCap(t *testing.T) {
+	resetHerdrSelfReports(t)
+	for i := 0; i < maxRememberedPanes; i++ {
+		RememberHerdrPane(deadPID+i, "w1:p1", "/tmp/herdr.sock")
+	}
+	if got := rememberedCount(); got != maxRememberedPanes {
+		t.Fatalf("filled to %d entries, want %d", got, maxRememberedPanes)
+	}
+
+	RememberHerdrPane(1, "w1:p9", "/tmp/other.sock")
+
+	report, ok := rememberedHerdrPane(1)
+	if !ok {
+		t.Fatal("a full map refused a new report even though every entry in it names " +
+			"a process that no longer exists")
+	}
+	if report.paneID != "w1:p9" {
+		t.Errorf("stored %+v, want the report as made", report)
+	}
+	if got := rememberedCount(); got >= maxRememberedPanes {
+		t.Errorf("%d entries after eviction — the dead ones were not dropped", got)
+	}
+}
+
+// TestRememberHerdrPaneUpdatesInPlace covers the report arriving again for a
+// pid already known, which is the ordinary case: the extension re-reports at
+// every turn end. It must not be treated as a new entry, or a busy session
+// would walk the map toward its cap on its own.
+func TestRememberHerdrPaneUpdatesInPlace(t *testing.T) {
+	resetHerdrSelfReports(t)
+	RememberHerdrPane(42, "w1:p1", "/tmp/a/herdr.sock")
+	RememberHerdrPane(42, "w2:p3", "/tmp/b/herdr.sock")
+
+	if got := rememberedCount(); got != 1 {
+		t.Fatalf("%d entries for one pid, want 1", got)
+	}
+	report, _ := rememberedHerdrPane(42)
+	if report.paneID != "w2:p3" || report.socketPath != "/tmp/b/herdr.sock" {
+		t.Errorf("kept %+v, want the later report — a pane can move between turns", report)
+	}
+}
+
+func rememberedCount() int {
+	rememberedHerdrPanes.mu.Lock()
+	defer rememberedHerdrPanes.mu.Unlock()
+	return len(rememberedHerdrPanes.entries)
+}

--- a/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
@@ -43,7 +43,13 @@ func LauncherPermissionDeclaration() agent.Agent {
 				"overwrite their own environment as they start, so nothing above can be " +
 				"read from them at all; for those, irrlicht asks the local herdr server " +
 				"over its control socket which pane holds the process, and reads no " +
-				"other pane's contents (#1934). Focusing " +
+				"other pane's contents (#1934). One agent can answer for itself " +
+				"instead: a pi session runs an irrlicht extension, and that extension " +
+				"reads the two herdr variables from inside the process and sends them " +
+				"with its turn-end signal, so the pane is known without asking herdr " +
+				"to find it (#1936). Such a report is confirmed against herdr before " +
+				"it is used, and it is only stored while this permission is granted — " +
+				"turned off, it is discarded on arrival. Focusing " +
 				"itself only happens when you " +
 				"click a session (kitty remote control / AppleScript, additionally " +
 				"gated by macOS automation prompts). Toggling off stops the capture " +

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1559,13 +1559,36 @@ func (pm *PIDManager) AdoptSelfReportedHerdrPane(sessionID, paneID, socketPath s
 func (pm *PIDManager) launcherPaneState(sessionID string) (pid int, paneMissing bool) {
 	pm.WithSessionStateLock(func() {
 		state, err := pm.repo.Load(sessionID)
-		if err != nil || state == nil {
+		if err != nil {
+			return
+		}
+		if state == nil {
 			return
 		}
 		pid = state.PID
-		paneMissing = state.Launcher != nil && state.Launcher.HerdrPaneID == ""
+		paneMissing = paneLessLauncher(state) != nil
 	})
 	return pid, paneMissing
+}
+
+// paneLessLauncher returns state's launcher when there is one and it carries no
+// herdr pane — the single condition both halves of the self-report path decide
+// on, so they cannot come to differ about what "needs a pane" means.
+//
+// Sequential guards rather than one disjunction: the three ways to answer nil
+// are unrelated facts (no session, no launcher, a pane already resolved) and
+// only the last of them is about this feature at all.
+func paneLessLauncher(state *session.SessionState) *session.Launcher {
+	if state == nil {
+		return nil
+	}
+	if state.Launcher == nil {
+		return nil
+	}
+	if state.Launcher.HerdrPaneID != "" {
+		return nil
+	}
+	return state.Launcher
 }
 
 // applySelfReportedHerdrPane merges a read that resolved a pane into
@@ -1584,14 +1607,15 @@ func (pm *PIDManager) applySelfReportedHerdrPane(sessionID string, fresh *sessio
 	var updated *session.SessionState
 	pm.WithSessionStateLock(func() {
 		state, err := pm.repo.Load(sessionID)
-		if err != nil || state == nil || state.Launcher == nil {
+		if err != nil {
 			return
 		}
-		if state.Launcher.HerdrPaneID != "" {
+		launcher := paneLessLauncher(state)
+		if launcher == nil {
 			return
 		}
-		state.Launcher.HerdrPaneID = fresh.HerdrPaneID
-		state.Launcher.HerdrSocketPath = fresh.HerdrSocketPath
+		launcher.HerdrPaneID = fresh.HerdrPaneID
+		launcher.HerdrSocketPath = fresh.HerdrSocketPath
 		// hostKnown gates only the host adoption, exactly as
 		// applyMultiplexerHostBackfill does: a client probe that did not run
 		// yields empty host fields that mean "not looked up", and adopting them
@@ -1599,7 +1623,7 @@ func (pm *PIDManager) applySelfReportedHerdrPane(sessionID string, fresh *sessio
 		// already has (#1485). The pane itself is unconditional — it came from
 		// the process, not from the probe.
 		if hostKnown {
-			state.Launcher.AdoptHostIdentity(fresh)
+			launcher.AdoptHostIdentity(fresh)
 		}
 		// The pane may have arrived with a tty the stored launcher lacked, and
 		// BackgroundAgent.Detached is derived from it (#744/#1546).

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -53,6 +53,21 @@ type LauncherEnvReader func(pid int) (l *session.Launcher, hostKnown bool)
 // injected to preserve the hexagonal layering (#744).
 type BackgroundReader func(pid int) *session.BackgroundAgent
 
+// HerdrPaneRecorder hands the launcher reader the herdr pane a process
+// reported about ITSELF, keyed by pid (#1936).
+//
+// It is a one-way seam on purpose: this layer never reads the recorded value
+// back. The recorded pane's only consumer is the reader — the pane has to be
+// known BEFORE ReadLauncherEnv resolves the attached client, or the session
+// gets an address with no window — so recording and then re-reading through
+// LauncherEnvReader is what puts it in front of that resolution without this
+// package learning how a herdr pane is confirmed.
+//
+// Nil (tests, demo mode, a revoked launcher consent) disables the self-report
+// path entirely, and disabling it costs nothing that was not already absent:
+// the reader keeps resolving panes the way it does for every other agent.
+type HerdrPaneRecorder func(pid int, paneID, socketPath string)
+
 // PIDManager manages the process lifecycle for sessions. It discovers PIDs,
 // registers them with ProcessWatcher, handles exits, and sweeps dead processes.
 type PIDManager struct {
@@ -81,6 +96,11 @@ type PIDManager struct {
 
 	// launcherEnv reads launcher env from a PID. Optional — nil skips capture.
 	launcherEnv LauncherEnvReader
+
+	// herdrPaneRecorder forwards a session's own report of the herdr pane it
+	// runs in to the launcher reader. Optional — nil skips the self-report
+	// path (#1936).
+	herdrPaneRecorder HerdrPaneRecorder
 
 	// background reads background-agent metadata from a PID. Optional — nil
 	// skips capture (#744).
@@ -232,6 +252,13 @@ func (pm *PIDManager) SetSessionSupersededHandler(fn func(oldID, newID string)) 
 // Nil disables launcher capture.
 func (pm *PIDManager) SetLauncherEnvReader(fn LauncherEnvReader) {
 	pm.launcherEnv = fn
+}
+
+// SetHerdrPaneRecorder installs the seam that hands a session's own report of
+// its herdr pane to the launcher reader (#1936). Nil disables the self-report
+// path. Called once at startup.
+func (pm *PIDManager) SetHerdrPaneRecorder(fn HerdrPaneRecorder) {
+	pm.herdrPaneRecorder = fn
 }
 
 // SetBackgroundReader installs a reader that flags a session as a background
@@ -1447,6 +1474,140 @@ func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
 func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 	state.UpdatedAt = time.Now().Unix()
 	_ = pm.repo.Save(state)
+}
+
+// AdoptSelfReportedHerdrPane records the herdr pane sessionID reported for
+// itself and, when that session's launcher has none, repairs it on the spot
+// (#1936). paneID and socketPath are already validated and confined by the
+// receiver that decoded them.
+//
+// # Why the repair is here rather than on a sweep
+//
+// A pane-less launcher asks for nothing: launcherBackfillNeedsFor returns no
+// need for it, and refreshMultiplexerHosts skips it because
+// hostedInAMultiplexerPane is false. Both are deliberate — they are what keeps
+// a machine running no multiplexer from paying a read per session per sweep —
+// and neither should change for this. Adding a "the pane might be missing"
+// need would make needs.any() true for essentially every session on every
+// machine, which is a cost regression against exactly what that gate exists to
+// prevent (#1405, #1485, #1492).
+//
+// So the repair is driven by the event instead. A report arriving IS the cheap
+// evidence that this session is in a herdr pane, and it is the only moment at
+// which anything new can be learned, so one read is paid here and none
+// anywhere else. A machine with no herdr never reaches this function: no
+// report is ever sent.
+//
+// # Why it re-reads instead of writing the reported pane straight in
+//
+// Writing paneID onto the stored launcher would produce a session that
+// addresses a pane and has no window to raise. The host of a pane belongs to
+// the herdr CLIENT displaying it (#1350), which only ReadLauncherEnv resolves
+// — and it would stay unresolved forever after, because the periodic refresh
+// requires the fresh read to describe the same pane (SamePaneAs) and a read
+// that cannot see the pane never will. Recording first and re-reading second
+// is what puts the pane in front of that resolution.
+//
+// At most one read per report, and only for a session that is missing a pane:
+// a session that already has one records the report — so a later read, after a
+// daemon restart or a PID re-bind, is the cheap kind — and returns.
+func (pm *PIDManager) AdoptSelfReportedHerdrPane(sessionID, paneID, socketPath string) {
+	if pm.herdrPaneRecorder == nil {
+		return
+	}
+	pid, paneMissing := pm.launcherPaneState(sessionID)
+	if pid <= 0 {
+		// No PID bound yet: the hook beat process discovery. Nothing is
+		// stashed for later, because the extension re-sends the report at
+		// every turn end — the next one finds a bound session. A stash would
+		// buy one turn of latency in exchange for a map whose entries have no
+		// natural end.
+		return
+	}
+	pm.herdrPaneRecorder(pid, paneID, socketPath)
+	if !paneMissing || pm.launcherEnv == nil {
+		return
+	}
+	// Outside the lock, like every other launcher read: it can block on the
+	// herdr socket and on the client probe, and assignMu serializes PID
+	// discovery for every session.
+	fresh, hostKnown := pm.launcherEnv(pid)
+	if fresh == nil || fresh.HerdrPaneID == "" {
+		// The report did not survive confirmation against herdr — the pane no
+		// longer holds this pid, or no server answered. Either way the session
+		// keeps what it had.
+		return
+	}
+	state := pm.applySelfReportedHerdrPane(sessionID, fresh, hostKnown)
+	if state == nil {
+		return
+	}
+	pm.log.LogInfo(logComponentSessionDetector, sessionID,
+		fmt.Sprintf("herdr pane adopted from the session's own report: pane=%q host_bundle_id=%q tty=%q",
+			state.Launcher.HerdrPaneID, state.Launcher.HostBundleID, state.Launcher.TTY))
+	pm.broadcast(outbound.PushTypeUpdated, state)
+}
+
+// launcherPaneState reports sessionID's PID and whether its launcher exists
+// and is missing a herdr pane — the two facts AdoptSelfReportedHerdrPane
+// decides on, read together under the lock so they cannot disagree.
+//
+// A session with no Launcher at all reports paneMissing false rather than
+// true: there is nothing to repair yet, and captureLauncher will run the
+// ordinary read (which now consults the report just recorded) when the PID is
+// bound.
+func (pm *PIDManager) launcherPaneState(sessionID string) (pid int, paneMissing bool) {
+	pm.WithSessionStateLock(func() {
+		state, err := pm.repo.Load(sessionID)
+		if err != nil || state == nil {
+			return
+		}
+		pid = state.PID
+		paneMissing = state.Launcher != nil && state.Launcher.HerdrPaneID == ""
+	})
+	return pid, paneMissing
+}
+
+// applySelfReportedHerdrPane merges a read that resolved a pane into
+// sessionID's stored launcher, returning the updated state when something
+// changed and nil otherwise.
+//
+// Load-modify-save under WithSessionStateLock for the reason
+// applyMultiplexerHostRefresh gives: the caller's read happened outside the
+// lock, so the session may have been reaped or re-bound meanwhile, and the
+// lock is the one assignPIDLocked takes around its own load-modify-save.
+//
+// The pane guard is re-checked rather than trusted from before the read: a
+// concurrent capture may have resolved the same pane already, and overwriting
+// it here would race two sources for one field.
+func (pm *PIDManager) applySelfReportedHerdrPane(sessionID string, fresh *session.Launcher, hostKnown bool) *session.SessionState {
+	var updated *session.SessionState
+	pm.WithSessionStateLock(func() {
+		state, err := pm.repo.Load(sessionID)
+		if err != nil || state == nil || state.Launcher == nil {
+			return
+		}
+		if state.Launcher.HerdrPaneID != "" {
+			return
+		}
+		state.Launcher.HerdrPaneID = fresh.HerdrPaneID
+		state.Launcher.HerdrSocketPath = fresh.HerdrSocketPath
+		// hostKnown gates only the host adoption, exactly as
+		// applyMultiplexerHostBackfill does: a client probe that did not run
+		// yields empty host fields that mean "not looked up", and adopting them
+		// would write emptiness over the ancestry-derived host the session
+		// already has (#1485). The pane itself is unconditional — it came from
+		// the process, not from the probe.
+		if hostKnown {
+			state.Launcher.AdoptHostIdentity(fresh)
+		}
+		// The pane may have arrived with a tty the stored launcher lacked, and
+		// BackgroundAgent.Detached is derived from it (#744/#1546).
+		refreshBackgroundDetached(state)
+		pm.touchAndSave(state)
+		updated = state
+	})
+	return updated
 }
 
 // refreshMultiplexerHosts re-resolves the host window of every herdr-hosted session,

--- a/core/application/services/pid_manager_herdr_selfreport_test.go
+++ b/core/application/services/pid_manager_herdr_selfreport_test.go
@@ -1,0 +1,251 @@
+package services_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// paneLessSession is the shape #1936 exists for: a pi session whose launcher
+// was captured from ancestry alone, so it names a terminal but no pane. The
+// daemon could not read $HERDR_PANE_ID from the process, because a Node agent
+// that sets process.title hides its own environment (#1934).
+func paneLessSession(l *session.Launcher) *session.SessionState {
+	return &session.SessionState{
+		SessionID: "s",
+		Adapter:   "pi",
+		State:     session.StateWorking,
+		PID:       os.Getpid(),
+		UpdatedAt: time.Now().Unix(),
+		Launcher:  l,
+	}
+}
+
+// recorderSpy captures what was handed to the launcher reader's self-report
+// seam, and how often the reader itself then ran.
+type recorderSpy struct {
+	pids    []int
+	panes   []string
+	sockets []string
+	reads   int
+}
+
+func (r *recorderSpy) record(pid int, paneID, socketPath string) {
+	r.pids = append(r.pids, pid)
+	r.panes = append(r.panes, paneID)
+	r.sockets = append(r.sockets, socketPath)
+}
+
+// TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher is the defect test.
+// Without this path the session below keeps its ancestry-derived host forever:
+// launcherBackfillNeedsFor asks for nothing (it has a tty and no pane) and
+// refreshMultiplexerHosts skips it (hostedInAMultiplexerPane is false), so
+// nothing in a daemon's lifetime looks at it again.
+func TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = paneLessSession(&session.Launcher{
+		TermProgram: "Apple_Terminal", // the herdr SERVER's terminal — #1348's misroute
+		TTY:         "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	spy := &recorderSpy{}
+	pm.SetHerdrPaneRecorder(spy.record)
+	// With the report recorded, the reader now resolves the pane — and, through
+	// it, the client actually displaying it.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		spy.reads++
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p2",
+			HerdrSocketPath: "/cfg/herdr/sessions/f/herdr.sock",
+			TermProgram:     "ghostty",
+			TTY:             "/dev/ttys077",
+		}, true
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	if len(spy.pids) != 1 || spy.pids[0] != os.Getpid() {
+		t.Fatalf("recorded pids %v, want exactly this session's", spy.pids)
+	}
+	if spy.panes[0] != "w1:p2" || spy.sockets[0] != "/cfg/herdr/sessions/f/herdr.sock" {
+		t.Errorf("recorded %q on %q, want the report as received", spy.panes[0], spy.sockets[0])
+	}
+	got := repo.states["s"].Launcher
+	if got.HerdrPaneID != "w1:p2" || got.HerdrSocketPath != "/cfg/herdr/sessions/f/herdr.sock" {
+		t.Fatalf("pane not adopted: %+v", got)
+	}
+	if got.TermProgram != "ghostty" {
+		t.Errorf("TermProgram = %q, want the attached client's — the pane's window "+
+			"belongs to the client, not to the ancestry walk", got.TermProgram)
+	}
+	if got.TTY != "/dev/ttys077" {
+		t.Errorf("TTY = %q, want the client's", got.TTY)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_KnownPaneCostsNoRead pins the cost rule. A
+// report arrives at every turn end, so a session whose pane is already
+// resolved must not pay a launcher read for each one — it records the report,
+// which is what makes a LATER read (after a restart, or a PID re-bind) the
+// cheap kind, and stops.
+func TestAdoptSelfReportedHerdrPane_KnownPaneCostsNoRead(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = paneLessSession(&session.Launcher{
+		HerdrPaneID:     "w1:p2",
+		HerdrSocketPath: "/cfg/herdr/sessions/f/herdr.sock",
+		TermProgram:     "ghostty",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	spy := &recorderSpy{}
+	pm.SetHerdrPaneRecorder(spy.record)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		spy.reads++
+		return nil, false
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	if len(spy.pids) != 1 {
+		t.Errorf("recorded %d reports, want 1 — recording is the cheap half and "+
+			"always happens", len(spy.pids))
+	}
+	if spy.reads != 0 {
+		t.Errorf("read the launcher %d times for a session that already has its pane", spy.reads)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_UnconfirmedReportChangesNothing covers the
+// report that does not survive confirmation inside the reader — pid reuse, or
+// no herdr server answering. The session keeps exactly what it had.
+func TestAdoptSelfReportedHerdrPane_UnconfirmedReportChangesNothing(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = paneLessSession(&session.Launcher{
+		TermProgram: "Apple_Terminal",
+		TTY:         "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetHerdrPaneRecorder(func(int, string, string) {})
+	// The reader ran and resolved no pane: the report was not confirmed.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{TermProgram: "Apple_Terminal", TTY: "/dev/ttys012"}, true
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p9", "/cfg/herdr/sessions/f/herdr.sock")
+
+	got := repo.states["s"].Launcher
+	if got.HerdrPaneID != "" || got.HerdrSocketPath != "" {
+		t.Errorf("stored a pane the reader did not confirm: %+v", got)
+	}
+	if got.TermProgram != "Apple_Terminal" {
+		t.Errorf("host disturbed by a report that led nowhere: %+v", got)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_UnprobedHostIsNotAdopted applies #1485's rule
+// on this path too: empty host fields from a read whose client probe did not
+// run mean "not looked up", not "detached". Adopting them would erase the host
+// the session already has, on the strength of a probe that never happened.
+func TestAdoptSelfReportedHerdrPane_UnprobedHostIsNotAdopted(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = paneLessSession(&session.Launcher{
+		TermProgram: "Apple_Terminal",
+		TTY:         "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetHerdrPaneRecorder(func(int, string, string) {})
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p2",
+			HerdrSocketPath: "/cfg/herdr/sessions/f/herdr.sock",
+		}, false // the client probe did not run
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	got := repo.states["s"].Launcher
+	if got.HerdrPaneID != "w1:p2" {
+		t.Errorf("the pane came from the process, not the probe, and must be kept: %+v", got)
+	}
+	if got.TermProgram != "Apple_Terminal" {
+		t.Errorf("TermProgram = %q — a probe that did not run cleared a known host", got.TermProgram)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_NoPIDIsNotStashed pins the deliberate absence
+// of a stash. A report arriving before PID discovery is dropped, because the
+// extension sends one at every turn end and the next lands on a bound session
+// — an entry with no natural end is the cost that buys one turn of latency.
+func TestAdoptSelfReportedHerdrPane_NoPIDIsNotStashed(t *testing.T) {
+	repo := newMockRepo()
+	unbound := paneLessSession(&session.Launcher{TermProgram: "Apple_Terminal"})
+	unbound.PID = 0
+	repo.states["s"] = unbound
+
+	pm := newPIDManagerForTest(repo)
+	spy := &recorderSpy{}
+	pm.SetHerdrPaneRecorder(spy.record)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		spy.reads++
+		return nil, false
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	if len(spy.pids) != 0 {
+		t.Errorf("recorded %v against a session with no PID; the map is keyed by pid, "+
+			"so there is nothing to key it under", spy.pids)
+	}
+	if spy.reads != 0 {
+		t.Errorf("read the launcher %d times with no PID to read", spy.reads)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_WithoutARecorderDoesNothing pins the disabled
+// path — demo mode, tests, and a revoked "Terminal focus" consent all leave
+// the seam nil, and none of them may pay a read.
+func TestAdoptSelfReportedHerdrPane_WithoutARecorderDoesNothing(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = paneLessSession(&session.Launcher{TermProgram: "Apple_Terminal"})
+
+	pm := newPIDManagerForTest(repo)
+	reads := 0
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		reads++
+		return nil, false
+	})
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	if reads != 0 {
+		t.Errorf("read the launcher %d times with the self-report path disabled", reads)
+	}
+	if got := repo.states["s"].Launcher; got.HerdrPaneID != "" {
+		t.Errorf("adopted a pane with no recorder wired: %+v", got)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_UnknownSessionIsQuiet covers the report for a
+// session the daemon has already reaped — the hook races teardown the same way
+// HandleStopHook does.
+func TestAdoptSelfReportedHerdrPane_UnknownSessionIsQuiet(t *testing.T) {
+	pm := newPIDManagerForTest(newMockRepo())
+	spy := &recorderSpy{}
+	pm.SetHerdrPaneRecorder(spy.record)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		spy.reads++
+		return nil, false
+	})
+
+	pm.AdoptSelfReportedHerdrPane("gone", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+
+	if len(spy.pids) != 0 || spy.reads != 0 {
+		t.Errorf("acted on a session that is not there: recorded %v, read %d times",
+			spy.pids, spy.reads)
+	}
+}

--- a/core/application/services/pid_manager_herdr_selfreport_test.go
+++ b/core/application/services/pid_manager_herdr_selfreport_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/application/services"
 	"irrlicht/core/domain/session"
 )
 
@@ -38,12 +39,18 @@ func (r *recorderSpy) record(pid int, paneID, socketPath string) {
 	r.sockets = append(r.sockets, socketPath)
 }
 
-// TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher is the defect test.
-// Without this path the session below keeps its ancestry-derived host forever:
-// launcherBackfillNeedsFor asks for nothing (it has a tty and no pane) and
-// refreshMultiplexerHosts skips it (hostedInAMultiplexerPane is false), so
-// nothing in a daemon's lifetime looks at it again.
-func TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher(t *testing.T) {
+// reportedSocket is the socket path the tests below report and expect back.
+const reportedSocket = "/cfg/herdr/sessions/f/herdr.sock"
+
+// repairSetup builds the #1936 defect scenario: a session whose launcher names
+// a terminal and no pane, with a reader that — once the report is recorded —
+// resolves both the pane and the client displaying it.
+//
+// Shared by the two tests below rather than inlined in each, because the two
+// halves of the repair (what is handed to the reader, and what lands on the
+// session) are one scenario asserted from two ends.
+func repairSetup(t *testing.T) (*mockRepo, *services.PIDManager, *recorderSpy) {
+	t.Helper()
 	repo := newMockRepo()
 	repo.states["s"] = paneLessSession(&session.Launcher{
 		TermProgram: "Apple_Terminal", // the herdr SERVER's terminal — #1348's misroute
@@ -53,29 +60,57 @@ func TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher(t *testing.T) {
 	pm := newPIDManagerForTest(repo)
 	spy := &recorderSpy{}
 	pm.SetHerdrPaneRecorder(spy.record)
-	// With the report recorded, the reader now resolves the pane — and, through
-	// it, the client actually displaying it.
 	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		spy.reads++
 		return &session.Launcher{
 			HerdrPaneID:     "w1:p2",
-			HerdrSocketPath: "/cfg/herdr/sessions/f/herdr.sock",
+			HerdrSocketPath: reportedSocket,
 			TermProgram:     "ghostty",
 			TTY:             "/dev/ttys077",
 		}, true
 	})
+	return repo, pm, spy
+}
 
-	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", "/cfg/herdr/sessions/f/herdr.sock")
+// TestAdoptSelfReportedHerdrPane_HandsTheReportToTheReader covers the first
+// half: the report reaches the seam the launcher read consults, keyed by this
+// session's own pid.
+func TestAdoptSelfReportedHerdrPane_HandsTheReportToTheReader(t *testing.T) {
+	_, pm, spy := repairSetup(t)
 
-	if len(spy.pids) != 1 || spy.pids[0] != os.Getpid() {
-		t.Fatalf("recorded pids %v, want exactly this session's", spy.pids)
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", reportedSocket)
+
+	if len(spy.pids) != 1 {
+		t.Fatalf("recorded %d reports, want 1", len(spy.pids))
 	}
-	if spy.panes[0] != "w1:p2" || spy.sockets[0] != "/cfg/herdr/sessions/f/herdr.sock" {
-		t.Errorf("recorded %q on %q, want the report as received", spy.panes[0], spy.sockets[0])
+	if spy.pids[0] != os.Getpid() {
+		t.Errorf("recorded pid %d, want this session's %d", spy.pids[0], os.Getpid())
 	}
+	if spy.panes[0] != "w1:p2" {
+		t.Errorf("recorded pane %q, want w1:p2", spy.panes[0])
+	}
+	if spy.sockets[0] != reportedSocket {
+		t.Errorf("recorded socket %q, want %q", spy.sockets[0], reportedSocket)
+	}
+}
+
+// TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher is the defect test.
+// Without this path the session keeps its ancestry-derived host forever:
+// launcherBackfillNeedsFor asks for nothing (it has a tty and no pane) and
+// refreshMultiplexerHosts skips it (hostedInAMultiplexerPane is false), so
+// nothing in a daemon's lifetime looks at it again.
+func TestAdoptSelfReportedHerdrPane_RepairsAPaneLessLauncher(t *testing.T) {
+	repo, pm, _ := repairSetup(t)
+
+	pm.AdoptSelfReportedHerdrPane("s", "w1:p2", reportedSocket)
+
 	got := repo.states["s"].Launcher
-	if got.HerdrPaneID != "w1:p2" || got.HerdrSocketPath != "/cfg/herdr/sessions/f/herdr.sock" {
+	if got.HerdrPaneID != "w1:p2" {
 		t.Fatalf("pane not adopted: %+v", got)
+	}
+	if got.HerdrSocketPath != reportedSocket {
+		t.Errorf("socket = %q, want %q — the pane and its server are one fact",
+			got.HerdrSocketPath, reportedSocket)
 	}
 	if got.TermProgram != "ghostty" {
 		t.Errorf("TermProgram = %q, want the attached client's — the pane's window "+

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -537,6 +537,14 @@ func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
 	d.pidMgr.SetLauncherEnvReader(fn)
 }
 
+// SetHerdrPaneRecorder installs the seam that hands a session's own report of
+// its herdr pane to the launcher reader (#1936). Production wires
+// processlifecycle.RememberHerdrPane behind the launcher consent; nil (the
+// default) disables the self-report path. Call before Run.
+func (d *SessionDetector) SetHerdrPaneRecorder(fn HerdrPaneRecorder) {
+	d.pidMgr.SetHerdrPaneRecorder(fn)
+}
+
 // SetBackgroundReader installs a reader that flags a session as a detached
 // background agent (e.g. a Claude Code Agent View bg agent) when its PID is
 // first assigned (#744).

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -327,6 +327,26 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 	d.dispatchHookActivity(sessionID, transcriptPath, session.HookStop)
 }
 
+// HandleHerdrPaneHint records the herdr pane a session reported about itself
+// (#1936). Called by the pi hook receiver, which is the only adapter that can
+// report one: irrlicht runs code inside a pi session, and for a Node agent
+// that is the one vantage point from which $HERDR_PANE_ID is legible at all
+// (#1934).
+//
+// paneID and socketPath arrive validated and confined — the receiver rejects a
+// pane address that is not shaped like one and a socket outside herdr's own
+// tree, before this is called.
+//
+// A pure forward, deliberately: this method neither classifies nor pushes.
+// Everything about a launcher belongs to PIDManager, including the decision
+// that nothing needs doing, and duplicating any part of it here would give the
+// hook path its own opinion about a field the PID path owns.
+//
+// Safe to call from any goroutine (the HTTP handler), like HandleStopHook.
+func (d *SessionDetector) HandleHerdrPaneHint(sessionID, paneID, socketPath string) {
+	d.pidMgr.AdoptSelfReportedHerdrPane(sessionID, paneID, socketPath)
+}
+
 // HandlePermissionPromptHook records a notification-shaped "a prompt is open
 // right now, and the user is blocked on it" signal. Two adapters call it:
 // gemini-cli's Notification/ToolPermission (issue #1717, the original caller)

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -747,6 +747,27 @@ type setupPermissionServiceDeps struct {
 	StopGastown      func() error
 }
 
+// herdrPaneRecorder returns the seam that stores the herdr pane a pi session
+// reported about itself, for the launcher reader to use (#1936). A Node agent
+// that sets process.title hides its own environment from
+// sysctl(kern.procargs2), so this is the only route by which $HERDR_PANE_ID
+// reaches irrlicht for pi.
+//
+// Gated on the SAME consent as ReadLauncherEnv, and separately rather than by
+// reusing that closure: the report arrives through the pi hooks channel, which
+// is granted independently, so without this check a user who turned "Terminal
+// focus" off would still have their pane captured through a side channel.
+// Checked per call so a revoke takes effect immediately, and dropping the
+// report on arrival rather than storing it and declining to use it.
+func herdrPaneRecorder(permService *services.PermissionService) services.HerdrPaneRecorder {
+	return func(pid int, paneID, socketPath string) {
+		if !permService.Granted(processlifecycle.LauncherName, processlifecycle.PermissionKeyLauncherEnv) {
+			return
+		}
+		processlifecycle.RememberHerdrPane(pid, paneID, socketPath)
+	}
+}
+
 func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps) *services.PermissionService {
 	detector := deps.Detector
 	logger := deps.Logger
@@ -818,21 +839,8 @@ func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps)
 		return processlifecycle.ReadLauncherEnv(pid)
 	})
 	// Let a pi session tell us which herdr pane it is in, for the reader
-	// above to use (#1936). A Node agent that sets process.title hides its
-	// own environment from sysctl(kern.procargs2), so this is the only route
-	// by which $HERDR_PANE_ID reaches irrlicht for pi.
-	//
-	// Gated on the SAME consent as the reader, and separately rather than by
-	// reusing that closure: the report arrives through the pi hooks channel,
-	// which is granted independently, so without this check a user who turned
-	// "Terminal focus" off would still have their pane captured through a side
-	// channel. Checked per call so a revoke takes effect immediately.
-	detector.SetHerdrPaneRecorder(func(pid int, paneID, socketPath string) {
-		if !permService.Granted(processlifecycle.LauncherName, processlifecycle.PermissionKeyLauncherEnv) {
-			return
-		}
-		processlifecycle.RememberHerdrPane(pid, paneID, socketPath)
-	})
+	// above to use (#1936).
+	detector.SetHerdrPaneRecorder(herdrPaneRecorder(permService))
 	// Flag detached Claude Code background agents (Agent View bg agents that keep
 	// running in the daemon pool) so the UI can badge them instead of showing a
 	// phantom row (#744). Reads ~/.claude/sessions/<pid>.json, gated by the same

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -817,6 +817,22 @@ func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps)
 		}
 		return processlifecycle.ReadLauncherEnv(pid)
 	})
+	// Let a pi session tell us which herdr pane it is in, for the reader
+	// above to use (#1936). A Node agent that sets process.title hides its
+	// own environment from sysctl(kern.procargs2), so this is the only route
+	// by which $HERDR_PANE_ID reaches irrlicht for pi.
+	//
+	// Gated on the SAME consent as the reader, and separately rather than by
+	// reusing that closure: the report arrives through the pi hooks channel,
+	// which is granted independently, so without this check a user who turned
+	// "Terminal focus" off would still have their pane captured through a side
+	// channel. Checked per call so a revoke takes effect immediately.
+	detector.SetHerdrPaneRecorder(func(pid int, paneID, socketPath string) {
+		if !permService.Granted(processlifecycle.LauncherName, processlifecycle.PermissionKeyLauncherEnv) {
+			return
+		}
+		processlifecycle.RememberHerdrPane(pid, paneID, socketPath)
+	})
 	// Flag detached Claude Code background agents (Agent View bg agents that keep
 	// running in the daemon pool) so the UI can badge them instead of showing a
 	// phantom row (#744). Reads ~/.claude/sessions/<pid>.json, gated by the same


### PR DESCRIPTION
Closes #1936.

**Stacked on #1935 — base is `fix/1934-herdr-pane-for-node-agents`, so this merges after it.** The stack is not stylistic: #1935 created the seam inside `ReadLauncherEnv` where a pane must be known before the attached client is resolved, and this change is a second, better source feeding that same seam. On `main` alone it would not work, for a reason worth stating because it is not obvious — see "Why this cannot stand alone" below.

## What it does

A pi session tells irrlicht which herdr pane it is in, instead of irrlicht having to work it out.

`extension.js` — the file irrlicht already installs into pi, because an extension module is the only way to observe pi's lifecycle at all — reads `HERDR_PANE_ID` and `HERDR_SOCKET_PATH` from its own `process.env` and sends them with the turn-end payload it was already posting. The daemon confines them, records them against the pid, and `adoptHerdrPane` prefers them over #1934's scan.

The reason the extension has to be the one reading them is #1934's finding: the daemon reads a process's environment from outside — `sysctl(kern.procargs2)` on darwin — and a Node agent that sets `process.title` overwrites the argv+env region that call exposes. For pi that read comes back empty. Inside the process the values are still there. This is the only vantage point from which they are visible.

## Why this cannot stand alone

Writing a reported pane straight onto the stored launcher produces a session that addresses a pane and has no window to raise, and it stays that way permanently:

- a pane's host belongs to the herdr **client** displaying it (#1350), and only `ReadLauncherEnv` resolves that;
- the periodic refresh that would otherwise fix it requires the fresh read to describe the same pane (`SamePaneAs`), and a read that cannot see the pane never will;
- meanwhile the session now satisfies `hostedInAMultiplexerPane`, so it pays a read on every liveness sweep and gets nothing for it.

That is strictly worse than storing nothing. So the report is **recorded and then re-read through the reader**, which is what puts it in front of the client resolution. #1935's `adoptHerdrPane` is that point.

## The report is confirmed, not believed

#1934's invariant is *cwd narrows, pid decides*. A self-report could bypass it — the pane is stated authoritatively, but pids get reused — so a remembered entry is checked with one `pane.process_info` against the socket it names before it is used. That is also why the pid-keyed map needs no careful eviction: a stale entry cannot be believed, only dropped.

Three outcomes, not two, matching #1485's rule in the memo next door: confirmed is used, contradicted is dropped, and a server that did not answer leaves the entry alone and falls through to the scan.

Cost against #1934's route: one request on a known socket for a known pane, versus `pane.list` plus up to `maxPaneCandidates` `process_info` calls. Same answer, less work — and it removes the scan's two failure modes for the one agent that can avoid them: a working directory that no longer matches the pane's, and more panes in one directory than the cap admits.

## Nothing periodic changed, deliberately

A pane-less launcher asks for nothing — `launcherBackfillNeedsFor` returns no need for it and `refreshMultiplexerHosts` skips it — and both are what keep a machine with no multiplexer from paying a read per session per sweep. Adding a "the pane might be missing" need would make `needs.any()` true for essentially every session on every machine, which is a regression against exactly what #1405/#1485/#1492 tuned that gate to prevent.

So the repair is driven by the event instead. **A report arriving is itself the cheap evidence that this session is in a herdr pane**, and it is the only moment at which anything new can be learned, so one read is paid there and none anywhere else. A session that already has its pane records the report and stops. A machine with no herdr never reaches the code at all, because no report is ever sent.

## Security: the socket path is confined before anything acts on it

`hooks.go`'s header already establishes that "our own extension wrote it" buys nothing on a local, unauthenticated endpoint. What is new here is the *consequence*: a transcript path is read, while a socket path is dialed, and the client holding that pane's log open is adopted as the window click-to-focus raises. Unconfined, any local process could choose which window irrlicht raises.

`herdrhint.go` confines it by four properties, each closing a different way in:

- **absolute and already clean** — rejected rather than normalised, because normalising a hostile path into an acceptable one is how these checks become bypasses;
- **named `herdr.sock`** — one accepted file per directory;
- **under the config root**, tested against `root + separator`, so `…/herdrevil/herdr.sock` does not pass a bare string prefix;
- **actually a socket, by `Lstat`** — not `Stat`, so a link planted inside the root pointing at a socket outside it is seen as the link it is.

The pane id gets an allowlist rather than a denylist. Every rejection is silent and costs the session its pane, never its turn-end signal — `TestRejectedHerdrPaneStillDeliversTheTurnEnd` covers six ways to be refused.

Documented and *not* defended against: a symlinked directory component inside `~/.config/herdr`. Reaching that already requires write access there, and an attacker with it owns herdr's real socket too.

`$XDG_CONFIG_HOME` is deliberately not consulted. Whether herdr honours it was not measured, and honouring a variable herdr ignores would move the accepted root away from the real one and reject every genuine report. A user whose herdr lives elsewhere keeps today's behaviour.

## Consent

The report rides in on the pi hooks channel but it is launcher-identity data, so recording it is gated on `launcher/env` — the same permission every other launcher read is taken under, checked per call so a revoke takes effect immediately. Without it the report is discarded on arrival rather than stored and ignored. It cannot reuse the gate inside the `LauncherEnvReader` closure, because the report bypasses the reader by construction.

No new permission key: the capability and the consent decision are unchanged, only the mechanism. Both disclosures name the new route — pi's hooks copy says the file reads those two variables and sends them, and says storing them is gated separately by "Terminal focus".

## Verification

`go test ./core/... -race -count=1` green; `gofmt`, `go vet` clean. ARS gate passes (composite 7.9330 → 7.9291, no category regression). The local preflight's two failures are missing binaries (`ars`, `govulncheck`, `gosec`) rather than findings — `ars` was installed and run separately, as above; the other two run in CI.

CodeScene took two rounds, both fixed rather than suppressed. The first flagged seven items, all in code this branch adds, including one hotspot gate on `applySelfReportedHerdrPane`. Two of those fixes were worth more than the score: both halves of the self-report path turned out to be asking the same question in two spellings (now `paneLessLauncher`, one place), and `confinedHerdrSocketPath`'s four checks answer questions of different kinds — how the path is written, where it points, what is actually there — which is the distinction someone auditing a confinement wants drawn. The second round flagged `validHerdrPaneID`, whose own comment claimed an allowlist should be "readable in one line" and then spelled it as a switch over byte ranges; the alphabet is now written out, and ranging over runes makes the multi-byte and invalid-UTF-8 rejections fall out rather than needing an argument.

All mutations were re-run against the refactored shape rather than carried over, since the refactor moved their targets — eight now, the two extra covering the extracted helper and the alphabet.

Six mutations, each applied to the current tree, confirmed to compile, and each killing exactly the test that claims the property:

| mutation | test that fails |
|---|---|
| `os.Lstat` → `os.Stat` | `TestConfinedHerdrSocketPathRejects/symlink_out` |
| drop the separator from the root prefix test | `TestConfinedHerdrSocketPathRejects/sibling_prefix` |
| forget the entry when the server did not answer | `TestSelfReportedPaneKeepsAReportItCouldNotCheck` |
| drop the self-report branch in `adoptHerdrPane` | `TestSelfReportedPaneSkipsTheScan` |
| adopt the host without `hostKnown` | `TestAdoptSelfReportedHerdrPane_UnprobedHostIsNotAdopted` |
| dispatch the pane after `HandleStopHook` | `TestHerdrPaneIsDispatchedBeforeTheTurnEnd` |

All six green again on restore. The two commits are ordered so each builds on its own: the daemon side first (the detector method exists, unused), the adapter side second (which widens `HookTarget`).

Not covered: nothing here executes the JavaScript, for the reason `extension_test.go`'s header gives. The guards pin the properties; the payload shape is bound to `piHookPayload` across the language boundary by `TestShippedExtensionPayloadMatchesTheReceiversFields`.

## What this does not fix

#1934's scan stays the ordinary path for every agent that runs no irrlicht extension — today, every other Node agent. Their pane is still inferred rather than reported, and the narrowness of that route is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLxrnHw5up6arPGPGkkzTq

