### PR TITLE
fix(macos): make every rendered project group reorderable

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+GroupComposition.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+GroupComposition.swift
@@ -56,10 +56,20 @@ extension SessionManager {
     /// keys on project *name*, not session_id: the echoed/ghost relay rows carry
     /// drifted ids that escape `relayGroups()`'s id-only filter. Relay-only
     /// projects (no local group of that name) still appear.
+    ///
+    /// The ordering spans local AND relay rows (#1948): a project from a
+    /// second daemon is a row the user sees, so it is a row the user can move.
+    /// Ordering only the local half was what made a relay group's chevrons
+    /// inert — it was rendered but absent from `projectGroupOrder`, the list
+    /// `moveProjectGroupUp/Down` act on.
+    ///
+    /// `groupedSessionIds` stays local-only: it feeds `patchApiGroups`' guard,
+    /// which is about the LOCAL patch path, not about display.
     func recomposeApiGroups() {
         let localNames = Set(localApiGroups.map(\.name))
-        apiGroups = orderedGroups(localApiGroups)
+        let displayed = localApiGroups
             + relayGroups().filter { !localNames.contains($0.name) }
+        apiGroups = orderedGroups(displayed)
         groupedSessionIds = Set(localApiGroups.flatMap { collectSessionIds(from: $0) })
     }
 
@@ -223,8 +233,15 @@ extension SessionManager {
 
     // MARK: - Project Group Order Management
 
+    /// Deduped on the way in — this is the one point where persisted,
+    /// user-editable, migration-aged data becomes `projectGroupOrder`, so the
+    /// in-memory array holds the no-duplicates invariant from birth rather
+    /// than acquiring it at the first recompose. Between this call and that
+    /// recompose, `reorderMoves(for:)` answers from whatever is here.
     func loadProjectGroupOrder() {
-        projectGroupOrder = defaults.stringArray(forKey: projectGroupOrderKey) ?? []
+        var seen = Set<String>()
+        projectGroupOrder = (defaults.stringArray(forKey: projectGroupOrderKey) ?? [])
+            .filter { seen.insert($0).inserted }
         print("📋 Loaded project group order with \(projectGroupOrder.count) groups")
     }
 
@@ -238,23 +255,68 @@ extension SessionManager {
     func orderedGroups(_ groups: [AgentGroup]) -> [AgentGroup] {
         let incomingNames = groups.map(\.name)
         let currentNames = Set(incomingNames)
-        let known = Set(projectGroupOrder)
 
-        var updated = projectGroupOrder.filter { currentNames.contains($0) }
-        let newNames = incomingNames.filter { !known.contains($0) }
-        updated.append(contentsOf: newNames)
+        // Known names in their remembered order, then names this payload adds,
+        // each kept once. `seen` is what enforces "once": two incoming groups
+        // can share a name, and a duplicate here would inflate the count
+        // `reorderMoves(for:)` reports and would give the sort below two
+        // entries to choose between. Dropping the later copy also heals the
+        // stored array on the next save.
+        var seen = Set<String>()
+        let updated = (projectGroupOrder + incomingNames).filter {
+            currentNames.contains($0) && seen.insert($0).inserted
+        }
 
         if updated != projectGroupOrder {
             projectGroupOrder = updated
             saveProjectGroupOrder()
         }
 
-        let index = Dictionary(uniqueKeysWithValues: projectGroupOrder.enumerated().map { ($1, $0) })
+        // Built by hand rather than with `Dictionary(uniqueKeysWithValues:)`,
+        // which TRAPS on a repeated key — a crash, not a mis-sort. The filter
+        // above already rules that out, but this array is also written by
+        // `loadProjectGroupOrder` from a user-editable store, and a reader
+        // that crashes on bad input is the wrong response for a menu bar app.
+        // First occurrence wins, matching `reorderMoves`' `firstIndex(of:)`.
+        var index: [String: Int] = [:]
+        for (offset, name) in projectGroupOrder.enumerated() where index[name] == nil {
+            index[name] = offset
+        }
         return groups.sorted { (index[$0.name] ?? Int.max) < (index[$1.name] ?? Int.max) }
     }
 
+    /// Which way `name` can be moved, or `nil` when it is not reorderable at
+    /// all — the only question the reorder chevrons ask.
+    ///
+    /// Answers about `projectGroupOrder`, never `apiGroups`. #1948 is what
+    /// happens when the view measures against the other one: back then the
+    /// order covered only the LOCAL half of the rendered list, so a relay row
+    /// padded the count the view saw — the last local group's down-chevron
+    /// rendered enabled and did nothing, and the relay group got two chevrons
+    /// that could never fire. `recomposeApiGroups` now orders the whole
+    /// rendered list, so every top-level row is in this array; `nil` means a
+    /// name that is not a rendered top-level group at all.
+    ///
+    /// Booleans, not coordinates, so the offer and the effect evaluate the
+    /// same expression: `moveProjectGroupUp/Down` guard on these, and
+    /// `GroupView` renders from them. Index arithmetic lives here and nowhere
+    /// else. `SessionManagerGroupOrderTests` asserts the two agree for every
+    /// rendered group, and goes red when this answers from `apiGroups`.
+    func reorderMoves(for name: String) -> (up: Bool, down: Bool)? {
+        projectGroupOrder.firstIndex(of: name).map(reorderMoves(atIndex:))
+    }
+
+    /// The rule itself, written once. Each handler judges the same index it
+    /// then swaps — asking `reorderMoves(for:)` and looking the index up
+    /// separately would be two lookups again, and a disagreement between them
+    /// swaps out of bounds instead of declining.
+    private func reorderMoves(atIndex i: Int) -> (up: Bool, down: Bool) {
+        (up: i > 0, down: i < projectGroupOrder.count - 1)
+    }
+
     func moveProjectGroupUp(name: String) {
-        guard let i = projectGroupOrder.firstIndex(of: name), i > 0 else { return }
+        guard let i = projectGroupOrder.firstIndex(of: name),
+              reorderMoves(atIndex: i).up else { return }
         projectGroupOrder.swapAt(i, i - 1)
         saveProjectGroupOrder()
         recomposeApiGroups()
@@ -262,7 +324,7 @@ extension SessionManager {
 
     func moveProjectGroupDown(name: String) {
         guard let i = projectGroupOrder.firstIndex(of: name),
-              i < projectGroupOrder.count - 1 else { return }
+              reorderMoves(atIndex: i).down else { return }
         projectGroupOrder.swapAt(i, i + 1)
         saveProjectGroupOrder()
         recomposeApiGroups()

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -120,7 +120,15 @@ class SessionManager: ObservableObject {
     let orderFilePath: URL
     var sessionOrder: [String] = []
 
-    // Project group ordering (persisted in UserDefaults)
+    // Project group ordering (persisted in UserDefaults).
+    //
+    // Membership in this array IS the reorderable set: `reorderMoves(for:)`
+    // returns nil for a name that is not here, and `GroupView` renders no
+    // chevrons for it. `orderedGroups` syncs it to every rendered top-level
+    // group — local and relay alike (#1948) — so the two sets stay equal.
+    // Narrowing what is synced here silently removes chevrons from the rows
+    // left out; widening what is rendered without syncing gives those rows
+    // chevrons the handlers cannot act on. Either half alone is the bug.
     @Published var projectGroupOrder: [String] = []
     let projectGroupOrderKey = "projectGroupOrder"
 
@@ -355,6 +363,16 @@ class SessionManager: ObservableObject {
                 rawValue: defaults.string(forKey: "summaryDisplayMode") ?? ""
             ) ?? .waiting)
 
+        // Read synchronously, BEFORE the observer below and before the
+        // deferred `Task`, so no hydration can meet an empty order:
+        // `orderedGroups` reads empty as "nothing persisted yet" and saves the
+        // daemon's order over it. Nobody has observed that window being hit —
+        // this removes it rather than proving it fires (#1948). The call only
+        // reads, so construction stays write-free; that is pinned by
+        // `PinnedAppStorageSnapshotTests.testBuildingASessionManagerWritesNoPreference`,
+        // run green with this line in place.
+        loadProjectGroupOrder()
+
         // Reconnect sources live when a Sources setting changes (no relaunch).
         // didChangeNotification fires for any default; sourcesSettingsChanged
         // diffs and only reconnects on an actual source-config change.
@@ -366,7 +384,6 @@ class SessionManager: ObservableObject {
 
         Task {
             loadSessionOrder()
-            loadProjectGroupOrder()
             setupNotificationDelegate()
             self.sourcesSettingsChanged()
             self.startProjectCostsPolling()

--- a/platforms/macos/Irrlicht/Views/GroupView.swift
+++ b/platforms/macos/Irrlicht/Views/GroupView.swift
@@ -118,13 +118,20 @@ struct GroupView: View {
                     .font(.caption2)
                     .foregroundColor(.secondary.opacity(isTopLevel ? 0.7 : 0.5))
 
-                if isTopLevel, sessionManager.apiGroups.count > 1,
-                   let idx = sessionManager.apiGroups.firstIndex(where: { $0.name == group.name }) {
+                // `reorderMoves` answers from the list the handlers mutate, and
+                // answers in the same booleans they guard on — the view does no
+                // index arithmetic of its own, which is what #1948 got wrong
+                // (it measured against `apiGroups`, whose relay rows were not
+                // in the order the handlers act on). Every rendered top-level
+                // group is now in that order, relay ones included, so the
+                // chevrons appear on all of them.
+                if isTopLevel, let moves = sessionManager.reorderMoves(for: group.name),
+                   moves.up || moves.down {
                     HStack(spacing: 0) {
-                        reorderButton(icon: "chevron.up", tooltip: "Move group up", disabled: idx == 0) {
+                        reorderButton(icon: "chevron.up", tooltip: "Move group up", disabled: !moves.up) {
                             sessionManager.moveProjectGroupUp(name: group.name)
                         }
-                        reorderButton(icon: "chevron.down", tooltip: "Move group down", disabled: idx == sessionManager.apiGroups.count - 1) {
+                        reorderButton(icon: "chevron.down", tooltip: "Move group down", disabled: !moves.down) {
                             sessionManager.moveProjectGroupDown(name: group.name)
                         }
                     }

--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -61,9 +61,21 @@ final class GroupViewSnapshotTests: XCTestCase {
             width: 350, height: height, defaults: defaults)
     }
 
+    /// Installs the groups the way hydration does, through `localApiGroups`.
+    /// Assigning `apiGroups` directly leaves `projectGroupOrder` empty, and
+    /// since #1948 the chevrons read their index and bounds from that order —
+    /// so a direct assignment renders no chevrons and this suite would grade
+    /// references that no longer show what they were recorded for.
+    ///
+    /// Measured, not assumed: reverting both seeding calls to
+    /// `sessionManager.apiGroups = …` fails exactly THREE references —
+    /// `testFirstOfThreeUpChevronDisabled`, `testMiddleOfThreeBothChevronsEnabled`
+    /// and `testLastOfThreeDownChevronDisabled`. `testSingleGroupNoChevrons`
+    /// and `testSubGroupNoChevrons` pass either way; neither renders a chevron
+    /// to lose.
     private func seedThreeGroups() -> [SessionManager.AgentGroup] {
         let groups = [makeGroup(name: "alpha"), makeGroup(name: "beta"), makeGroup(name: "gamma")]
-        sessionManager.apiGroups = groups
+        sessionManager.seedLocalApiGroups(groups)
         return groups
     }
 
@@ -87,7 +99,7 @@ final class GroupViewSnapshotTests: XCTestCase {
 
     func testSingleGroupNoChevrons() {
         let solo = makeGroup(name: "solo")
-        sessionManager.apiGroups = [solo]
+        sessionManager.seedLocalApiGroups([solo])
         let view = host(GroupView(group: solo))
         assertSnapshot(of: view, as: .pinnedImage)
     }

--- a/platforms/macos/Tests/RelayFixtures.swift
+++ b/platforms/macos/Tests/RelayFixtures.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Relay wire frames the suites feed to `SessionManager.handleRelayMessage`.
+///
+/// Shared rather than private per suite for the reason `TestAgentBranding`
+/// states: two copies of one fixture is how two suites quietly stop testing
+/// the same thing. The specific risk here is the key shape — `relaySessionMap`
+/// is keyed by `rowID` (`"daemon/id"`), and a suite that seeds that map by
+/// hand instead of sending a frame stays green when the ingest path changes
+/// the key. Going through `handleRelayMessage` is what keeps a relay fixture
+/// honest.
+enum RelayFixtures {
+
+    /// A relay Push frame — envelope `source` plus an inner `session_created`,
+    /// as the hub forwards it.
+    static func push(
+        source: String,
+        sessionId: String,
+        project: String,
+        state: String = "working"
+    ) -> String {
+        """
+        {"type":"push","source":"\(source)","msg":{"type":"session_created",\
+        "session":{"session_id":"\(sessionId)","state":"\(state)","model":"m",\
+        "cwd":"/tmp","project_name":"\(project)","first_seen":0,"updated_at":0}}}
+        """
+    }
+}

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -480,14 +480,10 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         """
     }
 
-    /// Builds a relay Push frame (envelope `source` + inner session_created)
-    /// as the hub would forward it.
+    /// Lifted to `RelayFixtures.push` so `SessionManagerGroupOrderTests` sends
+    /// the same frame rather than seeding `relaySessionMap` by hand.
     private func relayPush(source: String, sessionId: String, project: String, state: String = "working") -> String {
-        """
-        {"type":"push","source":"\(source)","msg":{"type":"session_created",\
-        "session":{"session_id":"\(sessionId)","state":"\(state)","model":"m",\
-        "cwd":"/tmp","project_name":"\(project)","first_seen":0,"updated_at":0}}}
-        """
+        RelayFixtures.push(source: source, sessionId: sessionId, project: project, state: state)
     }
 
     private func makeSession(

--- a/platforms/macos/Tests/SessionManagerGroupOrderTests.swift
+++ b/platforms/macos/Tests/SessionManagerGroupOrderTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+@testable import Irrlicht
+import Foundation
+
+/// Coverage for the project-group reorder chevrons (#1948).
+///
+/// `git grep -n "moveProjectGroup" HEAD -- platforms/macos/Tests` returned
+/// nothing before this file existed, so the handlers shipped in #93, regressed
+/// in #172 and regressed again in #1948 without a single test noticing.
+@MainActor
+final class SessionManagerGroupOrderTests: XCTestCase {
+    typealias AgentGroup = SessionManager.AgentGroup
+
+    private func makeSUT(order: [String] = []) -> (SessionManager, InMemoryDefaults) {
+        let defaults = InMemoryDefaults()
+        if !order.isEmpty { defaults.set(order, forKey: "projectGroupOrder") }
+        return (SessionManager(defaults: defaults), defaults)
+    }
+
+    /// Three local groups plus one relay-only group — the shape that made the
+    /// last local group's down-chevron render enabled while the handler
+    /// refused the move.
+    ///
+    /// The relay half goes in through `handleRelayMessage`, not by assigning
+    /// `relaySessionMap`: that map is keyed by `rowID` (`"daemon/id"`), so a
+    /// hand-seeded entry is a shape production never builds and would stay
+    /// green if the ingest path changed its key.
+    ///
+    /// Locals first, relay second — a name enters `projectGroupOrder` when it
+    /// is first rendered, so arrival order decides the initial positions. The
+    /// reverse sequence is legitimate and puts `delta` first; these tests want
+    /// the ordinary one, where the local daemon is already connected.
+    private func seedLocalPlusRelay(_ sut: SessionManager) {
+        sut.seedLocalApiGroups(["alpha", "beta", "gamma"].map { AgentGroup(name: $0) })
+        sut.handleRelayMessage(
+            RelayFixtures.push(source: "daemonB", sessionId: "r1", project: "delta")
+        )
+    }
+
+    // MARK: - Reading the persisted order
+
+    /// The order must be in place the moment construction returns.
+    /// `loadProjectGroupOrder()` used to run inside the deferred `Task` in
+    /// `SessionManager.init`, leaving a window where a hydration can reach
+    /// `orderedGroups` against an empty order — and that function's own
+    /// `saveProjectGroupOrder()` call then writes the daemon's order over the
+    /// user's. Closing the window, not evidence the window was ever hit.
+    func testConstructionReadsThePersistedOrderSynchronously() {
+        let (sut, _) = makeSUT(order: ["gamma", "beta", "alpha"])
+        XCTAssertEqual(
+            sut.projectGroupOrder, ["gamma", "beta", "alpha"],
+            "the persisted order was not readable until after init returned"
+        )
+    }
+
+    // MARK: - Moving a group (locks — no coverage existed before this file)
+
+    /// A plain all-local move, both directions. This passes on the unfixed
+    /// code too, so it is a LOCK on behaviour that must not change, not
+    /// evidence of the defect.
+    func testMovingAGroupReordersAndPersists() {
+        let (sut, defaults) = makeSUT()
+        sut.seedLocalApiGroups(["alpha", "beta", "gamma"].map { AgentGroup(name: $0) })
+
+        sut.moveProjectGroupDown(name: "alpha")
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["beta", "alpha", "gamma"])
+        XCTAssertEqual(defaults.stringArray(forKey: "projectGroupOrder"),
+                       ["beta", "alpha", "gamma"])
+
+        sut.moveProjectGroupUp(name: "alpha")
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "beta", "gamma"])
+        XCTAssertEqual(defaults.stringArray(forKey: "projectGroupOrder"),
+                       ["alpha", "beta", "gamma"])
+    }
+
+    // MARK: - The two lists the chevrons straddle
+
+    /// Every rendered top-level group is reorderable, relay-only ones
+    /// included. Reported against #1948: "moving of items works for local, but
+    /// not for remote". The reorderable order therefore spans the whole
+    /// rendered list, not just its local half.
+    func testARelayOnlyGroupIsRenderedAndIsReorderable() {
+        let (sut, _) = makeSUT()
+        seedLocalPlusRelay(sut)
+
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "beta", "gamma", "delta"])
+        XCTAssertEqual(sut.projectGroupOrder, ["alpha", "beta", "gamma", "delta"])
+        XCTAssertNotNil(sut.reorderMoves(for: "delta"),
+                        "a rendered group the user can see must be movable")
+    }
+
+    /// The move itself, across the local/relay boundary in both directions —
+    /// the behaviour the report asked for.
+    func testARelayOnlyGroupMovesAmongTheLocalOnes() {
+        let (sut, defaults) = makeSUT()
+        seedLocalPlusRelay(sut)
+
+        sut.moveProjectGroupUp(name: "delta")
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "beta", "delta", "gamma"])
+
+        sut.moveProjectGroupUp(name: "delta")
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "delta", "beta", "gamma"])
+        XCTAssertEqual(defaults.stringArray(forKey: "projectGroupOrder"),
+                       ["alpha", "delta", "beta", "gamma"])
+
+        sut.moveProjectGroupDown(name: "delta")
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "beta", "delta", "gamma"])
+    }
+
+    /// The invariant that makes the #1948 class unrepresentable rather than
+    /// merely guarded: the rendered top-level list and the reorderable order
+    /// are the same names in the same sequence. While that holds, "which list
+    /// did the view measure against" has no wrong answer.
+    ///
+    /// Mutation-checked, run rather than assumed: restoring
+    /// `recomposeApiGroups` to the pre-fix `orderedGroups(localApiGroups) +
+    /// relayGroups()…` fails this with `["alpha", "beta", "gamma", "delta"]`
+    /// against `["alpha", "beta", "gamma"]` — and takes the two relay tests
+    /// above down with it.
+    func testTheRenderedListAndTheReorderableOrderAreTheSameSequence() {
+        let (sut, _) = makeSUT()
+        seedLocalPlusRelay(sut)
+
+        XCTAssertEqual(sut.apiGroups.map(\.name), sut.projectGroupOrder)
+
+        sut.moveProjectGroupUp(name: "delta")
+        XCTAssertEqual(sut.apiGroups.map(\.name), sut.projectGroupOrder,
+                       "a move must leave the two lists in step")
+    }
+
+    /// The contract the chevrons rest on, stated as an equivalence rather than
+    /// as hard-coded rows: for every rendered top-level group, "the view
+    /// offers this move" and "the handler performs it" must be the same
+    /// boolean. #1948 broke it in both directions at once — the last local
+    /// group was offered a move it could not perform, and the relay group was
+    /// offered two.
+    ///
+    /// Mutation-checked, run rather than assumed: giving
+    /// `moveProjectGroupDown` its own bound instead of
+    /// `reorderMoves(atIndex:)` fails this with "the down-chevron offer for
+    /// gamma disagrees with the handler".
+    ///
+    /// What it deliberately does NOT catch any more: answering `reorderMoves`
+    /// from `apiGroups` instead of `projectGroupOrder`. That was the #1948
+    /// defect, and it was measured green under this test once the two lists
+    /// became the same sequence — reading either is now equivalent. The
+    /// invariant test above is what holds that in place; this one guards the
+    /// rule, that one guards the domain.
+    func testChevronOffersAgreeWithWhatTheHandlersDo() {
+        let (sut, _) = makeSUT()
+        seedLocalPlusRelay(sut)
+
+        for name in sut.apiGroups.map(\.name) {
+            let saved = sut.projectGroupOrder
+            let moves = sut.reorderMoves(for: name)
+
+            sut.moveProjectGroupUp(name: name)
+            XCTAssertEqual(moves?.up ?? false, sut.projectGroupOrder != saved,
+                           "the up-chevron offer for \(name) disagrees with the handler")
+            sut.projectGroupOrder = saved
+            sut.recomposeApiGroups()
+
+            sut.moveProjectGroupDown(name: name)
+            XCTAssertEqual(moves?.down ?? false, sut.projectGroupOrder != saved,
+                           "the down-chevron offer for \(name) disagrees with the handler")
+            sut.projectGroupOrder = saved
+            sut.recomposeApiGroups()
+        }
+    }
+
+    // MARK: - Stale persisted order
+
+    /// A duplicate in the persisted array must not survive into memory, where
+    /// it would inflate the count `reorderMoves` reports and give the sort in
+    /// `orderedGroups` two entries to choose between.
+    ///
+    /// The STORE is not rewritten at load — construction stays write-free, and
+    /// `orderedGroups` finds nothing to save because the deduped array already
+    /// matches the groups. The stored duplicate is harmless: every load drops
+    /// it again, and the next real save replaces it, which the move below
+    /// shows.
+    ///
+    /// Mutation-checked, run rather than assumed: dropping the dedupe from
+    /// `loadProjectGroupOrder` fails the first assertion with
+    /// `["alpha", "alpha", "beta"]`.
+    func testADuplicateInThePersistedOrderIsHealedOnLoad() {
+        let (sut, defaults) = makeSUT(order: ["alpha", "alpha", "beta"])
+        XCTAssertEqual(sut.projectGroupOrder, ["alpha", "beta"])
+
+        sut.seedLocalApiGroups(["alpha", "beta"].map { AgentGroup(name: $0) })
+        XCTAssertEqual(sut.apiGroups.map(\.name), ["alpha", "beta"])
+
+        sut.moveProjectGroupDown(name: "alpha")
+        XCTAssertEqual(defaults.stringArray(forKey: "projectGroupOrder"), ["beta", "alpha"])
+    }
+
+    /// The other duplicate source, which the load-time dedupe cannot see: two
+    /// incoming groups sharing a name.
+    ///
+    /// Mutation-checked, run rather than assumed: dropping
+    /// `seen.insert($0).inserted` from `orderedGroups` fails this with
+    /// `["dup", "dup"]`.
+    func testTwoIncomingGroupsSharingANameYieldOneOrderEntry() {
+        let (sut, _) = makeSUT()
+
+        sut.seedLocalApiGroups([AgentGroup(name: "dup"), AgentGroup(name: "dup")])
+
+        XCTAssertEqual(sut.projectGroupOrder, ["dup"])
+    }
+}


### PR DESCRIPTION
Closes #1948

## The defect, confirmed by the maintainer

> "moving of items works for local, but not for remote"

`GroupView` read the chevron index and the `disabled:` bounds from `apiGroups`.
`moveProjectGroupUp/Down` indexed into `projectGroupOrder`. Those lists had
different domains: `orderedGroups` was applied to the **local** groups only,
and `recomposeApiGroups` appended relay groups after it. So with any relay-only
group on screen:

- the relay group's chevrons were wholly inert — `firstIndex(of:)` returned
  `nil`, both handlers returned early;
- the **last local** group's down-chevron rendered *enabled*, because relay
  rows padded `apiGroups.count`, and did nothing.

## The fix

The rendered list and the reorderable order are now **one sequence**.
`recomposeApiGroups` orders local and relay rows together, so every top-level
row the user can see is a row the user can move — a project served by a second
daemon included. A relay project can be moved among the local ones and keeps
its place.

`reorderMoves(for:)` is the single question the chevrons ask. It answers from
`projectGroupOrder` in the two booleans the handlers guard on, so the view does
no index arithmetic of its own, and the rule lives in one private function that
each handler evaluates against the same index it then swaps.

Two hardenings from the triage design:

1. `SessionManager.init` reads the persisted order **synchronously**, before
   the `didChangeNotification` observer and before the deferred `Task`.
   `orderedGroups` reads an empty order as "nothing persisted yet" and saves
   the daemon's order over it, so any window where a hydration meets an empty
   order ends with the user's order destroyed. **The window has not been
   observed being hit** — this removes it rather than proving it fires.
2. Duplicate names are dropped where they can enter: on load (the
   user-editable store) and in `orderedGroups` (two incoming groups sharing a
   name). The sort index is built by hand rather than with
   `Dictionary(uniqueKeysWithValues:)`, which traps on a repeated key — a
   crash is the wrong response to a bad stored preference.

## Behaviour change worth knowing

Relay rows used to sit after every local row, always. They now take whatever
position the user gives them, and a new project registers at the end of the
order when it is first rendered — so initial placement follows arrival order,
not local-before-relay. A project whose sessions all end drops out of the
order and re-registers at the end if it returns; that already happened to
local projects and is unchanged.

## Test evidence

New suite `platforms/macos/Tests/SessionManagerGroupOrderTests.swift` (8 tests).
There was no coverage at all before it — `git grep -n "moveProjectGroup" HEAD --
platforms/macos/Tests` returned nothing, which is why #93's feature regressed in
#172 and again here without anything going red.

**Red-first (seen to fail before the fix existed):**

| Test | Failure before the fix |
|---|---|
| `testConstructionReadsThePersistedOrderSynchronously` | `("[]") is not equal to ("["gamma", "beta", "alpha"]")` |
| `testARelayOnlyGroupIsRenderedAndIsReorderable` | `XCTAssertNotNil failed - a rendered group the user can see must be movable` |
| `testARelayOnlyGroupMovesAmongTheLocalOnes` | `("["alpha", "beta", "gamma", "delta"]") is not equal to ("["alpha", "beta", "delta", "gamma"]")` |

**Mutation evidence** — for what the change *adds* there is no "before" to run
red, so each guard was mutated and the check confirmed red. All five were run,
not described:

| Mutation | Result |
|---|---|
| `recomposeApiGroups` back to `orderedGroups(localApiGroups) + relayGroups()…` | invariant test red: `["alpha","beta","gamma","delta"]` vs `["alpha","beta","gamma"]`, plus both relay tests |
| `moveProjectGroupDown` given its own bound instead of `reorderMoves(atIndex:)` | `the down-chevron offer for gamma disagrees with the handler` |
| drop the dedupe from `loadProjectGroupOrder` | `("["alpha", "alpha", "beta"]") is not equal to ("["alpha", "beta"]")` |
| drop `seen.insert($0).inserted` from `orderedGroups` | `("["dup", "dup"]") is not equal to ("["dup"]")` |
| revert `GroupViewSnapshotTests` seeding to `apiGroups = …` | exactly 3 references fail: `testFirstOfThreeUpChevronDisabled`, `testMiddleOfThreeBothChevronsEnabled`, `testLastOfThreeDownChevronDisabled` |

**A mutation that stopped killing, and why that is the point.** Answering
`reorderMoves` from `apiGroups` — the original #1948 defect — was measured
**green** once the two lists became one sequence. Reading either is now
equivalent, so the defect class is unrepresentable rather than guarded. The
invariant test `testTheRenderedListAndTheReorderableOrderAreTheSameSequence`
holds that in place; the contract test guards the rule, the invariant test
guards the domain. Both facts are recorded in the tests' own doc comments.

An earlier draft's first mutation aborted the runner with `Fatal error: Index
out of range` instead of failing cleanly. That was a real fragility — the
handler judged one lookup and swapped on another — and is why the rule now
lives in `reorderMoves(atIndex:)`, evaluated against the index the swap uses.

**Locks (pass by construction — not presented as red-first proof):**

- `testMovingAGroupReordersAndPersists` — the plain all-local path, both
  directions. Green on unfixed `main` too.
- `PinnedAppStorageSnapshotTests.testBuildingASessionManagerWritesNoPreference`
  — construction must stay write-free with the new synchronous read. Ran green.
- The four `GroupViewSnapshotTests` chevron references render byte-identically;
  no `.png` moved. They are reference-host-only (`--skip GroupViewSnapshotTests`
  in `macos-swift.yml`), so this PR's CI does not grade them — all six ran and
  passed locally on the reference host.

**Commands run:**

```
cd platforms/macos && swift build && swift test \
  --skip LauncherTestHarness --skip LauncherHarnessTests   # exit 0, 0 failures
tools/preflight.sh --changed --budget 540                  # macOS Swift build + test PASS,
                                                           # gofmt PASS, state-vocabulary PASS,
                                                           # every other gate SKIP (diff is macOS-only)
```

## Review and cleanup

A code review plus four cleanup passes (reuse / simplification / efficiency /
altitude) ran against `origin/main...HEAD`. Applied from them:

- the handlers use the accessor's rule instead of re-deriving it — three passes
  independently flagged that an earlier draft left the offer and the effect as
  two separate expressions, so the bug class survived, narrowed;
- booleans instead of `(index:count:)`, so the view holds no arithmetic;
- one contract test instead of two near-identical ones (also what CodeScene
  flagged), restoring state by assignment plus a recompose rather than by the
  opposite handler;
- the relay fixture goes through `handleRelayMessage` and a shared
  `RelayFixtures.push`, because `relaySessionMap` is keyed by `rowID` and a
  hand-seeded entry is a shape production never builds — it would have stayed
  green if relay keying changed;
- `known`/`newNames` folded into a single filtered build in `orderedGroups`;
- dedupe moved to the load boundary as well, so the invariant holds from birth;
- a note at `projectGroupOrder`'s declaration that membership in it *is* the
  reorderable set, and that narrowing the sync or widening the render without
  the other is the bug.

The altitude pass argued the accessor alone was not deep enough — that the
mechanism should be generalised so the question cannot arise. The maintainer's
report then forced exactly that, and the result is the one-sequence invariant
above.

## Design deviation

Triage named the accessor `reorderPosition(of:) -> (index: Int, count: Int)?`.
It ships as `reorderMoves(for:) -> (up: Bool, down: Bool)?`: coordinates leave
the bounds rule to be re-derived by every caller, which is the shape the bug was
made of.

Triage also said relay-only groups should render no chevrons, and to keep
`loadProjectGroupOrder()` in the deferred `Task` as an idempotent second read.
Both reversed — the first by the maintainer's report, the second because with
the synchronous read it is dead code and two load sites for one piece of state
is the drift this issue is about.

## Named, not fixed

Recorded here rather than filed, per AGENTS.md:

1. **`orderedGroups` is a query that mutates and persists.** It is called from
   `recomposeApiGroups()` on every WS patch and owns `projectGroupOrder`'s
   whole lifecycle. Both hardenings above are consequences of that. Splitting
   the command from a pure sort would delete the hazard instead of narrowing
   it, but it changes *when* new group names register — too much risk here.
2. **Pre-existing, and adjacent:** `reconcileSources()` clears `localApiGroups`
   when the user switches the Local source off, and the following
   `recomposeApiGroups()` → `orderedGroups([])` sets `projectGroupOrder = []`
   and saves it. **Toggling a Sources checkbox destroys the persisted group
   order.** Same code path on `main`; untouched here.
3. **The menu-bar icon orders projects independently.**
   `MenuBarStatusRenderer.orderedProjectGroups` groups `sessionManager.sessions`
   by `projectName ?? cwd`, orders by `projectGroupOrder`, then appends the
   rest alphabetically. Relay names are now in `projectGroupOrder`, so the icon
   follows the list order for them too — an incidental improvement, not one
   this PR tests.
4. **CodeScene's "String Heavy Function Arguments"** on
   `SessionManager+GroupComposition.swift` (10.00 → 9.69) is not addressed. The
   fix would be a wrapper type for a group name, rippling well past this diff
   for an advisory score.

## Human gate remaining

Confirm on a dev build (`/ir:test-mac`) that a remote project now moves, and
that the order survives a 30 s cost re-hydration and an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc
