### PR TITLE
feat(onboard): report the Desktop campaign's verdicts, not its display states

### DIFF
--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 const usage = `usage:
-  of status   [--agent a] [--scenario s] [--profile cli-local|desktop-local] [--runs] [--summary] [--json] [--repo-root .]
+  of status   [--agent a] [--scenario s] [--profile cli-local|desktop-local] [--runs] [--summary] [--verdicts] [--json] [--repo-root .]
   of validate [--json] [--repo-root .]
   of coverage [--hooks] [--json] [--repo-root .]
   of scenario add|update --name n [--id i] [--description d] [--process-file f] [--acceptance-file f]
@@ -187,6 +187,9 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	if request.Runs {
 		return runStatusRuns(request.RepoRoot, request.JSON, stdout, stderr)
 	}
+	if request.Verdicts {
+		return runStatusVerdicts(request, stdout, stderr)
+	}
 	return runMatrixStatus(request, stdout, stderr)
 }
 
@@ -194,6 +197,9 @@ type statusRequest struct {
 	Agent, Scenario, RepoRoot string
 	Profile                   matrix.ExecutionProfile
 	Runs, Summary, JSON       bool
+	// Verdicts reports the Desktop result contract instead of the profile
+	// view. See status_verdicts.go for why the two answer differently.
+	Verdicts bool
 }
 
 func parseStatusRequest(args []string) (statusRequest, error) {
@@ -203,6 +209,7 @@ func parseStatusRequest(args []string) (statusRequest, error) {
 		scenario = fs.String("scenario", "", "filter to one scenario (by name or id)")
 		runs     = fs.Bool("runs", false, "show the factory run-log instead of coverage")
 		summary  = fs.Bool("summary", false, "per-agent cell counts instead of the full cell dump")
+		verdicts = fs.Bool("verdicts", false, "Desktop Local verdicts from execution-results.json (requires --profile desktop-local and --agent)")
 		profile  = fs.String("profile", string(matrix.ProfileCLILocal), "execution profile (cli-local or desktop-local)")
 		asJSON   = fs.Bool("json", false, "emit JSON")
 		repoRoot = fs.String("repo-root", ".", "repository root")
@@ -219,6 +226,7 @@ func parseStatusRequest(args []string) (statusRequest, error) {
 	return statusRequest{
 		Agent: *agent, Scenario: *scenario, RepoRoot: *repoRoot,
 		Profile: executionProfile, Runs: *runs, Summary: *summary, JSON: *asJSON,
+		Verdicts: *verdicts,
 	}, nil
 }
 

--- a/tools/onboarding-factory/cmd/of/status_verdicts.go
+++ b/tools/onboarding-factory/cmd/of/status_verdicts.go
@@ -1,0 +1,118 @@
+package main
+
+// `of status --profile desktop-local --verdicts` reports the Claude Desktop
+// campaign's outcome from execution-results.json, the artifact that records it.
+//
+// The existing profile view cannot: it derives each cell's display state from
+// the cell's ASSESSMENT axes, which were measured for the CLI, plus whether a
+// desktop recording exists. A cell with an explicit, terminal not-runnable
+// Desktop verdict therefore shows as "pending-record" — the same token a cell
+// nobody has reached yet gets. This flag is additive and changes no existing
+// number; it prints the verdicts and then says, in one line, how far the
+// display state is from them, so the gap is visible rather than inferred.
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+// verdictsProfileError rejects --verdicts outside the profile it describes.
+// execution-results.json carries desktop-local results only, so under any other
+// profile the flag would print a table about a profile the user did not ask for.
+func verdictsProfileError(profile matrix.ExecutionProfile) error {
+	if profile == matrix.ProfileDesktopLocal {
+		return nil
+	}
+	return fmt.Errorf("--verdicts reads %s, which records %s results only; pass --profile %s",
+		desktopresults.FileName, matrix.ProfileDesktopLocal, matrix.ProfileDesktopLocal)
+}
+
+// verdictReport pairs the census with the display states the same cells carry,
+// so the two can be reported side by side.
+type verdictReport struct {
+	Census desktopresults.VerdictCensus `json:"census"`
+	// PendingDisplayState is how many cells the profile view calls
+	// "pending-record" while the contract holds a terminal verdict for them.
+	// Zero means the two agree.
+	PendingDisplayState int `json:"pending_display_state"`
+}
+
+func runStatusVerdicts(request statusRequest, stdout, stderr io.Writer) int {
+	if err := verdictsProfileError(request.Profile); err != nil {
+		fmt.Fprintf(stderr, "of status: %v\n", err)
+		return exitUsage
+	}
+	if request.Agent == "" {
+		fmt.Fprintln(stderr, "of status: --verdicts requires --agent")
+		return exitUsage
+	}
+	census, err := desktopresults.CountVerdicts(request.RepoRoot, request.Agent)
+	if err != nil {
+		fmt.Fprintf(stderr, "of status: %v\n", err)
+		return exitUsage
+	}
+	// A census over zero cells is a broken walk, not a clean campaign.
+	if census.Cells == 0 {
+		fmt.Fprintf(stderr, "of status: no %s cell found under %s — this census cannot run\n",
+			request.Agent, request.RepoRoot)
+		return exitUsage
+	}
+
+	pending, err := countPendingDisplayStates(request)
+	if err != nil {
+		fmt.Fprintf(stderr, "of status: %v\n", err)
+		return exitUsage
+	}
+	report := verdictReport{Census: census, PendingDisplayState: pending}
+
+	if request.JSON {
+		if err := writeJSON(stdout, report); err != nil {
+			fmt.Fprintf(stderr, "of status: encode: %v\n", err)
+			return exitUsage
+		}
+		return exitOK
+	}
+	printVerdictReport(stdout, report)
+	return exitOK
+}
+
+// countPendingDisplayStates counts the cells the profile view calls
+// pending-record. It re-reads the matrix rather than trusting a remembered
+// number, so the comparison is against what `of status` actually prints today.
+func countPendingDisplayStates(request statusRequest) (int, error) {
+	_, view, err := statusViewForRequest(request)
+	if err != nil {
+		return 0, err
+	}
+	pending := 0
+	for _, scenario := range view.Scenarios {
+		cell, ok := scenario.Cells[request.Agent]
+		if ok && cell.DisplayState == matrix.StatePendingRecord {
+			pending++
+		}
+	}
+	return pending, nil
+}
+
+func printVerdictReport(stdout io.Writer, report verdictReport) {
+	census := report.Census
+	fmt.Fprintf(stdout, "Claude Desktop Local verdicts — %s, from %s\n\n",
+		census.Agent, desktopresults.FileName)
+	for _, outcome := range desktopresults.Outcomes() {
+		fmt.Fprintf(stdout, "  %-18s %3d\n", outcome, census.ByOutcome[string(outcome)])
+	}
+	fmt.Fprintf(stdout, "  %-18s %3d  of %d cell(s)\n", "decided", census.WithVerdict, census.Cells)
+	if len(census.WithoutVerdict) > 0 {
+		fmt.Fprintf(stdout, "  %-18s %3d  %s\n", "no verdict",
+			len(census.WithoutVerdict), strings.Join(census.WithoutVerdict, ", "))
+	}
+	fmt.Fprintf(stdout, "\nnote: `of status --profile %s` calls %d of these cells \"pending-record\".\n",
+		matrix.ProfileDesktopLocal, report.PendingDisplayState)
+	fmt.Fprintln(stdout, "That view derives its display state from the cell's CLI assessment plus whether a")
+	fmt.Fprintln(stdout, "Desktop recording exists, so a terminal not-runnable verdict is invisible to it.")
+	fmt.Fprintln(stdout, "The counts above are the campaign's actual outcome.")
+}

--- a/tools/onboarding-factory/cmd/of/status_verdicts_test.go
+++ b/tools/onboarding-factory/cmd/of/status_verdicts_test.go
@@ -1,0 +1,150 @@
+package main
+
+// The census is an ADDED report, so there is no state in which it ever ran red
+// on its own. What proves it works is breaking each thing it depends on: the
+// artifacts it counts, the tree it walks, and the flags that bound it.
+//
+// The last test here is the reason the flag exists. A cell with a terminal
+// not-runnable Desktop verdict is counted as not-runnable by the census and
+// called "pending-record" by the profile view, in one fixture, at the same
+// moment. If someone repairs the display state, that test goes red and must be
+// updated deliberately — the disagreement may not disappear unnoticed.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
+)
+
+func verdictJSON(t *testing.T, root string) verdictReport {
+	t.Helper()
+	code, stdout, stderr := runOf("status", "--agent", "claudecode",
+		"--profile", "desktop-local", "--verdicts", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("of status --verdicts: exit=%d stderr:\n%s", code, stderr)
+	}
+	var report verdictReport
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("decode the verdict report: %v\nstdout:\n%s", err, stdout)
+	}
+	return report
+}
+
+func TestStatusVerdictsCountsEveryOutcome(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	report := verdictJSON(t, fixture.root)
+
+	// The fixture carries exactly one cell per outcome.
+	for _, outcome := range desktopresults.Outcomes() {
+		if got := report.Census.ByOutcome[string(outcome)]; got != 1 {
+			t.Errorf("outcome %s: count=%d, want 1", outcome, got)
+		}
+	}
+	if report.Census.Cells != 5 || report.Census.WithVerdict != 5 {
+		t.Fatalf("cells=%d with_verdict=%d, want 5 and 5", report.Census.Cells, report.Census.WithVerdict)
+	}
+	if len(report.Census.WithoutVerdict) != 0 {
+		t.Fatalf("every fixture cell carries a verdict; got %v", report.Census.WithoutVerdict)
+	}
+}
+
+// TestStatusVerdictsNamesACellWithNoVerdict is the mutation for the undecided
+// path: a cell whose result artifact is removed must be NAMED, not folded into
+// a smaller total that looks like a tidier campaign.
+func TestStatusVerdictsNamesACellWithNoVerdict(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	cellDir := fixture.cellDirs["not-runnable"]
+	if err := os.Remove(filepath.Join(cellDir, desktopResultsFile)); err != nil {
+		t.Fatalf("remove the result artifact: %v", err)
+	}
+
+	report := verdictJSON(t, fixture.root)
+	if report.Census.WithVerdict != 4 || report.Census.Cells != 5 {
+		t.Fatalf("with_verdict=%d cells=%d, want 4 and 5", report.Census.WithVerdict, report.Census.Cells)
+	}
+	if len(report.Census.WithoutVerdict) != 1 || !strings.Contains(report.Census.WithoutVerdict[0], "not-runnable") {
+		t.Fatalf("the undecided cell must be named; got %v", report.Census.WithoutVerdict)
+	}
+}
+
+// TestStatusVerdictsRefusesAnUnreadableArtifact keeps "cannot look" separate
+// from "found nothing": an artifact that cannot be parsed is the one case where
+// a silent zero reads exactly like a clean campaign.
+func TestStatusVerdictsRefusesAnUnreadableArtifact(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+	if err := os.WriteFile(path, []byte("{ this is not JSON"), 0o644); err != nil {
+		t.Fatalf("corrupt the result artifact: %v", err)
+	}
+	code, stdout, stderr := runOf("status", "--agent", "claudecode",
+		"--profile", "desktop-local", "--verdicts", "--repo-root", fixture.root)
+	if code == exitOK {
+		t.Fatalf("an unreadable artifact must fail the census; stdout:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, desktopResultsFile) {
+		t.Fatalf("the failure must name the artifact; stderr:\n%s", stderr)
+	}
+}
+
+// TestStatusVerdictsRefusesAnEmptyTree is the same rule one level up: a walk
+// that finds no cell has not measured a campaign with nothing in it.
+func TestStatusVerdictsRefusesAnEmptyTree(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"),
+		`{"meta":{"min_versions":{"claudecode":"2.0.0"}},"scenarios":[]}`)
+	write(t, filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", ".keep"), "")
+	code, _, stderr := runOf("status", "--agent", "claudecode",
+		"--profile", "desktop-local", "--verdicts", "--repo-root", root)
+	if code == exitOK {
+		t.Fatal("a tree with no cell must fail the census, not report zero")
+	}
+	if !strings.Contains(stderr, "cannot run") {
+		t.Fatalf("the failure must say the census could not run; stderr:\n%s", stderr)
+	}
+}
+
+func TestStatusVerdictsRejectsTheWrongFlags(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	t.Run("cli-local", func(t *testing.T) {
+		code, _, stderr := runOf("status", "--agent", "claudecode", "--verdicts", "--repo-root", fixture.root)
+		if code == exitOK {
+			t.Fatal("--verdicts under cli-local must be refused")
+		}
+		if !strings.Contains(stderr, "desktop-local") {
+			t.Fatalf("the refusal must name the profile to pass; stderr:\n%s", stderr)
+		}
+	})
+	t.Run("no agent", func(t *testing.T) {
+		code, _, stderr := runOf("status", "--profile", "desktop-local", "--verdicts", "--repo-root", fixture.root)
+		if code == exitOK {
+			t.Fatal("--verdicts without --agent must be refused")
+		}
+		if !strings.Contains(stderr, "--agent") {
+			t.Fatalf("the refusal must name the missing flag; stderr:\n%s", stderr)
+		}
+	})
+}
+
+// TestStatusVerdictsReportsTheDisplayStateDisagreement pins the defect the flag
+// exists to expose, in one fixture: the not-runnable cell has a terminal
+// Desktop verdict AND reads as pending-record in the profile view.
+//
+// This is a LOCK, not a red-first defect test. If the display state is ever
+// taught to read execution-results.json, this goes red and the expectation must
+// be changed on purpose rather than drifting.
+func TestStatusVerdictsReportsTheDisplayStateDisagreement(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	report := verdictJSON(t, fixture.root)
+
+	if report.Census.ByOutcome[string(desktopresults.OutcomeNotRunnable)] != 1 {
+		t.Fatalf("the fixture must carry one not-runnable verdict; got %v", report.Census.ByOutcome)
+	}
+	if report.PendingDisplayState == 0 {
+		t.Fatal("the profile view still cannot see a Desktop verdict, so at least one cell must " +
+			"read pending-record; a zero here means the display state was fixed — update this test")
+	}
+}

--- a/tools/onboarding-factory/internal/desktopresults/census.go
+++ b/tools/onboarding-factory/internal/desktopresults/census.go
@@ -1,0 +1,124 @@
+package desktopresults
+
+// The Desktop verdict census answers "how did the Claude Desktop campaign
+// actually come out", from the one artifact that records it.
+//
+// `of status --profile desktop-local` cannot answer it. That view derives each
+// cell's display state from matrix.DeriveDisplayState, which reads the cell's
+// ASSESSMENT axes plus whether a recording exists — and the assessment axes
+// were measured for the CLI. A cell the Desktop driver cannot drive has an
+// explicit, terminal not-runnable verdict here and no Desktop recording, so it
+// derives to "pending-record": indistinguishable from a cell nobody has
+// reached yet. 26 of the 50 claudecode cells are in exactly that position.
+//
+// Fixing the display state itself is a separate change with an import-direction
+// problem behind it (matrix cannot import this package; this package imports
+// matrix). This census is additive instead: it changes no existing number, and
+// it gives a documented figure a command that produces it.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+// VerdictCensus is one agent's Desktop Local verdicts, counted from the
+// execution-results.json files themselves.
+type VerdictCensus struct {
+	Agent string `json:"agent"`
+	// ByOutcome counts every desktop-local verdict, keyed by outcome. Outcomes
+	// with no cell are present with a zero, so a reader can tell "none" from
+	// "this build of the tool did not know about that outcome".
+	ByOutcome map[string]int `json:"by_outcome"`
+	// Cells is how many canonical cells the agent has.
+	Cells int `json:"cells"`
+	// WithVerdict is how many of them carry a desktop-local verdict.
+	WithVerdict int `json:"with_verdict"`
+	// WithoutVerdict names the cells carrying none, sorted. A count alone
+	// would let "every cell is decided" and "the walk found nothing" print
+	// the same way.
+	WithoutVerdict []string `json:"without_verdict"`
+}
+
+// Outcomes returns every outcome the contract defines, in report order.
+func Outcomes() []Outcome {
+	return []Outcome{
+		OutcomeObservedPassing,
+		OutcomeObservedFailure,
+		OutcomeNotRunnable,
+		OutcomeUnobservable,
+		OutcomeNotApplicable,
+	}
+}
+
+// CountVerdicts walks one agent's cells and counts their Desktop Local
+// verdicts.
+//
+// Every failure is returned, never skipped. A cell whose result artifact
+// cannot be parsed is the one case where a silent zero would read exactly like
+// a clean campaign, so it stops the census instead.
+func CountVerdicts(repoRoot, agent string) (VerdictCensus, error) {
+	scenariosRoot := filepath.Join(repoRoot, "replaydata", "agents", agent, "scenarios")
+	entries, err := os.ReadDir(scenariosRoot)
+	if err != nil {
+		return VerdictCensus{}, fmt.Errorf("read %s: %w", scenariosRoot, err)
+	}
+
+	census := VerdictCensus{Agent: agent, ByOutcome: map[string]int{}}
+	for _, outcome := range Outcomes() {
+		census.ByOutcome[string(outcome)] = 0
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		cellDir := filepath.Join(scenariosRoot, entry.Name())
+		if !isCell(cellDir) {
+			continue
+		}
+		census.Cells++
+		outcome, found, err := desktopOutcomeOf(cellDir)
+		if err != nil {
+			return VerdictCensus{}, err
+		}
+		if !found {
+			census.WithoutVerdict = append(census.WithoutVerdict, entry.Name())
+			continue
+		}
+		census.WithVerdict++
+		census.ByOutcome[string(outcome)]++
+	}
+	sort.Strings(census.WithoutVerdict)
+	return census, nil
+}
+
+// isCell reports whether a directory is a canonical cell, by its metadata.json.
+func isCell(cellDir string) bool {
+	info, err := os.Stat(filepath.Join(cellDir, metadataFile))
+	return err == nil && !info.IsDir()
+}
+
+// desktopOutcomeOf returns a cell's desktop-local outcome. found=false means
+// the cell carries no result artifact, or one with no desktop-local entry —
+// both are "undecided", which the census reports by name.
+func desktopOutcomeOf(cellDir string) (Outcome, bool, error) {
+	path := filepath.Join(cellDir, FileName)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", false, nil
+	} else if err != nil {
+		return "", false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	doc, err := Load(path)
+	if err != nil {
+		return "", false, fmt.Errorf("load %s: %w", path, err)
+	}
+	for _, result := range doc.Results {
+		if matrix.ExecutionProfile(result.ExecutionProfile) == matrix.ProfileDesktopLocal {
+			return result.Outcome, true, nil
+		}
+	}
+	return "", false, nil
+}


### PR DESCRIPTION
Found while starting #1894, which must publish *"the measured Desktop result
count"*. The only command that looks like it answers that question gives the
wrong number.

## The defect

`of status --profile desktop-local` derives each cell's display state from
`matrix.DeriveDisplayState`: the cell's **assessment axes** — measured for the
CLI — plus whether a Desktop recording exists. `desktopresults` is imported by
`cmd/of/validate.go` and the viewer, and by nothing in the status path.

So a cell the Desktop driver cannot drive, which has an explicit **terminal**
`not-runnable` verdict in `execution-results.json` and no Desktop recording,
derives to `pending-record` — the same token a cell nobody has reached yet gets.

```
$ of status --agent claudecode --scenario user-esc-interrupt --profile desktop-local
2.20   user-esc-interrupt   claudecode=pending-record        ← has a terminal verdict
```

26 of the 50 `claudecode` cells sit there. The summary says **23 pending**. The
number of undecided Desktop cells is **zero**.

## What this adds

```
$ of status --agent claudecode --profile desktop-local --verdicts
Claude Desktop Local verdicts — claudecode, from execution-results.json

  observed-passing    21
  observed-failure     0
  not-runnable        26
  unobservable         2
  not-applicable       1
  decided             50  of 50 cell(s)

note: `of status --profile desktop-local` calls 23 of these cells "pending-record".
That view derives its display state from the cell's CLI assessment plus whether a
Desktop recording exists, so a terminal not-runnable verdict is invisible to it.
The counts above are the campaign's actual outcome.
```

**It is additive — no existing number changes.** Repairing the display state
itself is a separate change with an import-direction problem behind it (`matrix`
cannot import `desktopresults`, because `desktopresults` imports `matrix`), and
it would move figures the maturity model reads. This reports the gap rather than
hiding it, and the report says so in its own output.

## It fails loudly wherever it cannot look

- an unparseable `execution-results.json` **stops** the census;
- a tree with no cell **stops** it, rather than reporting a clean zero;
- a cell carrying no verdict is **named**, never folded into a smaller total;
- `--verdicts` is refused under `cli-local` and without `--agent`.

## Red-first

The census is an ADDED report, so it has no state in which it ran red on its
own. Each mutation below was run against the committed code and reverted:

| Mutation | Result |
| --- | --- |
| unreadable artifact skipped instead of failing | `FAIL TestStatusVerdictsRefusesAnUnreadableArtifact` |
| undecided cells dropped instead of named | `FAIL TestStatusVerdictsNamesACellWithNoVerdict` |

`TestStatusVerdictsReportsTheDisplayStateDisagreement` is a **lock**, not a
defect test, and is labelled as one: it pins both readings of a single fixture
cell and goes red the day the display state learns to read the contract, so the
expectation gets changed on purpose rather than drifting.

## Gates

| Gate | Result |
| --- | --- |
| `go test ./tools/onboarding-factory/... -race -count=1` | PASS |
| `of validate` | OK |
| `tools/preflight.sh --only go` | PASS (12/12) |
| `tools/preflight.sh --only arch` | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc