### PR TITLE
fix(web): the release copy-list tripwire reads upper-case tags

### DIFF
--- a/platforms/web/release-files.test.js
+++ b/platforms/web/release-files.test.js
@@ -431,6 +431,14 @@ describe('shipped-set parsers', () => {
     ['unquoted attributes', '<script src=irrlicht.js></script>', ['irrlicht.js']],
     ['multi-token rel', '<link rel="stylesheet alternate" href="alt.css">', ['alt.css']],
     ['icon rel', '<link rel="apple-touch-icon" href="elfdans-icon.svg">', ['elfdans-icon.svg']],
+    // HTML tag names are case-insensitive, and attrValue already matched with
+    // /i while the two TAG regexes did not — so an upper-case tag dropped its
+    // file out of the release requirement silently, the same failure the
+    // single-quote case above was added for. CodeQL js/bad-tag-filter (alert
+    // 63) flagged exactly this on shippedFiles.testutil.js:57.
+    ['upper-case script tag', '<SCRIPT SRC="irrlicht.js"></SCRIPT>', ['irrlicht.js']],
+    ['upper-case link tag', '<LINK REL="stylesheet" HREF="irrlicht.css">', ['irrlicht.css']],
+    ['mixed-case script tag', '<Script src="elfdans.js"></Script>', ['elfdans.js']],
     // Must NOT be read as an entry.
     ['inline script', '<script>const x = 1;</script>', []],
     ['unrelated rel', '<link rel="dns-prefetch" href="https://example.test">', []],

--- a/platforms/web/shippedFiles.testutil.js
+++ b/platforms/web/shippedFiles.testutil.js
@@ -52,13 +52,21 @@ function attrValue(tag, name) {
 // the PWA manifest and the icons. Attribute order inside the tag is not
 // assumed, nor is quoting, and `rel` is matched as the TOKEN SET it is —
 // `rel="stylesheet alternate"` is a stylesheet.
+//
+// Both tag regexes carry /i because HTML tag names are case-insensitive.
+// attrValue already matched that way; these two did not, so `<SCRIPT SRC=…>`
+// dropped its file out of the release requirement without tripping a guard —
+// the same silent under-check the single-quote case above was written for.
+// CodeQL js/bad-tag-filter (alert 63) flagged it. The three upper/mixed-case
+// cases in release-files.test.js were run red against the /g-only version
+// before this line changed.
 export function parseHtmlEntries(html) {
   const entries = [];
-  for (const tag of html.matchAll(/<script\b[^>]*>/g)) {
+  for (const tag of html.matchAll(/<script\b[^>]*>/gi)) {
     const src = attrValue(tag[0], 'src');
     if (src) entries.push(src);
   }
-  for (const tag of html.matchAll(/<link\b[^>]*>/g)) {
+  for (const tag of html.matchAll(/<link\b[^>]*>/gi)) {
     const rel = attrValue(tag[0], 'rel');
     const href = attrValue(tag[0], 'href');
     if (!rel || !href) continue;


### PR DESCRIPTION
Closes CodeQL alert 63 (`js/bad-tag-filter`, High), the one finding blocking `tools/security-scan.sh` for the v0.6.3 release.

`parseHtmlEntries` in `platforms/web/shippedFiles.testutil.js` matched `<script>` and `<link>` case-sensitively, while `attrValue` directly beside it already matched attributes with `/i`. HTML tag names are case-insensitive, so a `<SCRIPT SRC="irrlicht.js">` in `index.html` would drop irrlicht.js out of the release requirement without tripping a single fail-loud guard — the same silent under-check the single-quote case in this parser was written for, and the shape of the v0.4.4 defect where the dashboard shipped with an unreachable module graph.

**Exposure: none.** The file is test-only. It is absent from `WEB_FILES` in `tools/build-release.sh`, and no file in that list imports it, so it is never served to a user and the regexp was never an HTML-filtering sink in a shipped page. What it actually cost was a release tripwire able to check less than it claimed.

**Red first.** Three upper/mixed-case rows were added to the existing `htmlCases` table in `release-files.test.js` and run against the unchanged `/g`-only parser:

```
× html parser: upper-case script tag
× html parser: upper-case link tag
× html parser: mixed-case script tag
  Tests  3 failed | 62 passed (65)
```

Both regexes then gained `/i`:

```
  Tests  65 passed (65)
```

Full suite after the fix: `platforms/web` 682 passed (31 files); `tools/onboarding-factory/internal/viewer/web` 120 passed (8 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc