### PR TITLE
fix(onboard): tie a Desktop front-end verdict to the build it was measured on

### DIFF
--- a/replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md
+++ b/replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md
@@ -10,6 +10,16 @@ Measured against Claude Desktop 1.46388.4 with bundled Claude Code 2.1.260, on
 2026-09-06 and 2026-09-07. Every figure below comes from a tree the driver
 saved at the moment of refusal.
 
+Every verdict that cites this file records that build in its own
+`measured_desktop_version`, and `of validate` refuses one that does not. These
+are the only Desktop verdicts that can expire without anybody touching the
+repository: they say what the app SHOWS, and Claude Desktop ships new builds on
+its own schedule. The driver refuses every build but the one its catalog is
+pinned to, so
+`desktopdriver.TestFrontendVerdictsNameTheSupportedDesktopVersion` fails the
+moment that pin and these verdicts disagree — moving the pin means re-measuring
+each claim below, and the failure names them.
+
 ## There is no Stop control, at any point in a turn — 2-20
 
 The catalog believed Desktop swapped the composer's Send button for a Stop

--- a/replaydata/agents/claudecode/scenarios/2-18_user-blocking-plan-mode-approval/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-18_user-blocking-plan-mode-approval/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The turn drives and every piece of evidence is captured \u2014 transcript, registry, session, process and environment \u2014 but the run cannot discharge its ownership obligation, so it can never end cleanly. Archiving the owned session needs the conversation's `More options` menu, and on this machine that control cannot be clicked. Measured on 1.46388.4 on 2026-09-07 from the tree at desktop-evidence/, saved by the driver at the moment of refusal: the menu sits at (2161,-373,26x26) and a window-management affordance, an AXButton described `Move`, sits over it at (2165,-376,44x16). Seven candidate points inside the menu's own frame were hit-tested across five attempts a run, over four runs; every one returned something other than the menu or a descendant of it. The sidebar carries the same menu per row, away from the window chrome, but it cannot identify this session: five unarchived sessions share the title, because Desktop names a session after its content and every repeat of this scenario earns the same name. Re-check by re-running the cell and reading the tree the failure leaves behind.",
       "missing_control": "a clickable owned-session menu \u2014 the control exists but no point inside it hit-tests to it",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",
         "replaydata/agents/claudecode/scenarios/2-18_user-blocking-plan-mode-approval/metadata.json"

--- a/replaydata/agents/claudecode/scenarios/2-20_user-esc-interrupt/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-20_user-esc-interrupt/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The recipe's `interrupt` step has no control to drive. Claude Desktop 1.46388.4 exposes no Stop control at any point in a turn: a tree captured ten seconds into a streaming turn carried 767 controls (the committed copy is redacted down to 517 — it dropped the macOS menu-bar rows, which carried the operator's Recent Items), of which exactly one was the composer's `Send` button and none anywhere was described or titled `Stop`. The tree is committed at desktop-evidence/no-stop-control-1.46388.4.json; check it with `jq '[.[] | select(.description==\"Stop\" or .title==\"Stop\")] | length'`, which returns 0. The driver's interrupt clicks that control and its Escape key press watches for it, so both are undrivable here. This is a control gap in the front end, not a defect in the scenario: the cell stays valid for cli-local, where the TUI owns the keyboard and Escape cancels the turn.",
       "missing_control": "a Stop control on the composer while a turn runs — 1.46388.4 exposes none at any point in a turn",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",
         "replaydata/agents/claudecode/scenarios/2-20_user-esc-interrupt/metadata.json",

--- a/replaydata/agents/claudecode/scenarios/2-26_permission-gate-non-mutating-tool/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-26_permission-gate-non-mutating-tool/execution-results.json
@@ -6,6 +6,7 @@
       "execution_profile": "desktop-local",
       "outcome": "not-runnable",
       "missing_control": "no control is missing; the Read tool is never gated, so the second waiting episode this cell asserts never occurs",
+      "measured_desktop_version": "1.46388.4",
       "reason": "The driver drove this cell successfully: it typed the prompt, the Write tool was gated, it found the permission dialog and answered it with `Allow once`, and the turn resumed. What the cell asserts did not happen. It requires TWO gate episodes \u2014 the Write tool gated (`mutating_gate_waiting`), then the Read tool gated in its OWN episode (`readonly_gate_waiting`, the assertion under test). Measured on 2026-09-07 the recording carries one: working -> waiting -> ready. The read was never gated, so the cell cannot reach the state it asserts under this profile. The spec's own note predicts this and says it fails on main too \u2014 PermissionRequest is installed with a nine-tool matcher that excludes Read, and no lower classifier rung re-derives the prompt (#1861) \u2014 so the Desktop profile reproduces a known defect rather than revealing a new one. Re-check by re-running the cell and counting `waiting` transitions in the staged events.jsonl.",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",

--- a/replaydata/agents/claudecode/scenarios/2-27_blocking-dialog-without-tool-call/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-27_blocking-dialog-without-tool-call/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The blocking dialog the scenario exists to observe does not occur under this front end. The recipe's second turn asks the agent to print 300 lines and then answers the expected dialog with Enter. Measured on 2026-09-07: at the moment of that keystroke the tree carried 854 controls and no dialog among them \u2014 no numbered choice buttons, and the composer showing `Send`, so the turn had already finished. The keystroke therefore landed on an empty composer and its postcondition could not become true. The driver CAN answer a Desktop dialog \u2014 cell 2-26 records exactly that \u2014 so this is an elicitation gap, not a control gap: nothing in the recipe makes Claude Desktop raise a non-tool blocking dialog. The tree is at desktop-evidence/ in the staged run the failure names.",
       "missing_control": "no control is missing; Desktop raises no blocking dialog that is not a tool permission prompt",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",
         "replaydata/agents/claudecode/scenarios/2-27_blocking-dialog-without-tool-call/metadata.json"

--- a/replaydata/agents/claudecode/scenarios/2-3_task-list/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-3_task-list/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "Claude Desktop's agent has no task-list tool, so the loop this cell exists to observe cannot happen. Measured on 2026-09-07, the agent's own words after searching for one: \"TodoWrite, TaskCreate, checklist) and found no match. I cannot complete this instruction as written.\" It made eight ToolSearch calls looking, and the turn ended `waiting` on that question where the spec asserts `ready`. This is a capability gap in the front end, not a driver or recipe fault: the driver typed the prompt, the session was created and observed, and the recipe is the same three steps its six tool-using peers use. The cell stays valid for cli-local, where the tool exists.",
       "missing_control": "a task-list tool in the Desktop agent's toolset",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",
         "replaydata/agents/claudecode/scenarios/2-3_task-list/metadata.json"

--- a/replaydata/agents/claudecode/scenarios/3-5_workflow-fanout/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/3-5_workflow-fanout/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The fan-out this cell exists to observe does not happen under this front end. Five attempts on 2026-09-06 and 2026-09-07. Three recordings carried no `transcript_new` for any child session at all. The last two bore children \u2014 one, then two \u2014 and neither produced the parent-child link the spec anchors every later phase on, so `parent_linked`, `fanout_working`, `parent_turn_end` and `children_swept` all fail together. The parent's own turn ended `waiting` within eleven seconds every time, which is the agent asking a question rather than launching agents. The driver drove the recipe correctly each time: the session was created, the prompt was typed, the turn ran and closed. Re-check with `jq -r 'select(.kind==\"transcript_new\")' on a staged run's events.jsonl.",
       "missing_control": "no control is missing; the agent does not launch the child agents the cell observes",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md",
         "replaydata/agents/claudecode/scenarios/3-5_workflow-fanout/metadata.json"

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -563,3 +563,64 @@ func writeJSONFixture(t *testing.T, path string, value any) {
 	}
 	write(t, path, string(b)+"\n")
 }
+
+// makeFrontendVerdict turns a fixture cell's evidence reference into the shared
+// front-end file, which is what marks a verdict as a claim about what Claude
+// Desktop SHOWS rather than about the driver, the harness or a recording.
+func makeFrontendVerdict(t *testing.T, fixture desktopFixture, scenario string) string {
+	t.Helper()
+	cellDir := fixture.cellDirs[scenario]
+	evidencePath := filepath.Join(cellDir, "desktop-evidence", "frontend-gaps.md")
+	write(t, evidencePath, "Measured against Claude Desktop 9.9.9.\n")
+	ref := filepath.ToSlash(strings.TrimPrefix(evidencePath, fixture.root+string(filepath.Separator)))
+	path := filepath.Join(cellDir, desktopResultsFile)
+	mutateFirstResult(t, path, func(r map[string]any) { r["evidence_refs"] = []any{ref} })
+	return path
+}
+
+// TestValidateDesktopMeasuredVersionMutations is committed mutation evidence
+// for the front-end freshness rule.
+//
+// The rule has no state in which it ever ran red before it existed, so what
+// proves it works is breaking the thing it protects. A front-end verdict says
+// what the app SHOWS; Claude Desktop ships new builds on its own schedule; and
+// the desktopdriver package refuses every build but its pinned one. Without the
+// build recorded as a comparable field, a release turned six committed verdicts
+// stale in silence while `of validate` went on printing OK.
+func TestValidateDesktopMeasuredVersionMutations(t *testing.T) {
+	t.Run("front-end verdict without the build", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		makeFrontendVerdict(t, fixture, "not-runnable")
+		requireDesktopFinding(t, fixture.root, "not-runnable", "measured_desktop_version")
+	})
+	t.Run("front-end verdict with a blank build", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := makeFrontendVerdict(t, fixture, "unobservable")
+		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "   " })
+		requireDesktopFinding(t, fixture.root, "unobservable", "measured_desktop_version")
+	})
+	t.Run("front-end verdict naming its build is accepted", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := makeFrontendVerdict(t, fixture, "not-runnable")
+		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "9.9.9" })
+		if code, _, stderr := runOf("validate", "--repo-root", fixture.root); code != exitOK {
+			t.Fatalf("a front-end verdict naming its build must be valid: exit=%d stderr:\n%s", code, stderr)
+		}
+	})
+	t.Run("census verdict may not carry a build", func(t *testing.T) {
+		// A grammar gap is not a measurement. Demanding a build here would ask
+		// for a re-measurement on every pin bump for a cell nothing measured.
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["not-runnable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "9.9.9" })
+		requireDesktopFinding(t, fixture.root, "not-runnable", "measured_desktop_version")
+	})
+	t.Run("observed result may not carry a build", func(t *testing.T) {
+		// The recording's own desktop-environment.json already carries it, and
+		// two copies of one fact are free to disagree.
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
+		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "9.9.9" })
+		requireDesktopFinding(t, fixture.root, "observed-pass", "measured_desktop_version")
+	})
+}

--- a/tools/onboarding-factory/internal/desktopdriver/recipe.go
+++ b/tools/onboarding-factory/internal/desktopdriver/recipe.go
@@ -122,18 +122,19 @@ var desktopElicits = map[string][]string{
 //     registry and this driver's ownership bookkeeping disagreeing about what
 //     is alive, and no measured control does it through the app.
 //
-// slash-command-step is the exception, and it is named for what it is. This
-// entry used to read "slash-command-entry — nothing measured shows the Desktop
-// composer EXECUTING a slash command rather than storing it as prompt text".
-// That was MEASURED AND DISPROVED on 2026-09-07 against 1.46388.4: typing "/"
-// opens a filtering popup of AXMenuItem elements inside the web area, Return
-// accepts one, and Send runs it — the app rendered the /context report and
-// headed the message "You said: /context". Two trees and the full sequence are
-// at replaydata/agents/claudecode/desktop-evidence/slash-commands.md.
+// A sixth entry, "slash-command-step", used to sit here and is gone. It read
+// "nothing measured shows the Desktop composer EXECUTING a slash command rather
+// than storing it as prompt text", and it was MEASURED AND DISPROVED on
+// 2026-09-07 against 1.46388.4: typing "/" opens a filtering popup of AXMenuItem
+// elements inside the web area, Return accepts one, and Send runs it — the app
+// rendered the /context report and headed the message "You said: /context". Two
+// trees and the full sequence are at
+// replaydata/agents/claudecode/desktop-evidence/slash-commands.md, and StepSlash
+// now drives them.
 //
-// The control exists. This driver has no step that drives it, which is why the
-// step is still refused — but a reader must not take the refusal as evidence
-// that Claude Desktop cannot run slash commands. It can.
+// It is recorded here because a refusal that turns out to be wrong is the one
+// entry a reader must not find silently deleted: the earlier wording is still
+// quoted in cells whose verdict cited it.
 var desktopMissingControls = map[string]string{
 	"session":       "session-list-row",
 	"restart":       "session-restart",

--- a/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
@@ -43,6 +43,39 @@ type frontendVerdict struct {
 	measured string
 }
 
+// frontendVerdictsInCell returns one cell's front-end verdicts.
+//
+// A cell with no result file yields none and no error — cells predate the
+// Desktop contract. Anything else that stops the read IS an error: a file that
+// exists and cannot be parsed must never read as a cell with nothing to say.
+func frontendVerdictsInCell(cellDir, cell string) ([]frontendVerdict, error) {
+	path := filepath.Join(cellDir, desktopresults.FileName)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	doc, err := desktopresults.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", path, err)
+	}
+	verdicts := make([]frontendVerdict, 0, len(doc.Results))
+	for _, result := range doc.Results {
+		if matrix.ExecutionProfile(result.ExecutionProfile) != matrix.ProfileDesktopLocal {
+			continue
+		}
+		if !result.CitesFrontendGaps() {
+			continue
+		}
+		verdicts = append(verdicts, frontendVerdict{
+			cell:     cell,
+			scenario: result.ScenarioID,
+			measured: result.MeasuredDesktopVersion,
+		})
+	}
+	return verdicts, nil
+}
+
 // loadFrontendVerdicts reads every committed cell and returns the desktop-local
 // results that rest on a front-end measurement.
 //
@@ -59,26 +92,11 @@ func loadFrontendVerdicts(scenariosDir string) ([]frontendVerdict, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		path := filepath.Join(scenariosDir, entry.Name(), desktopresults.FileName)
-		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-			continue
-		} else if statErr != nil {
-			return nil, fmt.Errorf("stat %s: %w", path, statErr)
+		found, err := frontendVerdictsInCell(filepath.Join(scenariosDir, entry.Name()), entry.Name())
+		if err != nil {
+			return nil, err
 		}
-		doc, loadErr := desktopresults.Load(path)
-		if loadErr != nil {
-			return nil, fmt.Errorf("load %s: %w", path, loadErr)
-		}
-		for _, result := range doc.Results {
-			if matrix.ExecutionProfile(result.ExecutionProfile) != matrix.ProfileDesktopLocal || !result.CitesFrontendGaps() {
-				continue
-			}
-			verdicts = append(verdicts, frontendVerdict{
-				cell:     entry.Name(),
-				scenario: result.ScenarioID,
-				measured: result.MeasuredDesktopVersion,
-			})
-		}
+		verdicts = append(verdicts, found...)
 	}
 	sort.Slice(verdicts, func(i, j int) bool { return verdicts[i].cell < verdicts[j].cell })
 	return verdicts, nil

--- a/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
@@ -1,0 +1,154 @@
+package desktopdriver
+
+// A FRONT-END verdict is the one Desktop result that can expire while nobody
+// touches the repository. It says what the app SHOWS — "Desktop exposes no Stop
+// control at any point in a turn" (2-20), "Desktop raises no blocking dialog
+// that is not a tool permission prompt" (2-27) — and each was measured once,
+// against one build. Every other verdict class is anchored in-tree: an observed
+// result to its recording, a census result to this package's own grammar, a
+// harness result to the shared runner.
+//
+// Claude Desktop ships on its own schedule, and this driver refuses any build
+// but supportedDesktopVersion. So the moment the pin falls behind the installed
+// app, two things are true at once and only one of them is visible: the driver
+// cannot run a single Desktop cell, and six verdicts still read as present-tense
+// facts about an app nothing has looked at since. That is the shape AGENTS.md
+// names — absence of a finding and inability to look producing the same output.
+// It happened: Desktop moved to 1.49585.0, every Desktop run began refusing at
+// the version gate, `of validate` went on printing OK, and the completeness gate
+// went on calling all fifty cells terminal.
+//
+// This test is the coupling that was missing. Bumping the pin now fails until
+// every front-end verdict is re-measured against the new build, and it names
+// them. It does not decide whether a verdict is still TRUE — only a measurement
+// does that — it refuses to let the question go unasked.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+const claudecodeScenariosDir = "../../../../replaydata/agents/claudecode/scenarios"
+
+// frontendVerdict is one committed front-end claim and the build behind it.
+type frontendVerdict struct {
+	cell     string
+	scenario string
+	measured string
+}
+
+// loadFrontendVerdicts reads every committed cell and returns the desktop-local
+// results that rest on a front-end measurement.
+//
+// It returns an error rather than an empty slice for anything it could not
+// read. A directory it cannot walk and a campaign with no front-end verdicts
+// left must not reach the caller as the same value.
+func loadFrontendVerdicts(scenariosDir string) ([]frontendVerdict, error) {
+	entries, err := os.ReadDir(scenariosDir)
+	if err != nil {
+		return nil, fmt.Errorf("read the claudecode scenarios directory: %w", err)
+	}
+	verdicts := make([]frontendVerdict, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(scenariosDir, entry.Name(), desktopresults.FileName)
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			continue
+		} else if statErr != nil {
+			return nil, fmt.Errorf("stat %s: %w", path, statErr)
+		}
+		doc, loadErr := desktopresults.Load(path)
+		if loadErr != nil {
+			return nil, fmt.Errorf("load %s: %w", path, loadErr)
+		}
+		for _, result := range doc.Results {
+			if matrix.ExecutionProfile(result.ExecutionProfile) != matrix.ProfileDesktopLocal || !result.CitesFrontendGaps() {
+				continue
+			}
+			verdicts = append(verdicts, frontendVerdict{
+				cell:     entry.Name(),
+				scenario: result.ScenarioID,
+				measured: result.MeasuredDesktopVersion,
+			})
+		}
+	}
+	sort.Slice(verdicts, func(i, j int) bool { return verdicts[i].cell < verdicts[j].cell })
+	return verdicts, nil
+}
+
+// auditFrontendVerdicts returns one line per verdict measured against a build
+// this driver no longer supports.
+func auditFrontendVerdicts(supported string, verdicts []frontendVerdict) []string {
+	stale := make([]string, 0, len(verdicts))
+	for _, verdict := range verdicts {
+		if verdict.measured == supported {
+			continue
+		}
+		stale = append(stale, fmt.Sprintf(
+			"%s (%s): measured on Desktop %q, but the driver supports %q",
+			verdict.cell, verdict.scenario, verdict.measured, supported,
+		))
+	}
+	return stale
+}
+
+func TestFrontendVerdictsNameTheSupportedDesktopVersion(t *testing.T) {
+	verdicts, err := loadFrontendVerdicts(claudecodeScenariosDir)
+	if err != nil {
+		t.Fatalf("collect the committed front-end verdicts: %v", err)
+	}
+	// Finding none means the walk broke, not that the campaign is clean: these
+	// verdicts are committed data and cells only ever gain them.
+	if len(verdicts) == 0 {
+		t.Fatalf("no front-end Desktop verdict found under %s — this check cannot run", claudecodeScenariosDir)
+	}
+	for _, stale := range auditFrontendVerdicts(supportedDesktopVersion, verdicts) {
+		t.Errorf(
+			"a front-end Desktop verdict is stale: %s\n"+
+				"re-measure it against %s and update its reason, or restore the pin",
+			stale, supportedDesktopVersion,
+		)
+	}
+}
+
+// TestFrontendVerdictAuditCatchesAPinBump mutates the thing the audit protects.
+// The audit is an ADDED check, so it has no state in which it ever ran red on
+// its own: what proves it works is that moving the pin turns every committed
+// verdict red, by name.
+func TestFrontendVerdictAuditCatchesAPinBump(t *testing.T) {
+	verdicts, err := loadFrontendVerdicts(claudecodeScenariosDir)
+	if err != nil {
+		t.Fatalf("collect the committed front-end verdicts: %v", err)
+	}
+	if got := auditFrontendVerdicts(supportedDesktopVersion, verdicts); len(got) != 0 {
+		t.Fatalf("the committed verdicts must be clean before the mutation: %v", got)
+	}
+
+	const bumped = "1.49585.0"
+	if bumped == supportedDesktopVersion {
+		t.Fatalf("the mutation must differ from the pin %q", supportedDesktopVersion)
+	}
+	stale := auditFrontendVerdicts(bumped, verdicts)
+	if len(stale) != len(verdicts) {
+		t.Fatalf("a pin bump must flag every front-end verdict; flagged %d of %d", len(stale), len(verdicts))
+	}
+}
+
+// TestFrontendVerdictAuditRefusesAnUnreadableTree keeps "cannot look" separate
+// from "found nothing".
+func TestFrontendVerdictAuditRefusesAnUnreadableTree(t *testing.T) {
+	if _, err := loadFrontendVerdicts(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("a scenarios directory that cannot be read must be an error, not an empty result")
+	}
+	if verdicts, err := loadFrontendVerdicts(t.TempDir()); err != nil || len(verdicts) != 0 {
+		t.Fatalf("an empty tree must read cleanly and carry no verdict; got %v, %v", verdicts, err)
+	}
+}

--- a/tools/onboarding-factory/internal/desktopresults/schema.go
+++ b/tools/onboarding-factory/internal/desktopresults/schema.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 
 	"irrlicht/tools/onboarding-factory/internal/matrix"
 )
@@ -53,6 +54,12 @@ type Evidence struct {
 	Environment     string `json:"environment"`
 }
 
+// FrontendGapsFile is the shared prose evidence a front-end verdict cites. A
+// result that names it is claiming something about what Claude Desktop SHOWS,
+// which is true of one build and unchecked on every other — see
+// MeasuredDesktopVersion.
+const FrontendGapsFile = "frontend-gaps.md"
+
 // Result is one execution-profile answer for the cell named by ScenarioID.
 type Result struct {
 	ScenarioID       string    `json:"scenario_id"`
@@ -63,6 +70,30 @@ type Result struct {
 	MissingControl   string    `json:"missing_control,omitempty"`
 	Evidence         *Evidence `json:"evidence,omitempty"`
 	EvidenceRefs     []string  `json:"evidence_refs,omitempty"`
+	// MeasuredDesktopVersion is the Claude Desktop build a FRONT-END verdict
+	// was measured against. It is required of a result citing FrontendGapsFile
+	// and refused everywhere else.
+	//
+	// Why it is a field and not a sentence in Reason. These verdicts read as
+	// present-tense facts — "Desktop exposes no Stop control at any point in a
+	// turn" — and each one was measured once, on one build. Held only in prose,
+	// the build they belong to cannot be compared to anything, so a Desktop
+	// release turned them stale in silence: the driver refused to run at all
+	// against the new build, and `of validate` still said OK. As a field it is
+	// comparable, and the desktopdriver package fails the moment the pin and
+	// these verdicts disagree.
+	MeasuredDesktopVersion string `json:"measured_desktop_version,omitempty"`
+}
+
+// CitesFrontendGaps reports whether the result rests on a front-end
+// measurement, by the shared evidence file it names.
+func (result Result) CitesFrontendGaps() bool {
+	for _, ref := range result.EvidenceRefs {
+		if path.Base(ref) == FrontendGapsFile {
+			return true
+		}
+	}
+	return false
 }
 
 // Document is one versioned per-cell execution-results.json artifact.

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -397,6 +397,12 @@ func (v *validation) validateObservedShape(context resultValidationContext) {
 	if strings.TrimSpace(result.MissingControl) != "" {
 		v.add(context.target, "missing_control", "is only valid for not-runnable")
 	}
+	if strings.TrimSpace(result.MeasuredDesktopVersion) != "" {
+		// The recording's own desktop-environment.json already carries the
+		// build. A second copy here would be free to disagree with it.
+		v.add(context.target, "measured_desktop_version",
+			"is only valid for a non-observed result; the recording's "+EnvironmentFile+" carries the build")
+	}
 	if result.Outcome == OutcomeObservedFailure && strings.TrimSpace(result.Reason) == "" {
 		v.add(context.target, "reason", "is required for observed-failure")
 	}
@@ -431,6 +437,7 @@ func (v *validation) validateCanonicalEvidenceNames(context resultValidationCont
 func (v *validation) validateNonObservedShape(context resultValidationContext) {
 	v.validateNonObservedEvidence(context)
 	v.validateNonObservedExclusions(context)
+	v.validateMeasuredDesktopVersion(context)
 }
 
 func (v *validation) validateNonObservedEvidence(context resultValidationContext) {
@@ -471,6 +478,35 @@ func (v *validation) allowedNonObservedEvidence(boundary evidenceBoundary) bool 
 		}
 	}
 	return false
+}
+
+// validateMeasuredDesktopVersion binds a front-end verdict to the build it was
+// measured on.
+//
+// A front-end verdict is the one class of Desktop result that can go stale
+// without anybody touching the repository: it describes what the app shows, and
+// the app ships a new build on its own schedule. Every other class is anchored
+// to something in-tree — a recording, the driver's own grammar census, a
+// harness limitation — and changes only when the tree does.
+//
+// The rule is deliberately narrow. Requiring the field of an observed result
+// would duplicate the recording's own desktop-environment.json, and two copies
+// of one fact drift; requiring it of a census verdict would demand a
+// re-measurement for a gap that is not a measurement at all.
+func (v *validation) validateMeasuredDesktopVersion(context resultValidationContext) {
+	result := context.result
+	measured := strings.TrimSpace(result.MeasuredDesktopVersion)
+	if !result.CitesFrontendGaps() {
+		if measured != "" {
+			v.add(context.target, "measured_desktop_version",
+				"is only valid for a result citing "+FrontendGapsFile)
+		}
+		return
+	}
+	if measured == "" {
+		v.add(context.target, "measured_desktop_version",
+			"is required for a front-end verdict: name the Claude Desktop build it was measured on")
+	}
 }
 
 func (v *validation) validateNonObservedExclusions(context resultValidationContext) {


### PR DESCRIPTION
Found while working #1892. It is not a recording; it is the reason the recording campaign's verdicts could go stale without saying so.

## The silence

Six Claude Code cells carry a Desktop verdict that is a claim about **what the app shows**:

| Cell | The claim |
| --- | --- |
| 2-3 task-list | the agent has no task-list tool |
| 2-18 user-blocking-plan-mode-approval | the owned-session menu cannot be clicked |
| 2-20 user-esc-interrupt | Desktop exposes no Stop control at any point in a turn |
| 2-26 permission-gate-non-mutating-tool | the Read tool is never gated |
| 2-27 blocking-dialog-without-tool-call | Desktop raises no blocking dialog that is not a tool permission prompt |
| 3-5 workflow-fanout | the agent does not fan out |

They are the only Desktop verdicts that can expire while nobody touches the repository. Every other class is anchored in-tree — an observed verdict to its recording, a census verdict to the driver's own grammar, a harness verdict to the shared runner.

Claude Desktop ships on its own schedule, and `desktopdriver` refuses every build but the one its catalog pins (`live.go:178`, exact equality, no override). So when the installed app moved to **1.49585.0** against a pin of **1.46388.4**, two things became true at once and only one was visible:

```
$ echo '{"protocolVersion":1,"command":"preflight"}' | claude-desktop-helper
{"status":{"desktopVersion":"1.49585.0","bundledClaudeCodeVersion":"2.1.260",...}}

$ grep supportedDesktopVersion tools/onboarding-factory/internal/desktopdriver/catalog.go
const supportedDesktopVersion = "1.46388.4"

$ go run ./tools/onboarding-factory/cmd/of validate
of validate: OK — catalog + cells are schema-valid and referentially consistent
```

No Desktop cell can run at all, and those six verdicts go on reading as present-tense facts about an app nothing has looked at since. Absence of a finding and inability to look produce the same output.

Four of the six never named a build at all. The two that did named it only inside prose, where nothing can compare it.

## What changes

- **`measured_desktop_version`** is a field on a Desktop result. It is **required** of a verdict citing `frontend-gaps.md` and **refused** everywhere else — an observed result because its recording's `desktop-environment.json` already carries the build (two copies of one fact are free to disagree), a census verdict because a grammar gap is not a measurement.
- **`TestFrontendVerdictsNameTheSupportedDesktopVersion`** fails when the pin and those verdicts disagree, and names each cell. Bumping the pin now costs a re-measurement of every front-end claim — which is what it always cost, unpriced.
- The six committed verdicts are backfilled with `1.46388.4`, the build `frontend-gaps.md`'s own header names. One added line per file, nothing else touched.

## Proof

Both checks are additions, so neither has a state in which it ever ran red on its own. Each is proved by mutating what it protects.

**Bump the pin, and the audit names all six and no others:**

```
$ sed -i '' 's/"1.46388.4"/"1.49585.0"/' .../catalog.go
$ go test ./tools/onboarding-factory/internal/desktopdriver/ -run TestFrontendVerdictsNameTheSupportedDesktopVersion
--- FAIL: TestFrontendVerdictsNameTheSupportedDesktopVersion (0.01s)
    a front-end Desktop verdict is stale: 2-18_user-blocking-plan-mode-approval ... measured on Desktop "1.46388.4", but the driver supports "1.49585.0"
    ... 2-20_user-esc-interrupt ...
    ... 2-26_permission-gate-non-mutating-tool ...
    ... 2-27_blocking-dialog-without-tool-call ...
    ... 2-3_task-list ...
    ... 3-5_workflow-fanout ...
```

That mutation is committed as `TestFrontendVerdictAuditCatchesAPinBump`, not left in this description.

**`TestValidateDesktopMeasuredVersionMutations`** commits five more: the field absent from a front-end verdict, blank on one, present on a census verdict, present on an observed result, and the accepted shape.

**Cannot-look stays apart from found-nothing:** `loadFrontendVerdicts` returns an error for a tree it cannot read, the audit fails when it finds zero verdicts, and `TestFrontendVerdictAuditRefusesAnUnreadableTree` pins both.

## Also corrected

`recipe.go` still told a reader that the Desktop driver "has no step that drives" a slash command and that the step "is still refused". #1933 gave it `StepSlash`; `desktopElicits` has carried it since, and `recipe-census.txt`'s own header already says so. A refusal comment that has stopped being true is exactly the kind of dismissal AGENTS.md asks to carry evidence, so the entry is rewritten as the history it now is rather than deleted — the earlier wording is still quoted in cells whose verdict cited it.

## Gates

`go test ./tools/onboarding-factory/... -race -count=1`, `of validate`, `tools/replay-fixtures.sh`, and `tools/preflight.sh --only go / --only tools / --only arch` all pass. The ARS composite is unchanged at 7.929.

## What this does not do

It does not re-measure anything. Whether 2-20's "no Stop control" still holds on 1.49585.0 is an open question this PR deliberately leaves open — see the note on #1892.

Refs #1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc