### PR TITLE
fix(onboard): the front-end evidence set was one filename, and two notes exist

### DIFF
--- a/replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md
+++ b/replaydata/agents/claudecode/desktop-evidence/frontend-gaps.md
@@ -11,9 +11,12 @@ Measured against Claude Desktop 1.46388.4 with bundled Claude Code 2.1.260, on
 saved at the moment of refusal.
 
 Every verdict that cites this file records that build in its own
-`measured_desktop_version`, and `of validate` refuses one that does not. These
-are the only Desktop verdicts that can expire without anybody touching the
-repository: they say what the app SHOWS, and Claude Desktop ships new builds on
+`measured_desktop_version`, and `of validate` refuses one that does not. The
+same holds for `slash-commands.md`, the other note measured against a specific
+build; `desktopresults.FrontendEvidenceFiles()` is the list, and
+`desktopdriver.TestFrontendEvidenceSetCoversEveryNoteNamingABuild` fails if a
+note here names a build and is missing from it. These are the only Desktop
+verdicts that can expire without anybody touching the repository: they say what the app SHOWS, and Claude Desktop ships new builds on
 its own schedule. The driver refuses every build but the one its catalog is
 pinned to, so
 `desktopdriver.TestFrontendVerdictsNameTheSupportedDesktopVersion` fails the

--- a/replaydata/agents/claudecode/desktop-evidence/slash-commands.md
+++ b/replaydata/agents/claudecode/desktop-evidence/slash-commands.md
@@ -10,6 +10,21 @@ to it, both from Claude Desktop 1.46388.4 with bundled Claude Code 2.1.260, and
 both with the macOS menu-bar subtree removed (it carries the operator's Recent
 Items, and nothing about the composer).
 
+Everything below is therefore a claim about one build, exactly like
+`frontend-gaps.md`. Every verdict citing this file records that build in its own
+`measured_desktop_version`, and `of validate` refuses one that does not.
+`desktopdriver.TestFrontendVerdictsNameTheSupportedDesktopVersion` then fails the
+moment the driver's pin and those verdicts disagree, so moving the pin means
+re-measuring this note rather than assuming it held.
+
+It did not work that way at first. The rule shipped keyed on the single
+filename `frontend-gaps.md`, so the four verdicts citing this note — 1-6, 2-5,
+2-7 and 5-3 — named no build and the freshness guard walked past them.
+`desktopresults.FrontendEvidenceFiles()` now holds both notes, and
+`desktopdriver.TestFrontendEvidenceSetCoversEveryNoteNamingABuild` derives the
+same set from the notes themselves: a note that names a Claude Desktop build and
+is not declared fails the build.
+
 ## What was measured
 
 Every step below ran through `claude-desktop-helper` against the live app. Each

--- a/replaydata/agents/claudecode/scenarios/1-6_checkpoint-rewind/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/1-6_checkpoint-rewind/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "Two gaps, neither about slash commands existing. Claude Desktop runs them and the driver drives them (see slash-commands.md), and this recipe's /rewind is in the popup. But the recipe delivers it through a `send` step rather than a `slash` step, and a send would submit the command as prose \u2014 so the recipe would need changing, which would change what cli-local records. The separate keyboard-key:\"Down\" gap is unmeasured and stands on its own. The cell stays valid for cli-local, where it is recorded today.",
       "missing_control": "keyboard-key:\"Down\", slash-command-popup",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/slash-commands.md",
         "replaydata/agents/claudecode/desktop-evidence/recipe-census.txt",

--- a/replaydata/agents/claudecode/scenarios/2-5_synchronous-slash-command/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-5_synchronous-slash-command/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "Measured on 2026-09-07 against Claude Desktop 1.46388.4: the composer DOES run slash commands. Typing \"/\" opens a filtering popup of AXMenuItem elements inside the web area, Return accepts an entry, and Send executes it \u2014 the app rendered the /context report and headed the message \"You said: /context\". This cell is the one slash case with a REAL Desktop gap. Its /cost exists as the alias \"usage (cost)\", but /help does not: the prefix returns \"debug\", \"team-onboarding\", \"heapdump\" and \"find-skills\" \u2014 fuzzy matches, no help command. The cell therefore stays not-runnable even after the driver grows a slash step. It stays valid for cli-local, where it is recorded today.",
       "missing_control": "the \"/help\" command in the Desktop command set",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/slash-commands.md",
         "replaydata/agents/claudecode/desktop-evidence/recipe-census.txt",

--- a/replaydata/agents/claudecode/scenarios/2-7_autonomous-loop/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/2-7_autonomous-loop/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The driver now drives Claude Desktop's command popup, and this recipe's /goal exists there. It is still not runnable, for a narrower and newly measured reason: the composer rewrites a TYPED backtick into an inline code node, and this recipe's goal text names two shell commands in backticks. Measured 2026-09-07 on 1.46388.4 \u2014 typing \"a `code` b\" leaves the composer reading \"a code<zero-width space> b\", and sending such a message headed the conversation \"You said: /compact keep echo hi please\", so the agent receives text the recipe did not write. Only the backtick does this: *, _, ** and # all survive. `send` steps are unaffected \u2014 they use set_value, which writes the accessibility value directly and keeps a backtick verbatim. Sibling cell 2-8, whose goal text has no backticks, records through the same slash step. The cell stays valid for cli-local, where it is recorded today.",
       "missing_control": "verbatim-typed-text",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/slash-commands.md",
         "replaydata/agents/claudecode/desktop-evidence/recipe-census.txt",

--- a/replaydata/agents/claudecode/scenarios/5-3_model-switch-midsession/execution-results.json
+++ b/replaydata/agents/claudecode/scenarios/5-3_model-switch-midsession/execution-results.json
@@ -7,6 +7,7 @@
       "outcome": "not-runnable",
       "reason": "The slash half of this recipe is runnable now: /model is in the Desktop command popup and the driver drives it, arguments included (see slash-commands.md). What is left is keyboard-key:\"1\", the model-picker selection the recipe presses after each /model call. The Desktop helper refuses a keystroke with no observable postcondition, and nothing measured shows what pressing \"1\" changes in the composer. The cell stays valid for cli-local, where it is recorded today.",
       "missing_control": "keyboard-key:\"1\"",
+      "measured_desktop_version": "1.46388.4",
       "evidence_refs": [
         "replaydata/agents/claudecode/desktop-evidence/slash-commands.md",
         "replaydata/agents/claudecode/desktop-evidence/recipe-census.txt",

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
 )
 
 const (
@@ -564,13 +566,22 @@ func writeJSONFixture(t *testing.T, path string, value any) {
 	write(t, path, string(b)+"\n")
 }
 
-// makeFrontendVerdict turns a fixture cell's evidence reference into the shared
-// front-end file, which is what marks a verdict as a claim about what Claude
-// Desktop SHOWS rather than about the driver, the harness or a recording.
+// makeFrontendVerdict turns a fixture cell's evidence reference into one of the
+// shared front-end notes, which is what marks a verdict as a claim about what
+// Claude Desktop SHOWS rather than about the driver, the harness or a recording.
 func makeFrontendVerdict(t *testing.T, fixture desktopFixture, scenario string) string {
 	t.Helper()
+	return makeVerdictCiting(t, fixture, scenario, desktopresults.FrontendGapsFile)
+}
+
+// makeVerdictCiting is makeFrontendVerdict for one named note. Every note in
+// desktopresults.FrontendEvidenceFiles() must carry the rule, not just the first
+// one: the rule shipped keyed on a single filename while a second note already
+// existed, and four verdicts citing it were exempt.
+func makeVerdictCiting(t *testing.T, fixture desktopFixture, scenario, note string) string {
+	t.Helper()
 	cellDir := fixture.cellDirs[scenario]
-	evidencePath := filepath.Join(cellDir, "desktop-evidence", "frontend-gaps.md")
+	evidencePath := filepath.Join(cellDir, "desktop-evidence", note)
 	write(t, evidencePath, "Measured against Claude Desktop 9.9.9.\n")
 	ref := filepath.ToSlash(strings.TrimPrefix(evidencePath, fixture.root+string(filepath.Separator)))
 	path := filepath.Join(cellDir, desktopResultsFile)
@@ -615,9 +626,25 @@ func TestValidateDesktopMeasuredVersionMutations(t *testing.T) {
 		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "9.9.9" })
 		requireDesktopFinding(t, fixture.root, "not-runnable", "measured_desktop_version")
 	})
+	t.Run("every declared front-end note carries the rule", func(t *testing.T) {
+		// Keyed on one filename, the rule exempted every verdict citing the
+		// other note. Drive the whole declared set, so a note added later
+		// without the rule fails here instead of widening the blind spot.
+		notes := desktopresults.FrontendEvidenceFiles()
+		if len(notes) == 0 {
+			t.Fatal("the declared front-end note set is empty — this check cannot run")
+		}
+		for _, note := range notes {
+			t.Run(note, func(t *testing.T) {
+				fixture := desktopResultsRepo(t, false)
+				makeVerdictCiting(t, fixture, "not-runnable", note)
+				requireDesktopFinding(t, fixture.root, "not-runnable", "measured_desktop_version")
+			})
+		}
+	})
 	t.Run("observed result may not carry a build", func(t *testing.T) {
-		// The recording's own desktop-environment.json already carries it, and
-		// two copies of one fact are free to disagree.
+		// The recording's own manifest.json already carries it in
+		// desktop_app_version, and two copies of one fact are free to disagree.
 		fixture := desktopResultsRepo(t, false)
 		path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
 		mutateFirstResult(t, path, func(r map[string]any) { r["measured_desktop_version"] = "9.9.9" })

--- a/tools/onboarding-factory/internal/desktopdriver/frontend_evidence_coverage_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/frontend_evidence_coverage_test.go
@@ -1,0 +1,157 @@
+package desktopdriver
+
+// The freshness guard next door ties a front-end verdict to the build it names.
+// It can only tie the verdicts it recognises, and it recognises them by the
+// evidence note they cite — so the set of notes IS the guard's reach.
+//
+// That set shipped holding one filename while two notes existed. frontend-gaps.md
+// was listed; slash-commands.md was not, though it opens with "both from Claude
+// Desktop 1.46388.4 with bundled Claude Code 2.1.260" and four verdicts rest on
+// it. All four passed validation naming no build at all, and the freshness guard
+// walked straight past them. Nothing was wrong with the guard's logic; the set it
+// was handed did not describe the tree.
+//
+// This test refuses to let the set be a hand-typed list again. It derives the
+// same answer from the notes themselves — a note that names a concrete Claude
+// Desktop build is a front-end measurement — and fails when the two disagree in
+// either direction. Adding the next measurement note now fails here until it is
+// declared, instead of quietly widening the blind spot.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
+)
+
+const claudecodeEvidenceDir = "../../../../replaydata/agents/claudecode/desktop-evidence"
+
+// desktopBuildMention matches a note stating the build it was measured on. The
+// committed notes all write it the same way, in their opening paragraph.
+var desktopBuildMention = regexp.MustCompile(`Claude Desktop [0-9]+\.[0-9]+\.[0-9]+`)
+
+// notesDeclaringADesktopBuild returns the prose notes that name a concrete
+// Claude Desktop build, sorted.
+//
+// A directory it cannot read is an error, never an empty result: "no note names
+// a build" and "no note could be opened" must not reach the caller alike.
+func notesDeclaringADesktopBuild(evidenceDir string) ([]string, error) {
+	entries, err := os.ReadDir(evidenceDir)
+	if err != nil {
+		return nil, fmt.Errorf("read the desktop-evidence directory: %w", err)
+	}
+	declaring := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(evidenceDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		if desktopBuildMention.Match(body) {
+			declaring = append(declaring, name)
+		}
+	}
+	sort.Strings(declaring)
+	return declaring, nil
+}
+
+// auditFrontendEvidenceCoverage compares the declared set against the notes that
+// actually name a build, and returns one line per disagreement.
+//
+// It reports both directions. A note that names a build and is not declared is
+// the defect that happened; a declared name with no such note is a typo that
+// would silently exempt every verdict citing the real file.
+func auditFrontendEvidenceCoverage(declared, declaring []string) []string {
+	declaredSet := make(map[string]bool, len(declared))
+	for _, name := range declared {
+		declaredSet[name] = true
+	}
+	declaringSet := make(map[string]bool, len(declaring))
+	for _, name := range declaring {
+		declaringSet[name] = true
+	}
+
+	findings := make([]string, 0, len(declared)+len(declaring))
+	for _, name := range declaring {
+		if !declaredSet[name] {
+			findings = append(findings, fmt.Sprintf(
+				"%s names a Claude Desktop build but is not in desktopresults.FrontendEvidenceFiles(): "+
+					"every verdict citing it is exempt from the freshness guard", name))
+		}
+	}
+	for _, name := range declared {
+		if !declaringSet[name] {
+			findings = append(findings, fmt.Sprintf(
+				"desktopresults.FrontendEvidenceFiles() names %s, and no note by that name declares a "+
+					"Claude Desktop build", name))
+		}
+	}
+	sort.Strings(findings)
+	return findings
+}
+
+func TestFrontendEvidenceSetCoversEveryNoteNamingABuild(t *testing.T) {
+	declaring, err := notesDeclaringADesktopBuild(claudecodeEvidenceDir)
+	if err != nil {
+		t.Fatalf("collect the notes that name a Desktop build: %v", err)
+	}
+	// Finding none means the scan broke. These notes are committed data, and
+	// the freshness guard is meaningless without at least one.
+	if len(declaring) == 0 {
+		t.Fatalf("no note under %s names a Claude Desktop build — this check cannot run", claudecodeEvidenceDir)
+	}
+	for _, finding := range auditFrontendEvidenceCoverage(desktopresults.FrontendEvidenceFiles(), declaring) {
+		t.Errorf("the front-end evidence set does not describe the tree: %s", finding)
+	}
+}
+
+// TestFrontendEvidenceCoverageCatchesAnUndeclaredNote replays the exact defect.
+// The audit is an ADDED check with no red state of its own, so what proves it
+// works is shrinking the declared set back to the single filename it shipped
+// with and watching the second note surface by name.
+func TestFrontendEvidenceCoverageCatchesAnUndeclaredNote(t *testing.T) {
+	declaring, err := notesDeclaringADesktopBuild(claudecodeEvidenceDir)
+	if err != nil {
+		t.Fatalf("collect the notes that name a Desktop build: %v", err)
+	}
+	if got := auditFrontendEvidenceCoverage(desktopresults.FrontendEvidenceFiles(), declaring); len(got) != 0 {
+		t.Fatalf("the committed set must be clean before the mutation: %v", got)
+	}
+
+	// The set as it shipped: frontend-gaps.md alone.
+	findings := auditFrontendEvidenceCoverage([]string{desktopresults.FrontendGapsFile}, declaring)
+	if len(findings) == 0 {
+		t.Fatal("dropping a note from the declared set must be caught")
+	}
+	if !strings.Contains(strings.Join(findings, "\n"), desktopresults.SlashCommandsFile) {
+		t.Fatalf("the finding must name the dropped note; got %v", findings)
+	}
+}
+
+// TestFrontendEvidenceCoverageCatchesAPhantomName is the other direction: a name
+// in the set that no note answers to exempts nothing and protects nothing.
+func TestFrontendEvidenceCoverageCatchesAPhantomName(t *testing.T) {
+	findings := auditFrontendEvidenceCoverage([]string{"frontend-gasp.md"}, []string{desktopresults.FrontendGapsFile})
+	if len(findings) != 2 {
+		t.Fatalf("a misspelt name must flag both the phantom and the uncovered note; got %v", findings)
+	}
+}
+
+// TestFrontendEvidenceCoverageRefusesAnUnreadableTree keeps "cannot look"
+// separate from "found nothing".
+func TestFrontendEvidenceCoverageRefusesAnUnreadableTree(t *testing.T) {
+	if _, err := notesDeclaringADesktopBuild(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Fatal("an evidence directory that cannot be read must be an error, not an empty result")
+	}
+	if notes, err := notesDeclaringADesktopBuild(t.TempDir()); err != nil || len(notes) != 0 {
+		t.Fatalf("an empty tree must read cleanly and name no note; got %v, %v", notes, err)
+	}
+}

--- a/tools/onboarding-factory/internal/desktopdriver/frontend_evidence_coverage_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/frontend_evidence_coverage_test.go
@@ -70,31 +70,29 @@ func notesDeclaringADesktopBuild(evidenceDir string) ([]string, error) {
 // the defect that happened; a declared name with no such note is a typo that
 // would silently exempt every verdict citing the real file.
 func auditFrontendEvidenceCoverage(declared, declaring []string) []string {
-	declaredSet := make(map[string]bool, len(declared))
-	for _, name := range declared {
-		declaredSet[name] = true
-	}
-	declaringSet := make(map[string]bool, len(declaring))
-	for _, name := range declaring {
-		declaringSet[name] = true
-	}
-
-	findings := make([]string, 0, len(declared)+len(declaring))
-	for _, name := range declaring {
-		if !declaredSet[name] {
-			findings = append(findings, fmt.Sprintf(
-				"%s names a Claude Desktop build but is not in desktopresults.FrontendEvidenceFiles(): "+
-					"every verdict citing it is exempt from the freshness guard", name))
-		}
-	}
-	for _, name := range declared {
-		if !declaringSet[name] {
-			findings = append(findings, fmt.Sprintf(
-				"desktopresults.FrontendEvidenceFiles() names %s, and no note by that name declares a "+
-					"Claude Desktop build", name))
-		}
-	}
+	findings := append(
+		namesMissingFrom(declaring, declared, "%s names a Claude Desktop build but is not in "+
+			"desktopresults.FrontendEvidenceFiles(): every verdict citing it is exempt from the "+
+			"freshness guard"),
+		namesMissingFrom(declared, declaring, "desktopresults.FrontendEvidenceFiles() names %s, and "+
+			"no note by that name declares a Claude Desktop build")...,
+	)
 	sort.Strings(findings)
+	return findings
+}
+
+// namesMissingFrom formats one finding per name absent from present.
+func namesMissingFrom(names, present []string, format string) []string {
+	known := make(map[string]bool, len(present))
+	for _, name := range present {
+		known[name] = true
+	}
+	findings := make([]string, 0, len(names))
+	for _, name := range names {
+		if !known[name] {
+			findings = append(findings, fmt.Sprintf(format, name))
+		}
+	}
 	return findings
 }
 

--- a/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
+++ b/tools/onboarding-factory/internal/desktopdriver/verdict_freshness_test.go
@@ -64,7 +64,7 @@ func frontendVerdictsInCell(cellDir, cell string) ([]frontendVerdict, error) {
 		if matrix.ExecutionProfile(result.ExecutionProfile) != matrix.ProfileDesktopLocal {
 			continue
 		}
-		if !result.CitesFrontendGaps() {
+		if !result.CitesFrontendEvidence() {
 			continue
 		}
 		verdicts = append(verdicts, frontendVerdict{

--- a/tools/onboarding-factory/internal/desktopresults/schema.go
+++ b/tools/onboarding-factory/internal/desktopresults/schema.go
@@ -54,11 +54,28 @@ type Evidence struct {
 	Environment     string `json:"environment"`
 }
 
-// FrontendGapsFile is the shared prose evidence a front-end verdict cites. A
-// result that names it is claiming something about what Claude Desktop SHOWS,
-// which is true of one build and unchecked on every other — see
-// MeasuredDesktopVersion.
-const FrontendGapsFile = "frontend-gaps.md"
+// The shared prose notes a FRONT-END verdict cites. A result that names one of
+// these is claiming something about what Claude Desktop SHOWS, which is true of
+// one build and unchecked on every other — see MeasuredDesktopVersion.
+//
+// The set is plural on purpose. It was a single file when the rule shipped, and
+// a second measurement note already existed: slash-commands.md carries its own
+// "both from Claude Desktop 1.46388.4" header, four verdicts rest on it, and
+// not one of them named a build, because the rule asked only about
+// frontend-gaps.md. A set keyed on one filename tests the filename rather than
+// the claim. desktopdriver's evidence-coverage test derives the same set from
+// the notes themselves and fails when a note declaring a build is missing here.
+const (
+	FrontendGapsFile  = "frontend-gaps.md"
+	SlashCommandsFile = "slash-commands.md"
+)
+
+// FrontendEvidenceFiles returns the front-end notes, in stable order. It
+// returns a fresh slice: a caller must not be able to shrink the set that
+// decides which verdicts carry a build.
+func FrontendEvidenceFiles() []string {
+	return []string{FrontendGapsFile, SlashCommandsFile}
+}
 
 // Result is one execution-profile answer for the cell named by ScenarioID.
 type Result struct {
@@ -71,8 +88,8 @@ type Result struct {
 	Evidence         *Evidence `json:"evidence,omitempty"`
 	EvidenceRefs     []string  `json:"evidence_refs,omitempty"`
 	// MeasuredDesktopVersion is the Claude Desktop build a FRONT-END verdict
-	// was measured against. It is required of a result citing FrontendGapsFile
-	// and refused everywhere else.
+	// was measured against. It is required of a result citing one of
+	// FrontendEvidenceFiles and refused everywhere else.
 	//
 	// Why it is a field and not a sentence in Reason. These verdicts read as
 	// present-tense facts — "Desktop exposes no Stop control at any point in a
@@ -85,12 +102,16 @@ type Result struct {
 	MeasuredDesktopVersion string `json:"measured_desktop_version,omitempty"`
 }
 
-// CitesFrontendGaps reports whether the result rests on a front-end
-// measurement, by the shared evidence file it names.
-func (result Result) CitesFrontendGaps() bool {
+// CitesFrontendEvidence reports whether the result rests on a front-end
+// measurement, by the shared evidence note it names.
+func (result Result) CitesFrontendEvidence() bool {
+	notes := FrontendEvidenceFiles()
 	for _, ref := range result.EvidenceRefs {
-		if path.Base(ref) == FrontendGapsFile {
-			return true
+		base := path.Base(ref)
+		for _, note := range notes {
+			if base == note {
+				return true
+			}
 		}
 	}
 	return false

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -398,10 +398,16 @@ func (v *validation) validateObservedShape(context resultValidationContext) {
 		v.add(context.target, "missing_control", "is only valid for not-runnable")
 	}
 	if strings.TrimSpace(result.MeasuredDesktopVersion) != "" {
-		// The recording's own desktop-environment.json already carries the
-		// build. A second copy here would be free to disagree with it.
+		// The recording's own manifest.json already carries the build, in
+		// desktop_app_version — the field identity.go reads. A second copy here
+		// would be free to disagree with it.
+		//
+		// This message used to name desktop-environment.json, which carries
+		// selected_environment and requested_workspace and no version at all.
+		// A message that sends a reader to the wrong file is worse than none:
+		// it looks like evidence.
 		v.add(context.target, "measured_desktop_version",
-			"is only valid for a non-observed result; the recording's "+EnvironmentFile+" carries the build")
+			"is only valid for a non-observed result; the recording's manifest.json carries the build in desktop_app_version")
 	}
 	if result.Outcome == OutcomeObservedFailure && strings.TrimSpace(result.Reason) == "" {
 		v.add(context.target, "reason", "is required for observed-failure")
@@ -490,16 +496,16 @@ func (v *validation) allowedNonObservedEvidence(boundary evidenceBoundary) bool 
 // harness limitation — and changes only when the tree does.
 //
 // The rule is deliberately narrow. Requiring the field of an observed result
-// would duplicate the recording's own desktop-environment.json, and two copies
-// of one fact drift; requiring it of a census verdict would demand a
-// re-measurement for a gap that is not a measurement at all.
+// would duplicate the recording's own manifest.json, and two copies of one fact
+// drift; requiring it of a census verdict would demand a re-measurement for a
+// gap that is not a measurement at all.
 func (v *validation) validateMeasuredDesktopVersion(context resultValidationContext) {
 	result := context.result
 	measured := strings.TrimSpace(result.MeasuredDesktopVersion)
-	if !result.CitesFrontendGaps() {
+	if !result.CitesFrontendEvidence() {
 		if measured != "" {
 			v.add(context.target, "measured_desktop_version",
-				"is only valid for a result citing "+FrontendGapsFile)
+				"is only valid for a result citing one of "+strings.Join(FrontendEvidenceFiles(), ", "))
 		}
 		return
 	}


### PR DESCRIPTION
Found while surveying #1893's cells. #1940 made a front-end Desktop verdict name
the build it was measured on, and tied that build to the driver's pin — but it
keyed the rule on a single filename, `frontend-gaps.md`, while a second
measurement note already existed.

`slash-commands.md` opens with *"both from Claude Desktop 1.46388.4 with bundled
Claude Code 2.1.260"*. Four verdicts rest on it — **1-6, 2-5, 2-7, 5-3** — and
none named a build. `of validate` printed OK and the freshness guard walked past
all four. The guard's logic was right; the set it was handed did not describe
the tree.

## What changed

- `desktopresults.FrontendEvidenceFiles()` replaces the single constant;
  `CitesFrontendEvidence` replaces `CitesFrontendGaps`.
- The four verdicts name `1.46388.4`, taken from `slash-commands.md`'s own
  header, not invented.
- **`desktopdriver.TestFrontendEvidenceSetCoversEveryNoteNamingABuild`** derives
  the set from the notes themselves — a note naming a concrete Claude Desktop
  build is a front-end measurement — and fails in **both** directions: an
  undeclared note, and a declared name no note answers to.
- Both notes document the rule.

### One corrected message from the parent PR

#1940's observed-result exclusion said the build lives in
`desktop-environment.json`. It does not — that file carries
`selected_environment` and `requested_workspace` and no version at all. The
build is in `manifest.json`'s `desktop_app_version`, the field `identity.go`
already reads. A message that sends a reader to the wrong file looks like
evidence, so it is now corrected in the message, the code comment and the test.

## Red-first proof, on the real tree

Both checks are ADDED, so neither has a state in which it ran red on its own.
Each mutation below was run against the committed tree, and both are committed
as fixtures.

**1 — the four verdicts, before the backfill:**

```
of validate: 4 violation(s):
  .../1-6_checkpoint-rewind/...:        measured_desktop_version: is required for a front-end verdict
  .../2-5_synchronous-slash-command/...: measured_desktop_version: is required for a front-end verdict
  .../2-7_autonomous-loop/...:           measured_desktop_version: is required for a front-end verdict
  .../5-3_model-switch-midsession/...:   measured_desktop_version: is required for a front-end verdict
```

**2 — the set shrunk back to the single filename it shipped with:**

```
--- FAIL: TestFrontendEvidenceSetCoversEveryNoteNamingABuild
    slash-commands.md names a Claude Desktop build but is not in
    desktopresults.FrontendEvidenceFiles(): every verdict citing it is exempt
    from the freshness guard
```

Committed as `TestFrontendEvidenceCoverageCatchesAnUndeclaredNote`,
`TestFrontendEvidenceCoverageCatchesAPhantomName` and
`TestFrontendEvidenceCoverageRefusesAnUnreadableTree` (cannot-look separated
from found-nothing). The validator mutation test now drives **every** note in
the declared set, and fails loudly if that set is empty.

## Gates

| Gate | Result |
| --- | --- |
| `go test ./tools/onboarding-factory/... -race -count=1` | PASS |
| `of validate` | OK |
| `tools/replay-fixtures.sh` | PASS (exit 0) |
| `tools/preflight.sh --only go` | PASS (12/12) |
| `tools/preflight.sh --only tools` | PASS |
| `tools/preflight.sh --only arch` | PASS — composite unchanged, 7.929234365438919 |

No recording changed. No daemon behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc