### PR TITLE
fix(claudecode): stop instructing markers into rendered assistant text

### DIFF
--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -155,7 +155,15 @@ func Agent() agent.Agent {
 				// to disclose the task-summary block retired in #1186 while
 				// saying nothing about the task-question block (#759) it has
 				// been writing to the user's CLAUDE.md ever since (#1377).
-				FeatureUnlocked: "Task-completion ETA chip + waiting-question headline from agent-reported markers",
+				//
+				// FeatureUnlocked is the one line still written by hand, so it
+				// is the one that can over-promise: until #1944 it offered a
+				// "waiting-question headline from agent-reported markers", and
+				// #1944 retired the block that produced that marker. The
+				// headline itself still ships — the daemon composes it from the
+				// transcript (#1186) — so the claim dropped here is the marker,
+				// not the feature.
+				FeatureUnlocked: "Task-completion ETA chip from an agent-reported progress marker",
 				Touches:         instructionsTouched(),
 				Detail:          instructionsDetail(),
 				Apply:           applyInstructionBlocks,

--- a/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
@@ -159,3 +159,80 @@ func TestInstructionsDisclosure_MatchesInstalledBlocks(t *testing.T) {
 		}
 	})
 }
+
+// agreeingPhrases are the count-dependent phrases the consent copy renders, as
+// (singular, plural) pairs. Issue #1944 took the installed set from two blocks
+// to one and turned three of them ungrammatical at once; only the first was
+// going through agreeing() before.
+var agreeingPhrases = [][2]string{
+	{"block", "blocks"},
+	{"a hidden marker", "hidden markers"},
+	{"this block", "these blocks"},
+}
+
+// retiredMarkerKeys are the in-band marker keys of blocks irrlicht no longer
+// installs. They are the vocabulary the over-promise arm above cannot see:
+// namePattern("task-question") compiles to `\btask[- ]question\b`, which never
+// matched the FeatureUnlocked line's "waiting-question headline from
+// agent-reported markers" — so the copy advertised a retired marker for the
+// whole of #1186's life and #1944 had to fix it by hand. Keyed on the marker
+// name rather than the block name because that is the word the copy reaches for
+// when it describes the feature rather than the file.
+var retiredMarkerKeys = []string{"irrlicht-question", "irrlicht-summary"}
+
+// TestInstructionsPermission_CopyNeverAdvertisesARetiredMarker closes that gap.
+// The consent copy — including the two hand-written lines, Title and
+// FeatureUnlocked — must not name a marker no installed block asks for.
+//
+// Confirmed by mutation, run: restoring the pre-#1944 FeatureUnlocked string
+// ("Task-completion ETA chip + waiting-question headline from agent-reported
+// markers") makes this test report `consent copy advertises "irrlicht-question"`.
+// That is the exact copy that shipped, and the existing over-promise arm above
+// stayed green on it.
+func TestInstructionsPermission_CopyNeverAdvertisesARetiredMarker(t *testing.T) {
+	perm := findPermission(t, Agent(), PermissionKeyInstructions)
+	copyText := strings.Join([]string{
+		perm.Title, perm.FeatureUnlocked, perm.Touches, perm.Detail,
+	}, "\n")
+	if strings.TrimSpace(copyText) == "" {
+		t.Fatal("no consent copy to inspect — an empty string is not a pass")
+	}
+	installed := strings.Join(installedBlockNames(t), " ")
+	for _, key := range retiredMarkerKeys {
+		// "irrlicht-question" -> "question": the copy says "waiting-question
+		// headline", never the raw marker key, so match on the distinguishing
+		// word with a boundary that tolerates the hyphenated compound.
+		word := strings.TrimPrefix(key, "irrlicht-")
+		if strings.Contains(installed, word) {
+			continue // a block by that name is installed after all
+		}
+		if regexp.MustCompile(`(?i)[-\s]` + regexp.QuoteMeta(word) + `\b`).MatchString(copyText) {
+			t.Errorf("consent copy advertises %q, but no installed block asks the agent for it — "+
+				"the permission promises a capability granting it does not deliver:\n%s", key, copyText)
+		}
+	}
+}
+
+// TestInstructionsDisclosure_NounsAgreeWithTheCount covers the half of the copy
+// the count arm above cannot see: its regexes tolerate "block" or "blocks", so
+// a sentence that hard-codes one or the other stays invisible to them.
+//
+// It reads the LIVE copy back rather than calling agreeing() and comparing —
+// a helper the format string does not call agrees with nothing. Confirmed by
+// mutation: replacing the "%s" that carries the hidden-marker phrase with a
+// hard-coded "hidden markers" makes this test report
+// `Detail copy does not use the agreed form "a hidden marker"`.
+func TestInstructionsDisclosure_NounsAgreeWithTheCount(t *testing.T) {
+	n := len(installedInstructionBlocks)
+	if n == 0 {
+		t.Fatal("no installed blocks to agree with — an empty inventory is not a pass")
+	}
+	rendered := instructionsTouched() + "\n" + instructionsDetail()
+	for _, pair := range agreeingPhrases {
+		want := agreeing(n, pair[0], pair[1])
+		if !strings.Contains(rendered, want) {
+			t.Errorf("consent copy does not use the agreed form %q for %d installed block(s):\n%s",
+				want, n, rendered)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -1,10 +1,16 @@
 // instructioninstaller.go manages the Irrlicht-managed emission rules in the
 // user-level Claude Code instruction file ~/.claude/CLAUDE.md: the task-eta
-// progress marker (issue #558) and the task-question marker (issue #759), each
-// in its own BEGIN/END-delimited block. The task-summary marker (issue #738)
-// was retired in #1186 — its block is now actively uninstalled, not written.
-// The blocks instruct the agent to emit in-band markers; with them in the
-// user-level file every project inherits the rules without per-repo opt-in.
+// progress marker (issue #558), in its own BEGIN/END-delimited block. Two
+// earlier blocks are retired and now actively uninstalled rather than written
+// — task-summary (issue #738, retired in #1186) and task-question (issue #759,
+// retired in #1944 because its carrier was the rendered response text, which
+// this surface shows to the user verbatim). The block instructs the agent to
+// emit an in-band marker; in the user-level file every project inherits the
+// rule without per-repo opt-in.
+//
+// The invariant #1944 installs: no irrlicht marker may be instructed into text
+// the user reads. The only carrier a block may name is a tool input the surface
+// does not render as prose — today the Bash `description` field.
 //
 // Like the hook/statusline installers, consent lives in the permission
 // wizard (issue #577): install/uninstall run as the claude-code/instructions
@@ -54,7 +60,9 @@ const (
 )
 
 // descriptionFieldLiteral is the backtick-quoted "`description`" carrier name
-// referenced by the managed instruction blocks below.
+// referenced by the managed instruction block below. Since #1944 it is the only
+// carrier a block may name: it is a tool input, not text the surface renders as
+// prose to the user.
 const descriptionFieldLiteral = "`description`"
 
 // managedTaskEtaBlock is the full block (sentinels inclusive) written
@@ -92,8 +100,21 @@ const descriptionFieldLiteral = "`description`"
 // "first marker in your first response, right before your first tool call"
 // rode the one path known to be lossy. v4 moves the first marker onto the
 // Bash `description` carrier too — tool inputs reach the daemon via the
-// PreToolUse hook (#604) regardless of text-block fate. End-of-turn text
-// survives upstream, so the no-Bash fallback stays response text.
+// PreToolUse hook (#604) regardless of text-block fate. Its remaining
+// no-Bash fallback was response text; v5 removes it.
+//
+// v5 (#1944): the fallback is deleted and the prohibition stated in its
+// place. v4 kept response text as a carrier on the premise that the surface
+// hides a bare HTML comment; that premise was probed in a real Claude Code
+// TUI (claude 2.1.263, driven under tmux on 2026-09-11, panes recorded on
+// issue #1944) and is false — the comment rendered verbatim both inline and
+// after a blank line. Whether the Bash `description` carrier is itself
+// hidden is NOT measured: the nested-`claude` probe that would settle it was
+// refused by the sandbox both at triage and at implementation time, so the
+// carrier v5 keeps is retained on the unverified assumption that the surface
+// does not print it. `instructionmarkercarrier_test.go`'s
+// TestInstalledInstructionBlocks_NeverInstructMarkerIntoRenderedText is the
+// tripwire that keeps a rendered-text carrier from coming back by hand.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `
 ## Task progress markers (managed by Irrlicht)
 
@@ -109,8 +130,9 @@ and update it as you make progress:
 is how many you've finished. Emit the first marker by appending it to the
 ` + descriptionFieldLiteral + ` of your first Bash call (never to the command itself).
 After each phase you complete, emit the updated marker the same way:
-appended to the ` + descriptionFieldLiteral + ` of the next Bash call you make, or in your
-response text when no Bash call is coming.
+appended to the ` + descriptionFieldLiteral + ` of the next Bash call you make. That
+field is the only carrier — never put the marker in your response text,
+which the user reads.
 ` + taskEtaEndSentinel
 
 // Sentinels delimiting the (now-retired) task-summary managed block. The
@@ -126,72 +148,50 @@ const (
 	taskSummaryEndSentinel   = managedBlockEndPrefix + "task-summary" + sentinelSuffix
 )
 
-// Sentinels delimiting the task-question managed block (issue #759). Distinct
-// from the eta/summary pairs so all three blocks coexist and are patched or
-// removed independently.
+// Sentinels delimiting the (now-retired) task-question managed block (issue
+// #759), retired in #1944. The block asked the agent to put the marker "on its
+// own line at the very end of your response", on the premise — written into
+// this comment for three versions — that Claude Code hides a bare HTML comment
+// at render time the way it strips one from CLAUDE.md at injection time.
+//
+// That premise was measured and is false. Probing a real Claude Code TUI
+// (claude 2.1.263, driven under tmux on 2026-09-11; captured panes are on
+// issue #1944) asked for the marker two ways: on the line after an anchor
+// sentence, and after a blank line. Both rendered the comment verbatim in the
+// pane, so the block was showing every irrlicht user the raw marker text. The
+// blank-line probe is the one that matters: it rules out "the model glued the
+// comment to the paragraph" as the explanation. The binary does ship
+// HTML-comment-stripping regexes (visible in `strings` over the installed
+// claude version), so the drop presumably applies on some other path; that the
+// assistant-text path does not reach them is an inference from the probe, not
+// something read out of the code.
+//
+// Nothing replaces the block, and waiting detection NARROWS rather than
+// surviving intact. Behind PendingQuestionMarker in IsWaitingForUserInput sits
+// PendingWaitingCue (#1150), but it is computed from tailer.WaitingScanWindow —
+// the trailing MaxWaitingScanRunes (2 × 200 = 400) runes, not the whole message
+// (core/pkg/tailer/parser.go's MaxWaitingScanRunes doc explains why the window
+// is bounded at all). ScanTaskQuestion ran over the COMPLETE text. So the case
+// the marker closed and the window does not is the one #1138 introduced it for:
+// a question sitting further back than 400 runes in a long final message, with
+// no cue in the tail — that turn now classifies ready rather than waiting. The
+// Stop-hook path is no rescue; hooks.go uses the same window. What is lost is
+// therefore that residual band plus the agent-authored headline wording; the
+// headline itself still ships, composed daemon-side (#1186 topic prefix +
+// extracted question). Accepted deliberately: the marker's own carrier was
+// printing in every user's terminal on every question, which is a certain harm
+// against an occasional one.
+//
+// The sentinels stay so applyInstructionBlocks can UNINSTALL a block any prior
+// version installed, cleaning it out of ~/.claude/CLAUDE.md on the next granted
+// daemon start — the same path task-summary took in #1186. Every parser is left
+// tolerant (ScanTaskQuestion, scanValueForMarkers — which is the hook walk —
+// and the replay path) so a live session still running an older CLAUDE.md, and
+// every frozen replaydata transcript, keep parsing exactly as before.
 const (
 	taskQuestionBeginSentinel = ManagedBlockSentinelPrefix + "task-question" + sentinelSuffix
 	taskQuestionEndSentinel   = managedBlockEndPrefix + "task-question" + sentinelSuffix
 )
-
-// managedTaskQuestionBlock instructs the agent to emit a terse one-line version
-// of the question it is blocked on when it ends a turn waiting on the user
-// (issue #759) — the preferred source for the surfaced waiting-state headline.
-// Unlike the eta/summary markers, a pending question has no following Bash call
-// to carry it, so the marker rides the end-of-turn response text — the one shape
-// that survives the claude ≥2.1.162 transcript text-drop (end-of-turn text is
-// not dropped; only mid-task pre-tool-call prose is). The example marker MUST
-// sit inside a fenced code block for the same reason as the other blocks —
-// Claude Code strips bare HTML comments from CLAUDE.md at injection time. The
-// daemon always falls back to compacting the raw last-assistant text, so the
-// marker is a refinement, not a requirement.
-//
-// v2 (#1142): the v1 guidance ("plain prose, under ~70 chars") produced
-// context-free headlines — the raw question with no hint of what task it
-// belongs to, cryptic to anyone scanning sessions. v2 asks for a
-// context → state → ask structure with good/bad examples, and relaxes the
-// hard ~70 cap to a soft ~90. That fuller headline survives to the UI: the
-// daemon-side compaction caps at 200 runes (not 70) since #979, and
-// ExtractQuestionSnippet keeps a single such sentence whole — the em-dash,
-// semicolon and colon separators used in the examples are not sentence
-// terminators (verified against core/domain/session's splitter). Only the
-// example placeholder and prose change; the marker key and sentinels are
-// untouched, so patchManagedBlock upgrades installed v1 blocks in place on
-// the next daemon start.
-//
-// v3 (#1186): the headline shape is now the explicit "<3–5 word topic>:
-// <question>" — a chat-conversation-title topic, then a colon, then the ask.
-// This is the same shape the daemon composes for the no-marker fallback path
-// (a topic derived from the first user prompt + the extracted question), so
-// marker and heuristic paths surface one consistent form. The marker carries
-// the whole line to question_headline verbatim (issue #1186 routes an
-// agent-authored marker through the verbatim compaction kind — no
-// sentence-selection that would drop the topic off a two-sentence marker).
-// Only the placeholder and examples change; the marker key and sentinels stay
-// put, so patchManagedBlock upgrades installed v1/v2 blocks in place.
-const managedTaskQuestionBlock = taskQuestionBeginSentinel + `
-## Pending-question marker (managed by Irrlicht)
-
-When you end your turn by asking the user a question, also emit a hidden
-one-line version of that question so tools can show a terse headline:
-
-` + "```" + `
-<!-- {"marker":"irrlicht-question","question":"<3–5 word topic>: <what happened — the choice>"} -->
-` + "```" + `
-
-Emit it on its own line at the very end of your response, only when you are
-actually waiting on the user.
-
-Start with a 3–5 word topic (like a chat conversation title), then ": ", then
-the question. The topic is the context; what follows the colon is the state
-then the ask — context, then state, then the ask — so someone who never saw
-the session understands it at a glance. Keep it high-signal; aim for ~90
-characters, and when clarity and brevity conflict, choose clarity.
-
-- Bad "Should I proceed?" → Good "DB migration: drops users.legacy_id — run it or keep the column?"
-- Bad "Which approach?" → Good "Auth refactor: 2 endpoints still untested — ship now or add tests first?"
-- Bad "Yes or no?" → Good "PR #482 review: 1 blocking finding left — fix now or merge and follow up?"
-` + taskQuestionEndSentinel
 
 // claudeMemoryDisplayPath is the instruction file as the consent copy shows it
 // — tilde-form, not the resolved absolute path, because the wizard text is read
@@ -258,13 +258,6 @@ func uninstallTaskEtaBlock() (bool, error) {
 	return uninstallBlock(taskEtaBeginSentinel, taskEtaEndSentinel)
 }
 
-// ensureTaskQuestionBlock writes-or-patches the task-question managed block
-// (issue #759) — installed alongside the task-eta block under the same
-// instructions permission.
-func ensureTaskQuestionBlock() (bool, error) {
-	return ensureBlockInstalled(taskQuestionBeginSentinel, taskQuestionEndSentinel, managedTaskQuestionBlock)
-}
-
 // managedInstructionBlock is one irrlicht-managed block in ~/.claude/CLAUDE.md:
 // the sentinels that delimit it, the content written between them, and the
 // clause the consent copy uses to disclose it.
@@ -298,14 +291,6 @@ var installedInstructionBlocks = []managedInstructionBlock{
 		content:   managedTaskEtaBlock,
 		discloses: "a task-progress marker, which irrlicht reads to project a completion ETA",
 	},
-	{
-		name:    "task-question",
-		begin:   taskQuestionBeginSentinel,
-		end:     taskQuestionEndSentinel,
-		content: managedTaskQuestionBlock,
-		discloses: "a one-line version of the question it is waiting on, so a human can tell " +
-			"what a session is blocked on",
-	},
 }
 
 // retiredInstructionBlocks are blocks an earlier version installed that this one
@@ -315,6 +300,7 @@ var installedInstructionBlocks = []managedInstructionBlock{
 // irrlicht writes.
 var retiredInstructionBlocks = []managedInstructionBlock{
 	{name: "task-summary", begin: taskSummaryBeginSentinel, end: taskSummaryEndSentinel},
+	{name: "task-question", begin: taskQuestionBeginSentinel, end: taskQuestionEndSentinel},
 }
 
 // instructionsTouched renders the Touches line of the instructions permission —
@@ -330,7 +316,7 @@ func instructionsTouched() string {
 	// back out of the rendered text, so a second copy of this switch is a second
 	// place the punctuation can drift.
 	return fmt.Sprintf("Maintains %d managed %s (%s) in %s",
-		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
+		len(installedInstructionBlocks), agreeing(len(installedInstructionBlocks), "block", "blocks"),
 		hookjson.EventList(names), claudeMemoryDisplayPath)
 }
 
@@ -343,32 +329,37 @@ func instructionsDetail() string {
 	for _, b := range installedInstructionBlocks {
 		clauses = append(clauses, b.name+" — "+b.discloses)
 	}
+	n := len(installedInstructionBlocks)
 	return fmt.Sprintf(
-		"Writes %d irrlicht-managed %s (each between BEGIN/END sentinels) to %s, "+
-			"instructing the agent to emit hidden markers: %s. All surrounding file "+
+		"Writes %d irrlicht-managed %s (delimited by BEGIN/END sentinels) to %s, "+
+			"instructing the agent to emit %s: %s. All surrounding file "+
 			"content is preserved byte-for-byte, and a managed block an earlier "+
 			"irrlicht version wrote but this one no longer uses is removed on the same "+
-			"pass. Toggling off removes these blocks and any such retired block, and "+
+			"pass. Toggling off removes %s and any such retired block, and "+
 			"nothing else (also available via the macOS Settings toggle).",
-		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
-		claudeMemoryDisplayPath, strings.Join(clauses, "; "))
+		n, agreeing(n, "block", "blocks"), claudeMemoryDisplayPath,
+		agreeing(n, "a hidden marker", "hidden markers"),
+		strings.Join(clauses, "; "), agreeing(n, "this block", "these blocks"))
 }
 
-// blockNoun agrees the noun with the count so a future single-block install
-// does not ship broken grammar in the copy the user consents to.
-func blockNoun(n int) string {
+// agreeing picks the form that agrees with n, so a single-block install does not
+// ship broken grammar in the copy the user consents to. It used to be one
+// function covering one phrase ("block"/"blocks"); #1944 retired task-question,
+// took the installed set to one and made three phrases ungrammatical at once,
+// which is the point at which one parameterised helper beats three near-copies.
+func agreeing(n int, one, many string) string {
 	if n == 1 {
-		return "block"
+		return one
 	}
-	return "blocks"
+	return many
 }
 
 // applyInstructionBlocks installs the managed instruction blocks — the grant
 // effect of the instructions permission. All are governed by a single toggle
-// so it covers every irrlicht-managed instruction. Retired blocks (the
-// irrlicht-summary one, issue #1186) are actively uninstalled here rather than
-// installed, so a CLAUDE.md a prior version wrote is cleaned up on the next
-// granted daemon start. Returns on the first error.
+// so it covers every irrlicht-managed instruction. Retired blocks (irrlicht-
+// summary, issue #1186; irrlicht-question, issue #1944) are actively
+// uninstalled here rather than installed, so a CLAUDE.md a prior version wrote
+// is cleaned up on the next granted daemon start. Returns on the first error.
 func applyInstructionBlocks() error {
 	for _, b := range installedInstructionBlocks {
 		if _, err := ensureBlockInstalled(b.begin, b.end, b.content); err != nil {

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -395,53 +395,7 @@ func TestPatchManagedBlock_BeginWithoutEndAppendsFresh(t *testing.T) {
 	}
 }
 
-func TestEnsureTaskQuestionBlock_CreatesFileIfAbsent(t *testing.T) {
-	home := withTempHome(t)
-	modified, err := ensureTaskQuestionBlock()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !modified {
-		t.Fatal("expected modified=true on first install")
-	}
-	content := readFileString(t, memoryPathFor(home))
-	for _, want := range []string{taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`} {
-		if !strings.Contains(content, want) {
-			t.Errorf("installed file missing %q", want)
-		}
-	}
-}
-
-// TestTaskQuestionBlock_DocumentsStructureAndExamples guards issue #1142: the
-// pending-question guidance must teach the context → state → ask structure and
-// carry good/bad examples, not just say "plain prose, ~70 chars". Assert on the
-// structural contract (the deliverable), tolerant of later wording tweaks to
-// the examples themselves.
-func TestTaskQuestionBlock_DocumentsStructureAndExamples(t *testing.T) {
-	for _, want := range []string{
-		"context",      // names the three-part structure...
-		"then the ask", // ...in order
-		"Bad ",         // carries labelled bad/good example pairs
-		"Good ",
-	} {
-		if !strings.Contains(managedTaskQuestionBlock, want) {
-			t.Errorf("task-question block missing %q — issue #1142 structure/examples regressed", want)
-		}
-	}
-	// The cap moved from a hard ~70 to a soft ~90; the old absolute rule must be gone.
-	if strings.Contains(managedTaskQuestionBlock, "under ~70 characters") {
-		t.Error("task-question block still carries the old hard ~70-char rule (issue #1142 relaxed it to ~90)")
-	}
-	// v3 (#1186): the block teaches the explicit "<topic>: <question>" shape.
-	if !strings.Contains(managedTaskQuestionBlock, `"<3–5 word topic>: <what happened — the choice>"`) {
-		t.Error("task-question block missing the v3 <topic>: <question> placeholder (issue #1186)")
-	}
-	if !strings.Contains(managedTaskQuestionBlock, `then ": ", then`) {
-		t.Error("task-question block must teach the colon join (issue #1186)")
-	}
-}
-
-func TestApplyInstructionBlocks_InstallsEtaAndQuestion_RetiresSummary(t *testing.T) {
+func TestApplyInstructionBlocks_InstallsEta_RetiresSummaryAndQuestion(t *testing.T) {
 	home := withTempHome(t)
 	if err := applyInstructionBlocks(); err != nil {
 		t.Fatal(err)
@@ -449,16 +403,19 @@ func TestApplyInstructionBlocks_InstallsEtaAndQuestion_RetiresSummary(t *testing
 	content := readFileString(t, memoryPathFor(home))
 	for _, want := range []string{
 		taskEtaBeginSentinel, taskEtaEndSentinel, `"marker":"irrlicht-eta"`,
-		taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("file missing %q after applyInstructionBlocks", want)
 		}
 	}
-	// The retired summary marker (#1186) is never installed.
-	for _, absent := range []string{taskSummaryBeginSentinel, `"marker":"irrlicht-summary"`} {
+	// Neither retired marker is ever installed: irrlicht-summary since #1186,
+	// irrlicht-question since #1944.
+	for _, absent := range []string{
+		taskSummaryBeginSentinel, `"marker":"irrlicht-summary"`,
+		taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`,
+	} {
 		if strings.Contains(content, absent) {
-			t.Errorf("file unexpectedly contains retired summary marker %q", absent)
+			t.Errorf("file unexpectedly contains retired marker %q", absent)
 		}
 	}
 	// Idempotent: re-applying changes nothing.
@@ -497,10 +454,48 @@ func TestApplyInstructionBlocks_UninstallsLegacySummaryBlock(t *testing.T) {
 	if !strings.HasPrefix(content, "# My setup\n\nAlways use tabs.\n") {
 		t.Errorf("user content not preserved:\n%s", content)
 	}
-	for _, want := range []string{taskEtaBeginSentinel, taskQuestionBeginSentinel} {
-		if !strings.Contains(content, want) {
-			t.Errorf("expected block %q installed alongside the cleanup", want)
+	if !strings.Contains(content, taskEtaBeginSentinel) {
+		t.Errorf("expected block %q installed alongside the cleanup", taskEtaBeginSentinel)
+	}
+}
+
+// TestApplyInstructionBlocks_UninstallsLegacyQuestionBlock is the issue #1944
+// upgrade test, modelled on the #1186 one above: a CLAUDE.md written by any
+// irrlicht up to v0.6.3 still carries the task-question block, and the user
+// never sees a "remove it" prompt — the next granted apply has to take it out.
+// Seen red on the commit before the fix (1e5e38dd), where apply rewrote the
+// block instead of removing it.
+func TestApplyInstructionBlocks_UninstallsLegacyQuestionBlock(t *testing.T) {
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacyQuestion := taskQuestionBeginSentinel + "\n## Pending-question marker (managed by Irrlicht)\n" +
+		"Emit it on its own line at the very end of your response.\n" +
+		`<!-- {"marker":"irrlicht-question","question":"old"} -->` + "\n" + taskQuestionEndSentinel
+	seeded := "# My setup\n\nAlways use tabs.\n\n" + legacyQuestion + "\n"
+	if err := os.WriteFile(path, []byte(seeded), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := applyInstructionBlocks(); err != nil {
+		t.Fatal(err)
+	}
+	content := readFileString(t, path)
+	for _, absent := range []string{
+		taskQuestionBeginSentinel, taskQuestionEndSentinel,
+		`"marker":"irrlicht-question"`, "at the very end of your response",
+	} {
+		if strings.Contains(content, absent) {
+			t.Errorf("legacy question block survived apply (%q):\n%s", absent, content)
 		}
+	}
+	if !strings.HasPrefix(content, "# My setup\n\nAlways use tabs.\n") {
+		t.Errorf("user content not preserved:\n%s", content)
+	}
+	if !strings.Contains(content, taskEtaBeginSentinel) {
+		t.Errorf("expected block %q installed alongside the cleanup", taskEtaBeginSentinel)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/instructionmarkercarrier_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructionmarkercarrier_test.go
@@ -1,0 +1,403 @@
+// instructionmarkercarrier_test.go holds the issue #1944 tripwire: the check
+// that no irrlicht-managed instruction block names the text a user reads as a
+// place to put a marker, plus the committed fixtures that keep the tripwire
+// honest. It sits apart from instructioninstaller_test.go because it tests a
+// property of the block INVENTORY rather than the file-patching machinery that
+// file covers.
+//
+// It is package-local rather than a contracttesting obligation for the reason
+// instructiondisclosure_test.go's own header already gives: claudecode is the
+// only adapter that installs managed instruction blocks (`git grep -l
+// 'ManagedBlockSentinelPrefix\|instructioninstaller'` returns one non-test
+// file), so there is no second implementation for a shared contract to hold to
+// account yet. Promote it when a second adapter grows blocks, alongside that
+// disclosure check.
+//
+// The rule is an ALLOWLIST, not a negation parser. An earlier version of this
+// file tried to tell a prohibition ("never put the marker in your response
+// text") apart from an instruction ("or in your response text…") by looking for
+// a negating word before the phrase. Review measured three ways through it, all
+// reproduced as fixtures below: a fallback appended to the block's own
+// "(never to the command itself)" sentence inherited that sentence's negator
+// and passed; a conditional phrasing carrying no negator at all passed; and
+// natural rewordings of the prohibition itself were REJECTED, because the "!"
+// in "<!--" was being treated as a sentence terminator and stranded the
+// negator. Parsing English negation is the wrong tool. Every mention of
+// rendered text is a finding unless the sentence is registered verbatim below,
+// so the failure direction is always safe and always actionable.
+package claudecode
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// renderedTextCarrierPhrases are the ways a managed block can refer to the text
+// the user reads. A phrase here is not itself a defect — the prohibition has to
+// name rendered text to forbid it — it is what makes the guard look at a
+// sentence at all. The list is meant as a tripwire for the shapes that have
+// actually shipped (issue #1944 removed two), not as a general reading of
+// English: it is defeated by an intervening adjective ("your final response"),
+// so a reviewer still has to read new block prose.
+var renderedTextCarrierPhrases = []string{
+	"response text",
+	"your response",
+	"your reply",
+	"your answer",
+	"your message",
+	"your output",
+	"the chat",
+	"chat output",
+	"visible text",
+	"rendered text",
+	"assistant text",
+}
+
+// permittedCarrierSentences are the exact sentences an installed block is
+// allowed to contain that mention rendered text: the prohibitions themselves.
+// Every other mention is a finding.
+//
+// Registering a sentence is deliberately a code change a reviewer sees. The
+// cost is that rewording the rule turns the guard red until the new wording is
+// registered; that is the intended direction, because the alternative — trying
+// to infer intent from the prose — is what findings 2 through 5 of this change's
+// review defeated three different ways.
+//
+// A registered sentence that matches nothing is also a finding
+// (TestRenderedTextCarrierGuard_StaleAllowlistEntryIsAFinding), so an entry
+// cannot outlive the prose it was written for. Same rule as
+// tools/state-vocabulary-lint.waivers: a waiver that stops matching fails too.
+var permittedCarrierSentences = []string{
+	"That field is the only carrier — never put the marker in your response text, which the user reads",
+}
+
+var (
+	// instructionFencedBlock matches a ``` … ``` region. The marker examples
+	// live in fences and are illustrations, not instructions, so they are
+	// removed before the prose is read.
+	instructionFencedBlock = regexp.MustCompile("(?s)```.*?```")
+	instructionWhitespace  = regexp.MustCompile(`\s+`)
+	// instructionSentenceEnd deliberately omits "!": the only "!" in a managed
+	// block is the one in "<!--", and treating it as a terminator cut both the
+	// sentinels and any prohibition that quotes the marker syntax in half.
+	instructionSentenceEnd = regexp.MustCompile(`[.;?]`)
+)
+
+// carrierFinding is one sentence the guard objects to.
+type carrierFinding struct {
+	block    string
+	phrase   string
+	sentence string
+}
+
+func (f carrierFinding) String() string {
+	return fmt.Sprintf(
+		"block %q mentions rendered text (%q) in a sentence that is not a registered "+
+			"prohibition:\n    %q\nIf that sentence STATES the rule, add it verbatim to "+
+			"permittedCarrierSentences. If it names rendered text as a place to put a "+
+			"marker, remove it — issue #1944: no irrlicht marker may be instructed into "+
+			"text the user reads.",
+		f.block, f.phrase, f.sentence)
+}
+
+// scanBlocksForRenderedTextCarrier returns a finding for every sentence in a
+// managed block that mentions rendered text without being a registered
+// prohibition, and a second result naming every registered prohibition that
+// matched nothing.
+//
+// An inventory it cannot inspect is itself a finding: an empty slice, or a block
+// in the installed list carrying no content, returns a finding rather than an
+// empty result, so "found nothing" and "looked at nothing" cannot produce the
+// same green (AGENTS.md: a verification mechanism must fail loudly when it
+// cannot run). TestRenderedTextCarrierGuard_CannotLookIsNotAPass drives both.
+func scanBlocksForRenderedTextCarrier(blocks []managedInstructionBlock) (findings []carrierFinding, unmatchedPermits []string) {
+	if len(blocks) == 0 {
+		return []carrierFinding{{
+			block:    "(none)",
+			phrase:   "(none)",
+			sentence: "guard inspected zero managed blocks — an empty inventory is not a pass",
+		}}, nil
+	}
+	matched := map[string]bool{}
+	for _, b := range blocks {
+		blockFindings, blockMatched := scanBlockForRenderedTextCarrier(b)
+		findings = append(findings, blockFindings...)
+		for _, m := range blockMatched {
+			matched[m] = true
+		}
+	}
+	return findings, stalePermittedSentences(matched)
+}
+
+// stalePermittedSentences returns the registered prohibitions that matched no
+// installed block — allowlist entries that outlived the prose they were written
+// for, and now turn the check off over nothing.
+func stalePermittedSentences(matched map[string]bool) []string {
+	var stale []string
+	for _, p := range permittedCarrierSentences {
+		if !matched[p] {
+			stale = append(stale, p)
+		}
+	}
+	return stale
+}
+
+// scanBlockForRenderedTextCarrier reads one block, returning its findings and
+// the registered prohibitions it matched (which the caller needs to tell a live
+// allowlist entry from a stale one).
+func scanBlockForRenderedTextCarrier(b managedInstructionBlock) (findings []carrierFinding, matched []string) {
+	if strings.TrimSpace(b.content) == "" {
+		return []carrierFinding{{
+			block:    b.name,
+			phrase:   "(none)",
+			sentence: "block is listed as installed but carries no content — nothing was inspected",
+		}}, nil
+	}
+	for _, sentence := range blockProseSentences(b.content) {
+		phrase, mentions := renderedTextMention(sentence)
+		switch {
+		case !mentions:
+			// Most sentences never name rendered text at all.
+		case permitted(sentence):
+			matched = append(matched, sentence)
+		default:
+			findings = append(findings, carrierFinding{block: b.name, phrase: phrase, sentence: sentence})
+		}
+	}
+	return findings, matched
+}
+
+// blockProseSentences reduces a managed block to the sentences a model reads as
+// instructions: fenced examples and the BEGIN/END sentinels are machinery, not
+// prose, and are dropped before the text is normalized and split.
+func blockProseSentences(content string) []string {
+	var sentences []string
+	for _, s := range instructionSentenceEnd.Split(blockProse(content), -1) {
+		if trimmed := strings.TrimSpace(s); trimmed != "" {
+			sentences = append(sentences, trimmed)
+		}
+	}
+	return sentences
+}
+
+// blockProse strips the machinery — fenced marker examples and the BEGIN/END
+// sentinel lines — and collapses the block's wrapped lines into one normalized
+// run of text, so a phrase broken across a line ("in your\nresponse text")
+// reads as one phrase.
+func blockProse(content string) string {
+	unfenced := instructionFencedBlock.ReplaceAllString(content, " ")
+	var kept []string
+	for _, line := range strings.Split(unfenced, "\n") {
+		if strings.Contains(line, ManagedBlockSentinelPrefix) || strings.Contains(line, managedBlockEndPrefix) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return instructionWhitespace.ReplaceAllString(strings.Join(kept, "\n"), " ")
+}
+
+// renderedTextMention reports the first carrier phrase the sentence contains.
+func renderedTextMention(sentence string) (string, bool) {
+	lower := strings.ToLower(sentence)
+	for _, phrase := range renderedTextCarrierPhrases {
+		if strings.Contains(lower, phrase) {
+			return phrase, true
+		}
+	}
+	return "", false
+}
+
+// permitted reports whether sentence is a registered prohibition. Comparison is
+// on the normalized form so a re-wrap of the block's source lines — which
+// changes the bytes but not the sentence — does not turn the guard red.
+func permitted(sentence string) bool {
+	for _, p := range permittedCarrierSentences {
+		if sentence == strings.TrimSpace(instructionWhitespace.ReplaceAllString(p, " ")) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInstalledInstructionBlocks_NeverInstructMarkerIntoRenderedText is the
+// issue #1944 defect test. Seen red against the pre-fix installer (1e5e38dd's
+// instructioninstaller.go restored over this tree, `go test
+// ./core/adapters/inbound/agents/claudecode/ -run
+// NeverInstructMarkerIntoRenderedText -count=1`) with three errors: an
+// unregistered carrier in task-eta ("response text"), one in task-question
+// ("your response"), and the stale-allowlist error, since the prohibition the
+// allowlist registers did not exist yet.
+func TestInstalledInstructionBlocks_NeverInstructMarkerIntoRenderedText(t *testing.T) {
+	findings, unmatched := scanBlocksForRenderedTextCarrier(installedInstructionBlocks)
+	for _, f := range findings {
+		t.Errorf("issue #1944: %s", f)
+	}
+	for _, p := range unmatched {
+		t.Errorf("permittedCarrierSentences registers a sentence no installed block contains — "+
+			"the prose it was written for is gone, so the entry now permits nothing and hides "+
+			"that the prohibition was dropped:\n    %q", p)
+	}
+}
+
+// reintroducedCarrierFixtures are the ways the deleted carrier could come back.
+// Each MUTATES THE SHIPPED BLOCK rather than a stand-in, so the guard is
+// exercised against the real surroundings — the fence, the backticked
+// identifiers, the em-dash, and the block's own pre-existing "never".
+//
+// The three marked wasMiss were MEASURED to slip past the negation-parsing
+// design this guard replaced (review findings 2 and 3): one inherits the negator
+// from the sentence it is spliced into, and two carry a negator the old rule
+// read as a prohibition. The unmarked ones that design did catch; they are kept
+// so the allowlist is exercised on more than the regressions. All are fixtures
+// rather than PR-body prose so the regression is re-run, not remembered.
+var reintroducedCarrierFixtures = []struct {
+	name    string
+	mutate  func(string) string
+	wasMiss bool // measured to slip past the pre-review negation-parsing guard
+}{
+	{
+		name:    "fallback spliced into the block's own \"(never to the command itself)\" sentence",
+		wasMiss: true,
+		mutate: func(block string) string {
+			return strings.Replace(block,
+				"(never to the command itself).",
+				"(never to the command itself), or in your response text when no Bash call is coming.",
+				1)
+		},
+	},
+	{
+		name:    "conditional phrasing whose only negator is \"are not\"",
+		wasMiss: true,
+		mutate: func(block string) string {
+			return spliceIntoProse(block, "If you are not making a Bash call, put the marker in your response text.")
+		},
+	},
+	{
+		name:    "negator opening a sentence that then instructs the carrier",
+		wasMiss: true,
+		mutate: func(block string) string {
+			return spliceIntoProse(block,
+				"Don't skip the marker when no Bash call is coming — put it in your response text.")
+		},
+	},
+	{
+		name: "imperative with the condition first",
+		mutate: func(block string) string {
+			return spliceIntoProse(block, "When no Bash call is coming, put the marker in your response text.")
+		},
+	},
+	{
+		name: "the exact sentence #1944 deleted, restored in place of the prohibition",
+		mutate: func(block string) string {
+			return strings.Replace(block,
+				"That\nfield is the only carrier — never put the marker in your response text,\nwhich the user reads.",
+				"or in your\nresponse text when no Bash call is coming.",
+				1)
+		},
+	},
+	{
+		name: "the retired task-question end-of-turn carrier (#759), re-added",
+		mutate: func(block string) string {
+			return spliceIntoProse(block,
+				"Emit it on its own line at the very end of your response, only when you are\nactually waiting on the user.")
+		},
+	},
+}
+
+// spliceIntoProse inserts extra into the block body just before the END
+// sentinel, so it lands inside the prose the guard reads. Appending AFTER the
+// sentinel — what the first version of these fixtures did — put the text in its
+// own segment where none of the block's surroundings could influence the
+// verdict, making the fixture a duplicate of a minimal stand-in (review
+// finding 5).
+func spliceIntoProse(block, extra string) string {
+	at := strings.LastIndex(block, taskEtaEndSentinel)
+	if at < 0 {
+		return block + "\n" + extra + "\n"
+	}
+	return block[:at] + extra + "\n" + block[at:]
+}
+
+func TestRenderedTextCarrierGuard_CatchesReintroducedProseCarrier(t *testing.T) {
+	for _, fx := range reintroducedCarrierFixtures {
+		t.Run(fx.name, func(t *testing.T) {
+			mutated := []managedInstructionBlock{{
+				name:    "task-eta",
+				begin:   taskEtaBeginSentinel,
+				end:     taskEtaEndSentinel,
+				content: fx.mutate(managedTaskEtaBlock),
+			}}
+			if mutated[0].content == managedTaskEtaBlock {
+				t.Fatal("fixture did not change the block — the mutation's anchor text has moved, " +
+					"so this case is silently testing the unmutated block")
+			}
+			findings, _ := scanBlocksForRenderedTextCarrier(mutated)
+			if len(findings) == 0 {
+				t.Errorf("guard stayed green on a re-added carrier (wasMiss=%v):\n%s",
+					fx.wasMiss, fx.mutate(managedTaskEtaBlock))
+			}
+		})
+	}
+}
+
+// TestRenderedTextCarrierGuard_CannotLookIsNotAPass pins the loud-failure half:
+// a guard handed nothing to inspect reports that instead of returning clean.
+func TestRenderedTextCarrierGuard_CannotLookIsNotAPass(t *testing.T) {
+	if findings, _ := scanBlocksForRenderedTextCarrier(nil); len(findings) == 0 {
+		t.Error("an empty inventory must produce a finding, not read as a clean pass")
+	}
+	hollow := []managedInstructionBlock{{
+		name: "task-eta", begin: taskEtaBeginSentinel, end: taskEtaEndSentinel,
+	}}
+	if findings, _ := scanBlocksForRenderedTextCarrier(hollow); len(findings) == 0 {
+		t.Error("an installed block with no content must produce a finding, not read as a clean pass")
+	}
+}
+
+// TestRenderedTextCarrierGuard_StaleAllowlistEntryIsAFinding drives the other
+// loud-failure direction: an allowlist is a way to turn a check off, so an entry
+// that no longer matches anything must fail rather than sit there permitting a
+// sentence nobody writes any more.
+func TestRenderedTextCarrierGuard_StaleAllowlistEntryIsAFinding(t *testing.T) {
+	stripped := []managedInstructionBlock{{
+		name:    "task-eta",
+		begin:   taskEtaBeginSentinel,
+		end:     taskEtaEndSentinel,
+		content: strings.Replace(managedTaskEtaBlock, "That\nfield is the only carrier — never put the marker in your response text,\nwhich the user reads.\n", "", 1),
+	}}
+	if stripped[0].content == managedTaskEtaBlock {
+		t.Fatal("fixture did not change the block — the prohibition's wording has moved")
+	}
+	findings, unmatched := scanBlocksForRenderedTextCarrier(stripped)
+	if len(findings) != 0 {
+		t.Errorf("removing the prohibition should leave no carrier finding, got %v", findings)
+	}
+	if len(unmatched) == 0 {
+		t.Error("a registered prohibition that matches nothing must be reported, not silently kept")
+	}
+}
+
+// TestRenderedTextCarrierGuard_UnregisteredRewordIsRejected documents the
+// allowlist's deliberate cost, so the next author meets it here with an
+// explanation rather than in CI with a confusing red. A reworded prohibition is
+// rejected until it is registered — safe direction, and the finding's own text
+// says which list to add it to.
+func TestRenderedTextCarrierGuard_UnregisteredRewordIsRejected(t *testing.T) {
+	reworded := []managedInstructionBlock{{
+		name:  "task-eta",
+		begin: taskEtaBeginSentinel,
+		end:   taskEtaEndSentinel,
+		content: strings.Replace(managedTaskEtaBlock,
+			"That\nfield is the only carrier — never put the marker in your response text,\nwhich the user reads.",
+			"Your response text must never carry the marker.", 1),
+	}}
+	findings, _ := scanBlocksForRenderedTextCarrier(reworded)
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding for an unregistered reword, got %d: %v", len(findings), findings)
+	}
+	if !strings.Contains(findings[0].String(), "permittedCarrierSentences") {
+		t.Errorf("finding must tell the author how to register the sentence:\n%s", findings[0])
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -600,9 +600,12 @@ func handleTextBlock(block map[string]interface{}, ev *tailer.ParsedEvent) {
 	if s := tailer.ScanTaskSummary(text, ev.Timestamp); s != nil {
 		ev.TaskSummary = s
 	}
-	// The question marker rides end-of-turn prose (the agent's final line
-	// when it asks the user something), which survives the text-drop, so the
-	// text-block scan is its primary path (#759).
+	// The question marker rode end-of-turn prose (#759) until #1944 retired
+	// the instruction block that asked for it — that carrier is the text the
+	// user reads, and this surface renders it verbatim. Irrlicht no longer
+	// asks any agent to emit it, so this scan is now a tolerance path only:
+	// a live session still running a pre-#1944 ~/.claude/CLAUDE.md, and every
+	// frozen replaydata transcript, still parse exactly as before.
 	if q := tailer.ScanTaskQuestion(text, ev.Timestamp); q != nil {
 		ev.TaskQuestion = q
 	}

--- a/core/pkg/tailer/taskquestion_scan.go
+++ b/core/pkg/tailer/taskquestion_scan.go
@@ -1,17 +1,30 @@
 // taskquestion_scan.go parses the agent-emitted task-question marker from
-// assistant text (issue #759). When the agent ends a turn by asking the user
-// something, it may author a terse one-line version of that question and emit
-// it in-band as a hidden HTML comment, e.g.
+// assistant text (issue #759). Irrlicht stopped ASKING for this marker in #1944
+// (see below); the scanner stays because sessions and recordings that predate
+// that still carry one. When an agent ends a turn by asking the user something,
+// it may author a terse one-line version of that question and emit it in-band
+// as a hidden HTML comment, e.g.
 //
 //	<!-- {"marker":"irrlicht-question","question":"Run the migration now?"} -->
 //
 // irrlicht only parses it (read-only). It is the question-state companion to
 // the irrlicht-summary marker (tasksummary_scan.go): the summary describes the
-// task, the question describes what the agent is currently blocked on. It is
-// the preferred source for the surfaced waiting-state headline; when absent the
-// daemon falls back to compacting the raw last-assistant text. Parsing is
-// tolerant by design — the model rewrites markers — so we accept key drift and
-// ignore anything malformed rather than erroring. Latest non-empty marker wins.
+// task, the question describes what the agent is currently blocked on.
+//
+// Since #1944 no adapter instructs an agent to emit it: the carrier was the
+// end-of-turn response text, which Claude Code renders verbatim, so the marker
+// was showing up in the user's chat. The scanner is deliberately unchanged —
+// a live session still running a pre-#1944 ~/.claude/CLAUDE.md keeps emitting
+// the marker, and recorded claudecode transcripts under replaydata/ contain
+// one (`git grep -l irrlicht-question -- replaydata/` lists them), so dropping
+// tolerance here would change how existing data parses. What the
+// surfaced waiting-state headline uses instead is what already shipped as the
+// no-marker path: the daemon compacts the raw last-assistant text and prefixes
+// the topic it derives from the first user prompt (#1186).
+//
+// Parsing is tolerant by design — the model rewrites markers — so we accept key
+// drift and ignore anything malformed rather than erroring. Latest non-empty
+// marker wins.
 package tailer
 
 import (


### PR DESCRIPTION
Closes #1944

## What was wrong

The `irrlicht-question` marker was printing verbatim in the user's terminal. It rode
the end-of-turn response text on a premise written into the installer's doc comment for
three block versions: that Claude Code hides a bare HTML comment at render time the way
it strips one from `CLAUDE.md` at injection time.

**That premise is measured and false.** A probe of a real Claude Code TUI (claude
2.1.263, driven under tmux on 2026-09-11; captured panes recorded in the triage comment
on #1944) asked for the marker two ways — on the line after an anchor sentence, and
after a blank line. Both rendered the comment verbatim in the pane. The blank-line probe
is the one that matters: it rules out "the model glued the comment to the paragraph" as
the explanation.

## The invariant this installs

**No irrlicht marker may be instructed into text the user reads.** The only carrier a
managed block may name is a tool input the surface does not render as prose — today the
Bash `description` field.

## Changes

- **Retire `managedTaskQuestionBlock`.** Its sentinel pair moves from
  `installedInstructionBlocks` to `retiredInstructionBlocks` and the block body is
  deleted, so `applyInstructionBlocks` now *uninstalls* it from `~/.claude/CLAUDE.md` on
  the next granted daemon start — the same path task-summary took in #1186. `ensureTaskQuestionBlock`
  goes with it (it had no production caller once the tables landed in #1377).
- **Consent copy needed no hand edit**, as designed: `instructionsTouched` /
  `instructionsDetail` / `blockNoun` re-derive from the tables and now render
  `Maintains 1 managed block (task-eta) in ~/.claude/CLAUDE.md`.
- **Keep the task-eta block, delete its prose fallback.** The sentence `or in your
  response text when no Bash call is coming` is gone; the block states the prohibition
  in its place.
- **No parser changed.** `ScanTaskQuestion`, `scanValueForMarkers`, the hook walk and
  the replay path stay tolerant, so a live session still running a pre-#1944 `CLAUDE.md`
  and every frozen replaydata transcript parse exactly as before. `topic` key tolerance
  was deliberately **not** added — the carrier is going away.
- **Replaced the doc comments that asserted the disproven carrier** with the measured
  result: the retired sentinel block in `instructioninstaller.go`, plus
  `claudecode/parser.go`'s `handleTextBlock` ("the text-block scan is its primary path")
  and `tailer/taskquestion_scan.go`'s header ("the preferred source for the surfaced
  waiting-state headline"). Prose only — no logic touched.

### Changes beyond the triage design

`agent.go`'s `FeatureUnlocked` is the one line of the instructions consent copy still
written by hand. It promised a *"waiting-question headline from agent-reported markers"*,
and after this PR there is no such marker. It now reads `Task-completion ETA chip from
an agent-reported progress marker`. Evidence it needed the edit: the disclosure test's
over-promise arm scans `Touches + Detail + FeatureUnlocked + Title`
(`instructiondisclosure_test.go:145`), and the copy was the only remaining place naming
a capability the change removes. The headline itself still ships — the daemon composes
it (`replayengine/metrics.go:226 questionHeadline`, #1186 topic prefix + extracted
question).

## What this costs — waiting detection narrows, it does not survive intact

An earlier draft of this PR (and the triage comment) claimed `PendingWaitingCue` is
derived from the "full, untruncated" assistant text, so nothing but headline *wording*
was lost. **Review measured that and it is wrong**, so the honest version:

`PendingWaitingCue` (#1150) is computed as
`session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full))`
(`core/adapters/inbound/agents/claudecode/parser.go:872`), and `WaitingScanWindow`
returns the trailing `MaxWaitingScanRunes` = 2 x 200 = **400 runes**
(`core/pkg/tailer/parser.go:1094`). `ScanTaskQuestion` ran over the **complete** block
text (`core/pkg/tailer/taskquestion_scan.go`).

So there is a residual band the marker covered and the window does not: a question
sitting further back than 400 runes in a long final message, with no cue in the tail.
That turn now classifies `ready` instead of `waiting` — which is the case #1138
introduced the marker for. The Stop-hook path is no rescue; `hooks.go` uses the same
window.

**Accepted deliberately**, and written into the code comment rather than glossed: the
marker's own carrier was printing in every user's terminal on *every* question — a
certain harm — against an occasional missed `waiting` classification. The headline
itself still ships, composed daemon-side (`replayengine/metrics.go:226`, #1186).

## Test evidence

**Red-first** (all three run against the base installer `1e5e38dd` restored over the
worktree via `git show <base>:<path> > <path>`, with the new tests in place):

| Test | Red output on base |
|---|---|
| `TestInstalledInstructionBlocks_NeverInstructMarkerIntoRenderedText` | 2 findings — the task-eta `"…or in your response text when no Bash call is coming"` and the task-question `"Emit it on its own line at the very end of your response…"` |
| `TestApplyInstructionBlocks_UninstallsLegacyQuestionBlock` | 4 findings — begin sentinel, end sentinel, `"marker":"irrlicht-question"` and the carrier sentence all survived apply |
| `TestApplyInstructionBlocks_InstallsEta_RetiresSummaryAndQuestion` | 3 findings — both question sentinels and the marker still written |

**The guard was redesigned after review.** Its first version tried to tell a
prohibition apart from an instruction by looking for a negating word before the carrier
phrase. Review measured **three ways through it** — a fallback appended to the block's
own `"(never to the command itself)"` sentence inherited that sentence's negator; two
other phrasings carried a negator the rule read as a prohibition — and four natural
rewordings of the prohibition that it **falsely rejected**, because the `!` in `<!--`
was being treated as a sentence terminator and stranded the negator.

Parsing English negation was the wrong tool. It is now an **allowlist**:

- Fenced examples and the BEGIN/END sentinels are stripped before the prose is read;
  `!` is no longer a sentence terminator.
- Every mention of rendered text is a finding **unless the sentence is registered
  verbatim** in `permittedCarrierSentences` (one entry today). Failures are always in
  the safe direction, and the finding text names the list to add to.
- A registered sentence that **matches nothing** is also a finding, so an allowlist
  entry cannot outlive the prose it was written for — the same rule
  `tools/state-vocabulary-lint.waivers` uses.

**Committed mutation fixtures** (the guard is new, so it has no "before the fix" of its
own — the thing it protects is mutated instead, and the mutation is committed rather
than described). All six **mutate the shipped block**, not a stand-in, so the fence, the
backticked identifiers, the em-dash and the block's own pre-existing "never" are all in
play; three are the exact shapes review measured slipping through:

| Fixture | Slipped past the old design? |
|---|---|
| fallback spliced into the block's own `(never to the command itself)` sentence | yes |
| `If you are not making a Bash call, put the marker in your response text.` | yes |
| `Don't skip the marker when no Bash call is coming — put it in your response text.` | yes |
| `When no Bash call is coming, put the marker in your response text.` | no |
| the exact sentence #1944 deleted, restored in place of the prohibition | no |
| the retired task-question end-of-turn carrier (#759), re-added | no |

Each fixture asserts the mutation actually changed the block, so an anchor string that
drifts fails loudly instead of silently testing the unmutated block.

- `TestRenderedTextCarrierGuard_CannotLookIsNotAPass` — an empty inventory, and a block
  listed as installed with no content, each produce a finding rather than a clean
  return. "Found nothing" and "looked at nothing" cannot render the same green.
- `TestRenderedTextCarrierGuard_StaleAllowlistEntryIsAFinding` — removing the
  prohibition from the block leaves no carrier finding but *does* report the now-stale
  allowlist entry.
- `TestRenderedTextCarrierGuard_UnregisteredRewordIsRejected` — documents the
  allowlist's deliberate cost where the next author will meet it.
- `TestInstructionsPermission_CopyNeverAdvertisesARetiredMarker` — **new guard for the
  `FeatureUnlocked` edit below.** Confirmed red by mutation: restoring the pre-#1944
  string makes it report `consent copy advertises "irrlicht-question"`, while the
  existing over-promise arm stays green on the same mutation (its
  `\btask[- ]question\b` pattern never matched "waiting-**question** headline" — which
  is why that copy shipped wrong for the whole of #1186's life).

**Locks** (pass before and after by construction — not presented as red-first proof):

- `instructiondisclosure_test.go` — all three arms. The count arm is what mechanically
  checks the 2 → 1 flip, and it needed no edit because the copy is derived.
- The `contracttesting` managed-user-files obligations, and
  `TestInstructionsPermission_GateContract`.
- `core/cmd/irrlichd/uninstall_task_eta_live_daemon_test.go` and
  `UninstallInstructionBlocks` — the sweep matches on the exported
  `ManagedBlockSentinelPrefix`, never on a block name, so it needed no edit and already
  covers the newly retired block (that is what #1377 fixed).
- `assertCurrentEtaContract`'s four pinned eta phrases, and the v1/v2/v3 in-place
  upgrade fixtures.

## Review

Delegated to a subagent running this repo's `/ir:code-review` at **medium** effort (the
triage-selected level; the real diff stayed small and self-contained, so it was not
raised). It reported **1 HIGH, 4 MEDIUM, 3 LOW and 3 nits, 0 critical**. Every one is
fixed in this branch:

| # | Finding | Fix |
|---|---|---|
| 1 (HIGH) | `PendingWaitingCue` is **not** "full untruncated text" — the dismissal was wrong | comment rewritten to the measured window + the residual gap stated; see the section above |
| 2 | the negator rule's stated justification was refuted by running what it cited | rule replaced by the allowlist; the false claim is gone |
| 3 | a fallback appended to the block's own `(never …)` sentence slipped through | allowlist catches it; committed as fixture 1 |
| 4 | `!` in `<!--` split sentences, falsely rejecting natural prohibition wordings | comments and fences stripped first; `!` no longer a terminator |
| 5 | the "real surroundings" fixture appended *after* the END sentinel, exercising none of them | fixtures now splice **into** the prose, and assert the mutation took |
| 6 | `(each between BEGIN/END sentinels)` still plural at a count of 1 | now count-neutral: `delimited by BEGIN/END sentinels` |
| 7 | "the claude binary carries a comment-dropping predicate" stated as fact | rephrased as inference, with the `strings` evidence named |
| 8 | nothing would catch the next `FeatureUnlocked` over-promise | new `TestInstructionsPermission_CopyNeverAdvertisesARetiredMarker`, proven red by mutation |
| nits | "the hook walk" double-counted `scanValueForMarkers`; `taskquestion_scan.go` opened in the present tense | both reworded |

Review also confirmed independently that the retirement leaves **no dead code or
orphaned constants**, that uninstall / round-trip / `--uninstall-task-eta` all still
behave, and that the two new installer tests were genuinely red on `1e5e38dd`.

## Simplify

Inline pass over `origin/main...HEAD`, all four angles:

- **reuse** — three near-identical noun helpers (`blockNoun`, and two I had added)
  collapsed into one `agreeing(n, one, many)`.
- **simplification** — `ensureTaskQuestionBlock` deleted (no caller once the tables drive
  Apply); a redundant second assertion dropped from the noun test.
- **efficiency** — regexes compiled once at package level; `strings.ToLower` once per
  sentence rather than per phrase. Nothing here is on a hot path.
- **altitude** — the guard tests the block **inventory**, which is the level the
  invariant lives at, and stays package-local rather than promoted to `contracttesting`,
  matching the precedent `instructiondisclosure_test.go` states for exactly this case
  (one adapter, no second implementation to hold to account). Parser tolerance stays at
  the parser level, unchanged.

## Preflight

Run as separate foreground `--only` chunks in the worktree. `swift` not run: no
`platforms/macos/` change. `linux` left opt-in.

| Gate | Result |
|---|---|
| `go` (gofmt, vet ×2, core tests, factory tests, of validate, rig smoke, replay fixtures) | PASS (12/12) — re-run after the review fixes |
| `arch` (ARS) | PASS — composite 7.928351 → 7.926871, no category regression |
| `web` (both trees) | PASS |
| `tools` (shell libs + state-vocabulary lint) | PASS |
| `skills` | PASS |
| `site` | PASS |
| `posix` / `bash` | PASS |
| `security` (govulncheck + gosec + npm audit) | PASS |

### CodeScene (advisory)

The check reports **fail**, and it is worth reading rather than waving through. Its
*critical* rules now pass and the changed test file's health went **8.35 → 9.69** across
three rounds of genuine flattening (a per-block scan, the stale-allowlist computation,
and the prose-stripping step each became their own function). What remains is two
**advisory** rules, left deliberately:

- `instructionmarkercarrier_test.go` — *String Heavy Function Arguments*.
- `instructioninstaller.go` — *Primitive Obsession*, **9.03 → 8.75**. This one is caused
  by my own simplify pass: collapsing `blockNoun` and the two new sibling helpers into a
  single `agreeing(n int, one, many string)` trades three named one-liners for one
  parameterised helper with two string arguments. It is a genuine tie — the named
  helpers read better at the call site, the parameterised one keeps all three phrases
  under one explanation — and CodeScene scores it slightly worse. Flagged rather than
  silently kept: reverting to three named helpers is a small, safe change if you prefer
  that side of it.

AGENTS.md records CodeScene as advisory and not a merge gate; every gating check is
green.

## Still assumed, not verified

**That the Bash `description` carrier is itself hidden by the Claude Code TUI.** The
triage marked this ASSUMED and it stays assumed: the nested-`claude` probe that would
settle it was refused by the sandbox classifier — at triage on the spawn, and here on
the `tmux send-keys` that would drive the session past its trust prompt (the session did
start; only the keystrokes were denied). Per the triage's conditional, the eta block is
therefore **kept** rather than retired, and this is written up as unverified in the
`v5` doc comment on `managedTaskEtaBlock` rather than as a measured fact. If that probe
later shows the `description` field also renders, the eta block should take the same
retirement path this PR gives task-question.

Two further limits, stated rather than glossed:

- No test can prove the *host* hides anything. This suite proves irrlicht never *asks*
  for a rendered marker. The probe is the only evidence about the host, and it is
  version-bound — it expires on the next Claude Code release.
- The guard is a tripwire for the phrasings that have actually shipped, not a general
  reading of English. It catches a sentence re-added by hand; a reviewer still has to
  read new block prose. That limit is written into the comment above the phrase list.

## Left out deliberately

- **No CHANGELOG entry.** The `[Unreleased]` section is empty and the recent PRs around
  it (#1939, #1942, #1943, #1945) added none — `/ir:release` composes the changelog from
  merged PRs. Flagging it rather than silently skipping: this change does delete a block
  from the user's own `CLAUDE.md`, so it is worth a release-note line when that runs.
- No new marker schema, no relocation of the question marker onto a tool call, no MCP or
  new channel, no attempt to make the host hide comments, no other adapter (`git grep -l
  'ManagedBlockSentinelPrefix\|instructioninstaller'` returns exactly one non-test file,
  so the issue's "check the other adapters" question answers as: none install markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc
